### PR TITLE
use include_str! to trigger a rebuild when the input spec is modified

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,9 +49,9 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cc"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 
 [[package]]
 name = "cfg-if"
@@ -314,9 +314,9 @@ checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "hyper"
-version = "0.14.14"
+version = "0.14.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b91bb1f221b6ea1f1e4371216b70f40748774c2fb5971b450c07773fb92d26b"
+checksum = "436ec0091e4f20e655156a30a0df3770fe2900aa301e548e08446ec794b6953c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -400,9 +400,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.106"
+version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
+checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "log"
@@ -544,9 +544,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.70"
+version = "0.9.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6517987b3f8226b5da3661dad65ff7f300cc59fb5ea8333ca191fc65fde3edf"
+checksum = "7df13d165e607909b363a4757a6f133f8a818a74e9d3a98d09c6128e15fa4c73"
 dependencies = [
  "autocfg",
  "cc",
@@ -814,9 +814,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a48d098c2a7fdf5740b19deb1181b4fb8a9e68e03ae517c14cde04b5725409"
+checksum = "271ac0c667b8229adf70f0f957697c96fafd7486ab7481e15dc5e45e3e6a4368"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -826,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9ea2a613fe4cd7118b2bb101a25d8ae6192e1975179b67b2f17afd11e70ac8"
+checksum = "6ebda811090b257411540779860bc09bf321bc587f58d2c5864309d1566214e7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -910,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
+checksum = "e277c495ac6cd1a01a58d0a0c574568b4d1ddf14f59965c6a58b8d96400b54f3"
 dependencies = [
  "itoa",
  "ryu",
@@ -1004,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83b2a3d4d9091d0abd7eba4dc2710b1718583bd4d8992e2190720ea38f391f7"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1019,9 +1019,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
+checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1103,8 +1103,8 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "typify"
-version = "0.0.2"
-source = "git+https://github.com/oxidecomputer/typify#69bc7f3e42fdeee40229fb8305773377b1d5e4d7"
+version = "0.0.6-dev"
+source = "git+https://github.com/oxidecomputer/typify#58bfcd02a2cd74bff047e9e8ad6e4f2b4f84f3af"
 dependencies = [
  "typify-impl",
  "typify-macro",
@@ -1112,12 +1112,13 @@ dependencies = [
 
 [[package]]
 name = "typify-impl"
-version = "0.0.2"
-source = "git+https://github.com/oxidecomputer/typify#69bc7f3e42fdeee40229fb8305773377b1d5e4d7"
+version = "0.0.6-dev"
+source = "git+https://github.com/oxidecomputer/typify#58bfcd02a2cd74bff047e9e8ad6e4f2b4f84f3af"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
+ "rustfmt-wrapper",
  "schemars",
  "serde_json",
  "syn",
@@ -1126,8 +1127,8 @@ dependencies = [
 
 [[package]]
 name = "typify-macro"
-version = "0.0.2"
-source = "git+https://github.com/oxidecomputer/typify#69bc7f3e42fdeee40229fb8305773377b1d5e4d7"
+version = "0.0.6-dev"
+source = "git+https://github.com/oxidecomputer/typify#58bfcd02a2cd74bff047e9e8ad6e4f2b4f84f3af"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
before:

```
qiviut /Users/ahl/src/progenitor/example-macro $ cargo build
   Compiling progenitor-macro v0.0.0 (/Users/ahl/src/progenitor/progenitor-macro)
   Compiling progenitor v0.0.0 (/Users/ahl/src/progenitor/progenitor)
   Compiling example-macro v0.0.1 (/Users/ahl/src/progenitor/example-macro)
    Finished dev [unoptimized + debuginfo] target(s) in 3.56s
qiviut /Users/ahl/src/progenitor/example-macro $ cargo build
qiviut /Users/ahl/src/progenitor/example-macro $ touch ../sample_openapi/keeper.json 
qiviut /Users/ahl/src/progenitor/example-macro $ cargo build -v
       Fresh unicode-xid v0.2.2
       Fresh autocfg v1.0.1
       Fresh cfg-if v1.0.0
       Fresh itoa v0.4.8
       Fresh lazy_static v1.4.0
       Fresh ppv-lite86 v0.2.15
       Fresh pin-project-lite v0.2.7
       Fresh bytes v1.1.0
       Fresh remove_dir_all v0.5.3
       Fresh hashbrown v0.11.2
       Fresh ucd-trie v0.1.3
       Fresh dyn-clone v1.0.4
       Fresh regex-syntax v0.6.25
       Fresh fnv v1.0.7
       Fresh convert_case v0.4.0
       Fresh same-file v1.0.6
       Fresh tinyvec_macros v0.1.0
       Fresh pin-utils v0.1.0
       Fresh futures-sink v0.3.17
       Fresh bitflags v1.3.2
       Fresh home v0.5.3
       Fresh matches v0.1.9
       Fresh unicode-width v0.1.9
       Fresh try-lock v0.2.3
       Fresh percent-encoding v2.1.0
       Fresh slab v0.4.5
       Fresh unicode-bidi v0.3.7
       Fresh httpdate v1.0.1
       Fresh tower-service v0.3.1
       Fresh base64 v0.13.0
       Fresh ipnet v2.3.1
       Fresh mime v0.3.16
       Fresh tracing-core v0.1.21
       Fresh pest v2.1.3
       Fresh http v0.2.5
       Fresh walkdir v2.3.2
       Fresh tinyvec v1.5.0
       Fresh form_urlencoded v1.0.1
       Fresh getopts v0.2.21
       Fresh proc-macro2 v1.0.32
       Fresh libc v0.2.106
       Fresh memchr v2.4.1
       Fresh ryu v1.0.5
       Fresh log v0.4.14
       Fresh core-foundation-sys v0.8.3
       Fresh tracing v0.1.29
       Fresh quote v1.0.10
       Fresh futures-core v0.3.17
       Fresh semver-parser v0.10.2
       Fresh futures-task v0.3.17
       Fresh unicode-normalization v0.1.19
       Fresh anyhow v1.0.45
       Fresh http-body v0.4.4
       Fresh httparse v1.5.1
       Fresh encoding_rs v0.8.29
       Fresh syn v1.0.81
       Fresh getrandom v0.2.3
       Fresh mio v0.7.14
       Fresh aho-corasick v0.7.18
       Fresh semver v0.11.0
       Fresh security-framework-sys v2.4.2
       Fresh core-foundation v0.9.2
       Fresh futures-util v0.3.17
       Fresh socket2 v0.4.2
       Fresh futures-channel v0.3.17
       Fresh want v0.3.0
       Fresh idna v0.2.3
       Fresh num-traits v0.2.14
       Fresh time v0.1.43
       Fresh serde_derive v1.0.130
       Fresh rand_core v0.6.3
       Fresh serde_derive_internals v0.25.0
       Fresh thiserror-impl v1.0.30
       Fresh tokio v1.13.0
       Fresh regex v1.5.4
       Fresh security-framework v2.4.2
       Fresh url v2.2.2
       Fresh serde v1.0.130
       Fresh rand_chacha v0.3.1
       Fresh thiserror v1.0.30
       Fresh schemars_derive v0.8.6
       Fresh tokio-util v0.6.9
       Fresh toolchain_find v0.2.0
       Fresh num-integer v0.1.44
       Fresh serde_json v1.0.69
       Fresh rand v0.8.4
       Fresh indexmap v1.7.0
       Fresh serde_urlencoded v0.7.0
       Fresh uuid v0.8.2
       Fresh chrono v0.4.19
       Fresh tempfile v3.2.0
       Fresh schemars v0.8.6
       Fresh openapiv3 v1.0.0-beta.5
       Fresh h2 v0.3.7
       Fresh typify-impl v0.0.2 (https://github.com/oxidecomputer/typify#69bc7f3e)
       Fresh native-tls v0.2.8
       Fresh rustfmt-wrapper v0.1.0
       Fresh hyper v0.14.14
       Fresh typify-macro v0.0.2 (https://github.com/oxidecomputer/typify#69bc7f3e)
       Fresh tokio-native-tls v0.3.0
       Fresh typify v0.0.2 (https://github.com/oxidecomputer/typify#69bc7f3e)
       Fresh hyper-tls v0.5.0
       Fresh progenitor-impl v0.0.0 (/Users/ahl/src/progenitor/progenitor-impl)
       Fresh reqwest v0.11.6
       Fresh progenitor-macro v0.0.0 (/Users/ahl/src/progenitor/progenitor-macro)
       Fresh progenitor v0.0.0 (/Users/ahl/src/progenitor/progenitor)
       Fresh example-macro v0.0.1 (/Users/ahl/src/progenitor/example-macro)
    Finished dev [unoptimized + debuginfo] target(s) in 0.09s
```

after:
```
qiviut /Users/ahl/src/progenitor/example-macro $ cargo build
   Compiling time v0.1.43
   Compiling uuid v0.8.2
   Compiling reqwest v0.11.6
   Compiling progenitor-macro v0.0.0 (/Users/ahl/src/progenitor/progenitor-macro)
   Compiling chrono v0.4.19
   Compiling progenitor v0.0.0 (/Users/ahl/src/progenitor/progenitor)
   Compiling example-macro v0.0.1 (/Users/ahl/src/progenitor/example-macro)
    Finished dev [unoptimized + debuginfo] target(s) in 3.75s
qiviut /Users/ahl/src/progenitor/example-macro $ touch ../sample_openapi/keeper.json 
qiviut /Users/ahl/src/progenitor/example-macro $ cargo build -v
       Fresh unicode-xid v0.2.2
       Fresh cfg-if v1.0.0
       Fresh autocfg v1.0.1
       Fresh itoa v0.4.8
       Fresh lazy_static v1.4.0
       Fresh ppv-lite86 v0.2.15
       Fresh remove_dir_all v0.5.3
       Fresh ucd-trie v0.1.3
       Fresh pin-project-lite v0.2.7
       Fresh bytes v1.1.0
       Fresh same-file v1.0.6
       Fresh regex-syntax v0.6.25
       Fresh hashbrown v0.11.2
       Fresh home v0.5.3
       Fresh dyn-clone v1.0.4
       Fresh fnv v1.0.7
       Fresh convert_case v0.4.0
       Fresh bitflags v1.3.2
       Fresh futures-sink v0.3.17
       Fresh tinyvec_macros v0.1.0
       Fresh pin-utils v0.1.0
       Fresh matches v0.1.9
       Fresh slab v0.4.5
       Fresh percent-encoding v2.1.0
       Fresh try-lock v0.2.3
       Fresh unicode-width v0.1.9
       Fresh unicode-bidi v0.3.7
       Fresh tower-service v0.3.1
       Fresh httpdate v1.0.1
       Fresh mime v0.3.16
       Fresh base64 v0.13.0
       Fresh ipnet v2.3.1
       Fresh pest v2.1.3
       Fresh tracing-core v0.1.21
       Fresh walkdir v2.3.2
       Fresh http v0.2.5
       Fresh tinyvec v1.5.1
       Fresh form_urlencoded v1.0.1
       Fresh getopts v0.2.21
       Fresh libc v0.2.107
       Fresh proc-macro2 v1.0.32
       Fresh memchr v2.4.1
       Fresh ryu v1.0.5
       Fresh semver-parser v0.10.2
       Fresh log v0.4.14
       Fresh tracing v0.1.29
       Fresh getrandom v0.2.3
       Fresh core-foundation-sys v0.8.3
       Fresh futures-core v0.3.17
       Fresh futures-task v0.3.17
       Fresh socket2 v0.4.2
       Fresh http-body v0.4.4
       Fresh unicode-normalization v0.1.19
       Fresh httparse v1.5.1
       Fresh anyhow v1.0.45
       Fresh encoding_rs v0.8.29
       Fresh time v0.1.43
       Fresh quote v1.0.10
       Fresh rand_core v0.6.3
       Fresh aho-corasick v0.7.18
       Fresh semver v0.11.0
       Fresh mio v0.7.14
       Fresh security-framework-sys v2.4.2
       Fresh core-foundation v0.9.2
       Fresh futures-util v0.3.17
       Fresh futures-channel v0.3.17
       Fresh want v0.3.0
       Fresh num-traits v0.2.14
       Fresh syn v1.0.81
       Fresh rand_chacha v0.3.1
       Fresh regex v1.5.4
       Fresh tokio v1.14.0
       Fresh security-framework v2.4.2
       Fresh idna v0.2.3
       Fresh serde_derive v1.0.130
       Fresh rand v0.8.4
       Fresh thiserror-impl v1.0.30
       Fresh serde_derive_internals v0.25.0
       Fresh toolchain_find v0.2.0
       Fresh tokio-util v0.6.9
       Fresh url v2.2.2
       Fresh num-integer v0.1.44
       Fresh serde v1.0.130
       Fresh tempfile v3.2.0
       Fresh schemars_derive v0.8.7
       Fresh thiserror v1.0.30
       Fresh serde_json v1.0.70
       Fresh indexmap v1.7.0
       Fresh rustfmt-wrapper v0.1.0
       Fresh native-tls v0.2.8
       Fresh serde_urlencoded v0.7.0
       Fresh uuid v0.8.2
       Fresh chrono v0.4.19
       Fresh schemars v0.8.7
       Fresh openapiv3 v1.0.0-beta.5
       Fresh h2 v0.3.7
       Fresh tokio-native-tls v0.3.0
       Fresh typify-impl v0.0.6-dev (https://github.com/oxidecomputer/typify#58bfcd02)
       Fresh hyper v0.14.15
       Fresh typify-macro v0.0.6-dev (https://github.com/oxidecomputer/typify#58bfcd02)
       Fresh hyper-tls v0.5.0
       Fresh typify v0.0.6-dev (https://github.com/oxidecomputer/typify#58bfcd02)
       Fresh reqwest v0.11.6
       Fresh progenitor-impl v0.0.0 (/Users/ahl/src/progenitor/progenitor-impl)
       Fresh progenitor-macro v0.0.0 (/Users/ahl/src/progenitor/progenitor-macro)
       Fresh progenitor v0.0.0 (/Users/ahl/src/progenitor/progenitor)
   Compiling example-macro v0.0.1 (/Users/ahl/src/progenitor/example-macro)
     Running `rustc --crate-name example_macro --edition=2018 example-macro/src/main.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C split-debuginfo=unpacked -C debuginfo=2 -C metadata=4af4c12019f3472b -C extra-filename=-4af4c12019f3472b --out-dir /Users/ahl/src/progenitor/target/debug/deps -C incremental=/Users/ahl/src/progenitor/target/debug/incremental -L dependency=/Users/ahl/src/progenitor/target/debug/deps --extern anyhow=/Users/ahl/src/progenitor/target/debug/deps/libanyhow-a701186c282849ba.rlib --extern chrono=/Users/ahl/src/progenitor/target/debug/deps/libchrono-8e2ce9749f0d4e58.rlib --extern percent_encoding=/Users/ahl/src/progenitor/target/debug/deps/libpercent_encoding-d2d21c99c2b79320.rlib --extern progenitor=/Users/ahl/src/progenitor/target/debug/deps/libprogenitor-dec12bd510c5d781.rlib --extern reqwest=/Users/ahl/src/progenitor/target/debug/deps/libreqwest-9cc9d3e65e41d29d.rlib --extern serde=/Users/ahl/src/progenitor/target/debug/deps/libserde-f68e99d106b9b555.rlib --extern uuid=/Users/ahl/src/progenitor/target/debug/deps/libuuid-5f52bc9c4a22acd5.rlib`
    Finished dev [unoptimized + debuginfo] target(s) in 0.53s
```

Looks like a not-unrelated crate came up with a similar idea: https://github.com/evestera/json_typegen/issues/35

See also: https://github.com/oxidecomputer/omicron/issues/396