### PR TITLE
introduce an intermediate form

### DIFF
--- a/progenitor-impl/tests/output/nexus.out
+++ b/progenitor-impl/tests/output/nexus.out
@@ -1,0 +1,2232 @@
+use anyhow::Result;
+mod progenitor_support {
+    use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
+    #[allow(dead_code)]
+    const PATH_SET: &AsciiSet = &CONTROLS
+        .add(b' ')
+        .add(b'"')
+        .add(b'#')
+        .add(b'<')
+        .add(b'>')
+        .add(b'?')
+        .add(b'`')
+        .add(b'{')
+        .add(b'}');
+    #[allow(dead_code)]
+    pub(crate) fn encode_path(pc: &str) -> String {
+        utf8_percent_encode(pc, PATH_SET).to_string()
+    }
+}
+
+pub mod types {
+    use serde::{Deserialize, Serialize};
+    #[doc = "A count of bytes, typically used either for memory or storage capacity\n\nThe maximum supported byte count is [`i64::MAX`].  This makes it somewhat inconvenient to define constructors: a u32 constructor can be infallible, but an i64 constructor can fail (if the value is negative) and a u64 constructor can fail (if the value is larger than i64::MAX).  We provide all of these for consumers' convenience."]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct ByteCount(pub u64);
+    impl std::ops::Deref for ByteCount {
+        type Target = u64;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    #[doc = "Client view of an [`Disk`]"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Disk {
+        #[doc = "human-readable free-form text about a resource"]
+        pub description: String,
+        #[serde(rename = "devicePath")]
+        pub device_path: String,
+        #[doc = "unique, immutable, system-controlled identifier for each resource"]
+        pub id: uuid::Uuid,
+        pub name: Name,
+        #[serde(rename = "projectId")]
+        pub project_id: uuid::Uuid,
+        pub size: ByteCount,
+        #[serde(
+            rename = "snapshotId",
+            default,
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub snapshot_id: Option<uuid::Uuid>,
+        pub state: DiskState,
+        #[doc = "timestamp when this resource was created"]
+        #[serde(rename = "timeCreated")]
+        pub time_created: chrono::DateTime<chrono::offset::Utc>,
+        #[doc = "timestamp when this resource was last modified"]
+        #[serde(rename = "timeModified")]
+        pub time_modified: chrono::DateTime<chrono::offset::Utc>,
+    }
+
+    #[doc = "Describes a Disk's attachment to an Instance"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct DiskAttachment {
+        #[serde(rename = "diskId")]
+        pub disk_id: uuid::Uuid,
+        #[serde(rename = "diskName")]
+        pub disk_name: Name,
+        #[serde(rename = "diskState")]
+        pub disk_state: DiskState,
+        #[serde(rename = "instanceId")]
+        pub instance_id: uuid::Uuid,
+    }
+
+    #[doc = "Create-time parameters for a [`Disk`]"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct DiskCreate {
+        pub description: String,
+        pub name: Name,
+        pub size: ByteCount,
+        #[doc = "id for snapshot from which the Disk should be created, if any"]
+        #[serde(
+            rename = "snapshotId",
+            default,
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub snapshot_id: Option<uuid::Uuid>,
+    }
+
+    #[doc = "A single page of results"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct DiskResultsPage {
+        #[doc = "list of items on this page of results"]
+        pub items: Vec<Disk>,
+        #[doc = "token used to fetch the next page of results (if any)"]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub next_page: Option<String>,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    #[serde(tag = "state", content = "instance")]
+    pub enum DiskState {
+        #[serde(rename = "creating")]
+        Creating,
+        #[serde(rename = "detached")]
+        Detached,
+        #[serde(rename = "attaching")]
+        Attaching(uuid::Uuid),
+        #[serde(rename = "attached")]
+        Attached(uuid::Uuid),
+        #[serde(rename = "detaching")]
+        Detaching(uuid::Uuid),
+        #[serde(rename = "destroyed")]
+        Destroyed,
+        #[serde(rename = "faulted")]
+        Faulted,
+    }
+
+    #[doc = "Supported set of sort modes for scanning by id only.\n\nCurrently, we only support scanning in ascending order."]
+    #[derive(Serialize, Deserialize, Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
+    pub enum IdSortMode {
+        #[serde(rename = "id-ascending")]
+        IdAscending,
+    }
+
+    impl ToString for IdSortMode {
+        fn to_string(&self) -> String {
+            match self {
+                IdSortMode::IdAscending => "id-ascending".to_string(),
+            }
+        }
+    }
+
+    #[doc = "Identity-related metadata that's included in nearly all public API objects"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct IdentityMetadata {
+        #[doc = "human-readable free-form text about a resource"]
+        pub description: String,
+        #[doc = "unique, immutable, system-controlled identifier for each resource"]
+        pub id: uuid::Uuid,
+        pub name: Name,
+        #[doc = "timestamp when this resource was created"]
+        #[serde(rename = "timeCreated")]
+        pub time_created: chrono::DateTime<chrono::offset::Utc>,
+        #[doc = "timestamp when this resource was last modified"]
+        #[serde(rename = "timeModified")]
+        pub time_modified: chrono::DateTime<chrono::offset::Utc>,
+    }
+
+    #[doc = "Client view of an [`Instance`]"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Instance {
+        #[doc = "human-readable free-form text about a resource"]
+        pub description: String,
+        #[doc = "RFC1035-compliant hostname for the Instance."]
+        pub hostname: String,
+        #[doc = "unique, immutable, system-controlled identifier for each resource"]
+        pub id: uuid::Uuid,
+        pub memory: ByteCount,
+        pub name: Name,
+        pub ncpus: InstanceCpuCount,
+        #[doc = "id for the project containing this Instance"]
+        #[serde(rename = "projectId")]
+        pub project_id: uuid::Uuid,
+        #[serde(rename = "runState")]
+        pub run_state: InstanceState,
+        #[doc = "timestamp when this resource was created"]
+        #[serde(rename = "timeCreated")]
+        pub time_created: chrono::DateTime<chrono::offset::Utc>,
+        #[doc = "timestamp when this resource was last modified"]
+        #[serde(rename = "timeModified")]
+        pub time_modified: chrono::DateTime<chrono::offset::Utc>,
+        #[serde(rename = "timeRunStateUpdated")]
+        pub time_run_state_updated: chrono::DateTime<chrono::offset::Utc>,
+    }
+
+    #[doc = "The number of CPUs in an Instance"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct InstanceCpuCount(pub u16);
+    impl std::ops::Deref for InstanceCpuCount {
+        type Target = u16;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    #[doc = "Create-time parameters for an [`Instance`]"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct InstanceCreate {
+        pub description: String,
+        pub hostname: String,
+        pub memory: ByteCount,
+        pub name: Name,
+        pub ncpus: InstanceCpuCount,
+    }
+
+    #[doc = "A single page of results"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct InstanceResultsPage {
+        #[doc = "list of items on this page of results"]
+        pub items: Vec<Instance>,
+        #[doc = "token used to fetch the next page of results (if any)"]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub next_page: Option<String>,
+    }
+
+    #[doc = "Running state of an Instance (primarily: booted or stopped)\n\nThis typically reflects whether it's starting, running, stopping, or stopped, but also includes states related to the Instance's lifecycle"]
+    #[derive(Serialize, Deserialize, Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
+    pub enum InstanceState {
+        #[serde(rename = "creating")]
+        Creating,
+        #[serde(rename = "starting")]
+        Starting,
+        #[serde(rename = "running")]
+        Running,
+        #[serde(rename = "stopping")]
+        Stopping,
+        #[serde(rename = "stopped")]
+        Stopped,
+        #[serde(rename = "rebooting")]
+        Rebooting,
+        #[serde(rename = "repairing")]
+        Repairing,
+        #[serde(rename = "failed")]
+        Failed,
+        #[serde(rename = "destroyed")]
+        Destroyed,
+    }
+
+    impl ToString for InstanceState {
+        fn to_string(&self) -> String {
+            match self {
+                InstanceState::Creating => "creating".to_string(),
+                InstanceState::Starting => "starting".to_string(),
+                InstanceState::Running => "running".to_string(),
+                InstanceState::Stopping => "stopping".to_string(),
+                InstanceState::Stopped => "stopped".to_string(),
+                InstanceState::Rebooting => "rebooting".to_string(),
+                InstanceState::Repairing => "repairing".to_string(),
+                InstanceState::Failed => "failed".to_string(),
+                InstanceState::Destroyed => "destroyed".to_string(),
+            }
+        }
+    }
+
+    #[doc = "An IPv4 subnet, including prefix and subnet mask"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Ipv4Net(pub String);
+    impl std::ops::Deref for Ipv4Net {
+        type Target = String;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    #[doc = "An IPv6 subnet, including prefix and subnet mask"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Ipv6Net(pub String);
+    impl std::ops::Deref for Ipv6Net {
+        type Target = String;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    #[doc = "An inclusive-inclusive range of IP ports. The second port may be omitted to represent a single port"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct L4PortRange(pub String);
+    impl std::ops::Deref for L4PortRange {
+        type Target = String;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct LoginParams {
+        pub username: String,
+    }
+
+    #[doc = "Names must begin with a lower case ASCII letter, be composed exclusively of lowercase ASCII, uppercase ASCII, numbers, and '-', and may not end with a '-'."]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Name(pub String);
+    impl std::ops::Deref for Name {
+        type Target = String;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    #[doc = "Supported set of sort modes for scanning by name or id"]
+    #[derive(Serialize, Deserialize, Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
+    pub enum NameOrIdSortMode {
+        #[serde(rename = "name-ascending")]
+        NameAscending,
+        #[serde(rename = "name-descending")]
+        NameDescending,
+        #[serde(rename = "id-ascending")]
+        IdAscending,
+    }
+
+    impl ToString for NameOrIdSortMode {
+        fn to_string(&self) -> String {
+            match self {
+                NameOrIdSortMode::NameAscending => "name-ascending".to_string(),
+                NameOrIdSortMode::NameDescending => "name-descending".to_string(),
+                NameOrIdSortMode::IdAscending => "id-ascending".to_string(),
+            }
+        }
+    }
+
+    #[doc = "Supported set of sort modes for scanning by name only\n\nCurrently, we only support scanning in ascending order."]
+    #[derive(Serialize, Deserialize, Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
+    pub enum NameSortMode {
+        #[serde(rename = "name-ascending")]
+        NameAscending,
+    }
+
+    impl ToString for NameSortMode {
+        fn to_string(&self) -> String {
+            match self {
+                NameSortMode::NameAscending => "name-ascending".to_string(),
+            }
+        }
+    }
+
+    #[doc = "Client view of an [`Organization`]"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Organization {
+        #[doc = "human-readable free-form text about a resource"]
+        pub description: String,
+        #[doc = "unique, immutable, system-controlled identifier for each resource"]
+        pub id: uuid::Uuid,
+        pub name: Name,
+        #[doc = "timestamp when this resource was created"]
+        #[serde(rename = "timeCreated")]
+        pub time_created: chrono::DateTime<chrono::offset::Utc>,
+        #[doc = "timestamp when this resource was last modified"]
+        #[serde(rename = "timeModified")]
+        pub time_modified: chrono::DateTime<chrono::offset::Utc>,
+    }
+
+    #[doc = "Create-time parameters for an [`Organization`]"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct OrganizationCreate {
+        pub description: String,
+        pub name: Name,
+    }
+
+    #[doc = "A single page of results"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct OrganizationResultsPage {
+        #[doc = "list of items on this page of results"]
+        pub items: Vec<Organization>,
+        #[doc = "token used to fetch the next page of results (if any)"]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub next_page: Option<String>,
+    }
+
+    #[doc = "Updateable properties of an [`Organization`]"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct OrganizationUpdate {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub description: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub name: Option<Name>,
+    }
+
+    #[doc = "Client view of a [`Project`]"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Project {
+        #[doc = "human-readable free-form text about a resource"]
+        pub description: String,
+        #[doc = "unique, immutable, system-controlled identifier for each resource"]
+        pub id: uuid::Uuid,
+        pub name: Name,
+        #[serde(rename = "organizationId")]
+        pub organization_id: uuid::Uuid,
+        #[doc = "timestamp when this resource was created"]
+        #[serde(rename = "timeCreated")]
+        pub time_created: chrono::DateTime<chrono::offset::Utc>,
+        #[doc = "timestamp when this resource was last modified"]
+        #[serde(rename = "timeModified")]
+        pub time_modified: chrono::DateTime<chrono::offset::Utc>,
+    }
+
+    #[doc = "Create-time parameters for a [`Project`]"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct ProjectCreate {
+        pub description: String,
+        pub name: Name,
+    }
+
+    #[doc = "A single page of results"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct ProjectResultsPage {
+        #[doc = "list of items on this page of results"]
+        pub items: Vec<Project>,
+        #[doc = "token used to fetch the next page of results (if any)"]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub next_page: Option<String>,
+    }
+
+    #[doc = "Updateable properties of a [`Project`]"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct ProjectUpdate {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub description: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub name: Option<Name>,
+    }
+
+    #[doc = "Client view of an [`Rack`]"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Rack {
+        pub identity: IdentityMetadata,
+    }
+
+    #[doc = "A single page of results"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct RackResultsPage {
+        #[doc = "list of items on this page of results"]
+        pub items: Vec<Rack>,
+        #[doc = "token used to fetch the next page of results (if any)"]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub next_page: Option<String>,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    #[serde(tag = "type", content = "value")]
+    pub enum RouteDestination {
+        #[serde(rename = "ip")]
+        Ip(String),
+        #[serde(rename = "vpc")]
+        Vpc(Name),
+        #[serde(rename = "subnet")]
+        Subnet(Name),
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    #[serde(tag = "type", content = "value")]
+    pub enum RouteTarget {
+        #[serde(rename = "ip")]
+        Ip(String),
+        #[serde(rename = "vpc")]
+        Vpc(Name),
+        #[serde(rename = "subnet")]
+        Subnet(Name),
+        #[serde(rename = "instance")]
+        Instance(Name),
+        #[serde(rename = "internetGateway")]
+        InternetGateway(Name),
+    }
+
+    #[doc = "A route defines a rule that governs where traffic should be sent based on its destination."]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct RouterRoute {
+        pub destination: RouteDestination,
+        pub identity: IdentityMetadata,
+        pub kind: RouterRouteKind,
+        #[doc = "The VPC Router to which the route belongs."]
+        pub router_id: uuid::Uuid,
+        pub target: RouteTarget,
+    }
+
+    #[doc = "Create-time parameters for a [`RouterRoute`]"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct RouterRouteCreateParams {
+        pub description: String,
+        pub destination: RouteDestination,
+        pub name: Name,
+        pub target: RouteTarget,
+    }
+
+    #[doc = "The classification of a [`RouterRoute`] as defined by the system. The kind determines certain attributes such as if the route is modifiable and describes how or where the route was created.\n\nSee [RFD-21](https://rfd.shared.oxide.computer/rfd/0021#concept-router) for more context"]
+    #[derive(Serialize, Deserialize, Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
+    pub enum RouterRouteKind {
+        Default,
+        VpcSubnet,
+        VpcPeering,
+        Custom,
+    }
+
+    impl ToString for RouterRouteKind {
+        fn to_string(&self) -> String {
+            match self {
+                RouterRouteKind::Default => "Default".to_string(),
+                RouterRouteKind::VpcSubnet => "VpcSubnet".to_string(),
+                RouterRouteKind::VpcPeering => "VpcPeering".to_string(),
+                RouterRouteKind::Custom => "Custom".to_string(),
+            }
+        }
+    }
+
+    #[doc = "A single page of results"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct RouterRouteResultsPage {
+        #[doc = "list of items on this page of results"]
+        pub items: Vec<RouterRoute>,
+        #[doc = "token used to fetch the next page of results (if any)"]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub next_page: Option<String>,
+    }
+
+    #[doc = "Updateable properties of a [`RouterRoute`]"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct RouterRouteUpdateParams {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub description: Option<String>,
+        pub destination: RouteDestination,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub name: Option<Name>,
+        pub target: RouteTarget,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Saga {
+        pub id: uuid::Uuid,
+        pub state: SagaState,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    #[serde(tag = "error")]
+    pub enum SagaErrorInfo {
+        #[serde(rename = "actionFailed")]
+        ActionFailed { source_error: serde_json::Value },
+        #[serde(rename = "deserializeFailed")]
+        DeserializeFailed { message: String },
+        #[serde(rename = "injectedError")]
+        InjectedError,
+        #[serde(rename = "serializeFailed")]
+        SerializeFailed { message: String },
+        #[serde(rename = "subsagaCreateFailed")]
+        SubsagaCreateFailed { message: String },
+    }
+
+    #[doc = "A single page of results"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct SagaResultsPage {
+        #[doc = "list of items on this page of results"]
+        pub items: Vec<Saga>,
+        #[doc = "token used to fetch the next page of results (if any)"]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub next_page: Option<String>,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    #[serde(tag = "state")]
+    pub enum SagaState {
+        #[serde(rename = "running")]
+        Running,
+        #[serde(rename = "succeeded")]
+        Succeeded,
+        #[serde(rename = "failed")]
+        Failed {
+            error_info: SagaErrorInfo,
+            error_node_name: String,
+        },
+    }
+
+    #[doc = "Client view of an [`Sled`]"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Sled {
+        #[doc = "human-readable free-form text about a resource"]
+        pub description: String,
+        #[doc = "unique, immutable, system-controlled identifier for each resource"]
+        pub id: uuid::Uuid,
+        pub name: Name,
+        #[serde(rename = "serviceAddress")]
+        pub service_address: String,
+        #[doc = "timestamp when this resource was created"]
+        #[serde(rename = "timeCreated")]
+        pub time_created: chrono::DateTime<chrono::offset::Utc>,
+        #[doc = "timestamp when this resource was last modified"]
+        #[serde(rename = "timeModified")]
+        pub time_modified: chrono::DateTime<chrono::offset::Utc>,
+    }
+
+    #[doc = "A single page of results"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct SledResultsPage {
+        #[doc = "list of items on this page of results"]
+        pub items: Vec<Sled>,
+        #[doc = "token used to fetch the next page of results (if any)"]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub next_page: Option<String>,
+    }
+
+    #[doc = "Client view of a [`User`]"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct User {
+        #[doc = "human-readable free-form text about a resource"]
+        pub description: String,
+        #[doc = "unique, immutable, system-controlled identifier for each resource"]
+        pub id: uuid::Uuid,
+        pub name: Name,
+        #[doc = "timestamp when this resource was created"]
+        #[serde(rename = "timeCreated")]
+        pub time_created: chrono::DateTime<chrono::offset::Utc>,
+        #[doc = "timestamp when this resource was last modified"]
+        #[serde(rename = "timeModified")]
+        pub time_modified: chrono::DateTime<chrono::offset::Utc>,
+    }
+
+    #[doc = "A single page of results"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct UserResultsPage {
+        #[doc = "list of items on this page of results"]
+        pub items: Vec<User>,
+        #[doc = "token used to fetch the next page of results (if any)"]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub next_page: Option<String>,
+    }
+
+    #[doc = "Client view of a [`Vpc`]"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Vpc {
+        #[doc = "human-readable free-form text about a resource"]
+        pub description: String,
+        #[serde(rename = "dnsName")]
+        pub dns_name: Name,
+        #[doc = "unique, immutable, system-controlled identifier for each resource"]
+        pub id: uuid::Uuid,
+        pub name: Name,
+        #[doc = "id for the project containing this VPC"]
+        #[serde(rename = "projectId")]
+        pub project_id: uuid::Uuid,
+        #[doc = "id for the system router where subnet default routes are registered"]
+        #[serde(rename = "systemRouterId")]
+        pub system_router_id: uuid::Uuid,
+        #[doc = "timestamp when this resource was created"]
+        #[serde(rename = "timeCreated")]
+        pub time_created: chrono::DateTime<chrono::offset::Utc>,
+        #[doc = "timestamp when this resource was last modified"]
+        #[serde(rename = "timeModified")]
+        pub time_modified: chrono::DateTime<chrono::offset::Utc>,
+    }
+
+    #[doc = "Create-time parameters for a [`Vpc`]"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct VpcCreate {
+        pub description: String,
+        #[serde(rename = "dnsName")]
+        pub dns_name: Name,
+        pub name: Name,
+    }
+
+    #[doc = "A single rule in a VPC firewall"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct VpcFirewallRule {
+        pub action: VpcFirewallRuleAction,
+        pub direction: VpcFirewallRuleDirection,
+        pub filters: VpcFirewallRuleFilter,
+        pub identity: IdentityMetadata,
+        #[doc = "the relative priority of this rule"]
+        pub priority: u16,
+        pub status: VpcFirewallRuleStatus,
+        #[doc = "list of sets of instances that the rule applies to"]
+        pub targets: Vec<VpcFirewallRuleTarget>,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
+    pub enum VpcFirewallRuleAction {
+        #[serde(rename = "allow")]
+        Allow,
+        #[serde(rename = "deny")]
+        Deny,
+    }
+
+    impl ToString for VpcFirewallRuleAction {
+        fn to_string(&self) -> String {
+            match self {
+                VpcFirewallRuleAction::Allow => "allow".to_string(),
+                VpcFirewallRuleAction::Deny => "deny".to_string(),
+            }
+        }
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
+    pub enum VpcFirewallRuleDirection {
+        #[serde(rename = "inbound")]
+        Inbound,
+        #[serde(rename = "outbound")]
+        Outbound,
+    }
+
+    impl ToString for VpcFirewallRuleDirection {
+        fn to_string(&self) -> String {
+            match self {
+                VpcFirewallRuleDirection::Inbound => "inbound".to_string(),
+                VpcFirewallRuleDirection::Outbound => "outbound".to_string(),
+            }
+        }
+    }
+
+    #[doc = "Filter for a firewall rule. A given packet must match every field that is present for the rule to apply to it. A packet matches a field if any entry in that field matches the packet."]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct VpcFirewallRuleFilter {
+        #[doc = "If present, the sources (if incoming) or destinations (if outgoing) this rule applies to."]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub hosts: Option<Vec<VpcFirewallRuleHostFilter>>,
+        #[doc = "If present, the destination ports this rule applies to."]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub ports: Option<Vec<L4PortRange>>,
+        #[doc = "If present, the networking protocols this rule applies to."]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub protocols: Option<Vec<VpcFirewallRuleProtocol>>,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    #[serde(tag = "type", content = "value")]
+    pub enum VpcFirewallRuleHostFilter {
+        #[serde(rename = "vpc")]
+        Vpc(Name),
+        #[serde(rename = "subnet")]
+        Subnet(Name),
+        #[serde(rename = "instance")]
+        Instance(Name),
+        #[serde(rename = "ip")]
+        Ip(String),
+        #[serde(rename = "internetGateway")]
+        InternetGateway(Name),
+    }
+
+    #[doc = "The protocols that may be specified in a firewall rule's filter"]
+    #[derive(Serialize, Deserialize, Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
+    pub enum VpcFirewallRuleProtocol {
+        #[serde(rename = "TCP")]
+        Tcp,
+        #[serde(rename = "UDP")]
+        Udp,
+        #[serde(rename = "ICMP")]
+        Icmp,
+    }
+
+    impl ToString for VpcFirewallRuleProtocol {
+        fn to_string(&self) -> String {
+            match self {
+                VpcFirewallRuleProtocol::Tcp => "TCP".to_string(),
+                VpcFirewallRuleProtocol::Udp => "UDP".to_string(),
+                VpcFirewallRuleProtocol::Icmp => "ICMP".to_string(),
+            }
+        }
+    }
+
+    #[doc = "A single page of results"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct VpcFirewallRuleResultsPage {
+        #[doc = "list of items on this page of results"]
+        pub items: Vec<VpcFirewallRule>,
+        #[doc = "token used to fetch the next page of results (if any)"]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub next_page: Option<String>,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
+    pub enum VpcFirewallRuleStatus {
+        #[serde(rename = "disabled")]
+        Disabled,
+        #[serde(rename = "enabled")]
+        Enabled,
+    }
+
+    impl ToString for VpcFirewallRuleStatus {
+        fn to_string(&self) -> String {
+            match self {
+                VpcFirewallRuleStatus::Disabled => "disabled".to_string(),
+                VpcFirewallRuleStatus::Enabled => "enabled".to_string(),
+            }
+        }
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    #[serde(tag = "type", content = "value")]
+    pub enum VpcFirewallRuleTarget {
+        #[serde(rename = "vpc")]
+        Vpc(Name),
+        #[serde(rename = "subnet")]
+        Subnet(Name),
+        #[serde(rename = "instance")]
+        Instance(Name),
+    }
+
+    #[doc = "A single rule in a VPC firewall"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct VpcFirewallRuleUpdate {
+        pub action: VpcFirewallRuleAction,
+        #[doc = "human-readable free-form text about a resource"]
+        pub description: String,
+        pub direction: VpcFirewallRuleDirection,
+        pub filters: VpcFirewallRuleFilter,
+        #[doc = "the relative priority of this rule"]
+        pub priority: u16,
+        pub status: VpcFirewallRuleStatus,
+        #[doc = "list of sets of instances that the rule applies to"]
+        pub targets: Vec<VpcFirewallRuleTarget>,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct VpcFirewallRuleUpdateParams(
+        pub std::collections::HashMap<String, VpcFirewallRuleUpdate>,
+    );
+    impl std::ops::Deref for VpcFirewallRuleUpdateParams {
+        type Target = std::collections::HashMap<String, VpcFirewallRuleUpdate>;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct VpcFirewallRuleUpdateResult(pub std::collections::HashMap<String, VpcFirewallRule>);
+    impl std::ops::Deref for VpcFirewallRuleUpdateResult {
+        type Target = std::collections::HashMap<String, VpcFirewallRule>;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    #[doc = "A single page of results"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct VpcResultsPage {
+        #[doc = "list of items on this page of results"]
+        pub items: Vec<Vpc>,
+        #[doc = "token used to fetch the next page of results (if any)"]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub next_page: Option<String>,
+    }
+
+    #[doc = "A VPC router defines a series of rules that indicate where traffic should be sent depending on its destination."]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct VpcRouter {
+        pub identity: IdentityMetadata,
+        pub kind: VpcRouterKind,
+        #[doc = "The VPC to which the router belongs."]
+        pub vpc_id: uuid::Uuid,
+    }
+
+    #[doc = "Create-time parameters for a [`VpcRouter`]"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct VpcRouterCreate {
+        pub description: String,
+        pub name: Name,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
+    pub enum VpcRouterKind {
+        #[serde(rename = "system")]
+        System,
+        #[serde(rename = "custom")]
+        Custom,
+    }
+
+    impl ToString for VpcRouterKind {
+        fn to_string(&self) -> String {
+            match self {
+                VpcRouterKind::System => "system".to_string(),
+                VpcRouterKind::Custom => "custom".to_string(),
+            }
+        }
+    }
+
+    #[doc = "A single page of results"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct VpcRouterResultsPage {
+        #[doc = "list of items on this page of results"]
+        pub items: Vec<VpcRouter>,
+        #[doc = "token used to fetch the next page of results (if any)"]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub next_page: Option<String>,
+    }
+
+    #[doc = "Updateable properties of a [`VpcRouter`]"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct VpcRouterUpdate {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub description: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub name: Option<Name>,
+    }
+
+    #[doc = "A VPC subnet represents a logical grouping for instances that allows network traffic between them, within a IPv4 subnetwork or optionall an IPv6 subnetwork."]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct VpcSubnet {
+        pub identity: IdentityMetadata,
+        #[serde(
+            rename = "ipv4_block",
+            default,
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub ipv_4_block: Option<Ipv4Net>,
+        #[serde(
+            rename = "ipv6_block",
+            default,
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub ipv_6_block: Option<Ipv6Net>,
+        #[doc = "The VPC to which the subnet belongs."]
+        pub vpc_id: uuid::Uuid,
+    }
+
+    #[doc = "Create-time parameters for a [`VpcSubnet`]"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct VpcSubnetCreate {
+        pub description: String,
+        #[serde(rename = "ipv4Block", default, skip_serializing_if = "Option::is_none")]
+        pub ipv_4_block: Option<Ipv4Net>,
+        #[serde(rename = "ipv6Block", default, skip_serializing_if = "Option::is_none")]
+        pub ipv_6_block: Option<Ipv6Net>,
+        pub name: Name,
+    }
+
+    #[doc = "A single page of results"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct VpcSubnetResultsPage {
+        #[doc = "list of items on this page of results"]
+        pub items: Vec<VpcSubnet>,
+        #[doc = "token used to fetch the next page of results (if any)"]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub next_page: Option<String>,
+    }
+
+    #[doc = "Updateable properties of a [`VpcSubnet`]"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct VpcSubnetUpdate {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub description: Option<String>,
+        #[serde(rename = "ipv4Block", default, skip_serializing_if = "Option::is_none")]
+        pub ipv_4_block: Option<Ipv4Net>,
+        #[serde(rename = "ipv6Block", default, skip_serializing_if = "Option::is_none")]
+        pub ipv_6_block: Option<Ipv6Net>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub name: Option<Name>,
+    }
+
+    #[doc = "Updateable properties of a [`Vpc`]"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct VpcUpdate {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub description: Option<String>,
+        #[serde(rename = "dnsName", default, skip_serializing_if = "Option::is_none")]
+        pub dns_name: Option<Name>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub name: Option<Name>,
+    }
+}
+
+#[derive(Clone)]
+pub struct Client {
+    baseurl: String,
+    client: reqwest::Client,
+}
+
+impl Client {
+    pub fn new(baseurl: &str) -> Self {
+        let dur = std::time::Duration::from_secs(15);
+        let client = reqwest::ClientBuilder::new()
+            .connect_timeout(dur)
+            .timeout(dur)
+            .build()
+            .unwrap();
+        Self::new_with_client(baseurl, client)
+    }
+
+    pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
+        Self {
+            baseurl: baseurl.to_string(),
+            client,
+        }
+    }
+
+    pub fn baseurl(&self) -> &String {
+        &self.baseurl
+    }
+
+    pub fn client(&self) -> &reqwest::Client {
+        &self.client
+    }
+
+    #[doc = "List racks in the system.\n\nhardware_racks_get: GET /hardware/racks"]
+    pub async fn hardware_racks_get(
+        &self,
+        limit: Option<std::num::NonZeroU32>,
+        page_token: Option<&str>,
+        sort_by: Option<types::IdSortMode>,
+    ) -> Result<types::RackResultsPage> {
+        let url = format!("{}/hardware/racks", self.baseurl,);
+        let mut query = Vec::new();
+        if let Some(v) = &limit {
+            query.push(("limit", v.to_string()));
+        }
+
+        if let Some(v) = &page_token {
+            query.push(("page_token", v.to_string()));
+        }
+
+        if let Some(v) = &sort_by {
+            query.push(("sort_by", v.to_string()));
+        }
+
+        let request = self.client.get(url).query(&query).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Fetch information about a particular rack.\n\nhardware_racks_get_rack: GET /hardware/racks/{rack_id}"]
+    pub async fn hardware_racks_get_rack(&self, rack_id: &uuid::Uuid) -> Result<types::Rack> {
+        let url = format!(
+            "{}/hardware/racks/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&rack_id.to_string()),
+        );
+        let request = self.client.get(url).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "List sleds in the system.\n\nhardware_sleds_get: GET /hardware/sleds"]
+    pub async fn hardware_sleds_get(
+        &self,
+        limit: Option<std::num::NonZeroU32>,
+        page_token: Option<&str>,
+        sort_by: Option<types::IdSortMode>,
+    ) -> Result<types::SledResultsPage> {
+        let url = format!("{}/hardware/sleds", self.baseurl,);
+        let mut query = Vec::new();
+        if let Some(v) = &limit {
+            query.push(("limit", v.to_string()));
+        }
+
+        if let Some(v) = &page_token {
+            query.push(("page_token", v.to_string()));
+        }
+
+        if let Some(v) = &sort_by {
+            query.push(("sort_by", v.to_string()));
+        }
+
+        let request = self.client.get(url).query(&query).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Fetch information about a sled in the system.\n\nhardware_sleds_get_sled: GET /hardware/sleds/{sled_id}"]
+    pub async fn hardware_sleds_get_sled(&self, sled_id: &uuid::Uuid) -> Result<types::Sled> {
+        let url = format!(
+            "{}/hardware/sleds/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&sled_id.to_string()),
+        );
+        let request = self.client.get(url).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "spoof_login: POST /login"]
+    pub async fn spoof_login(&self, body: &types::LoginParams) -> Result<reqwest::Response> {
+        let url = format!("{}/login", self.baseurl,);
+        let request = self.client.post(url).json(body).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res)
+    }
+
+    #[doc = "logout: POST /logout"]
+    pub async fn logout(&self) -> Result<reqwest::Response> {
+        let url = format!("{}/logout", self.baseurl,);
+        let request = self.client.post(url).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res)
+    }
+
+    #[doc = "List all organizations.\n\norganizations_get: GET /organizations"]
+    pub async fn organizations_get(
+        &self,
+        limit: Option<std::num::NonZeroU32>,
+        page_token: Option<&str>,
+        sort_by: Option<types::NameOrIdSortMode>,
+    ) -> Result<types::OrganizationResultsPage> {
+        let url = format!("{}/organizations", self.baseurl,);
+        let mut query = Vec::new();
+        if let Some(v) = &limit {
+            query.push(("limit", v.to_string()));
+        }
+
+        if let Some(v) = &page_token {
+            query.push(("page_token", v.to_string()));
+        }
+
+        if let Some(v) = &sort_by {
+            query.push(("sort_by", v.to_string()));
+        }
+
+        let request = self.client.get(url).query(&query).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Create a new organization.\n\norganizations_post: POST /organizations"]
+    pub async fn organizations_post(
+        &self,
+        body: &types::OrganizationCreate,
+    ) -> Result<types::Organization> {
+        let url = format!("{}/organizations", self.baseurl,);
+        let request = self.client.post(url).json(body).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Fetch a specific organization\n\norganizations_get_organization: GET /organizations/{organization_name}"]
+    pub async fn organizations_get_organization(
+        &self,
+        organization_name: &types::Name,
+    ) -> Result<types::Organization> {
+        let url = format!(
+            "{}/organizations/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+        );
+        let request = self.client.get(url).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Update a specific organization.\n * TODO-correctness: Is it valid for PUT to accept application/json that's a subset of what the resource actually represents?  If not, is that a problem? (HTTP may require that this be idempotent.)  If so, can we get around that having this be a slightly different content-type (e.g., \"application/json-patch\")?  We should see what other APIs do.\n\norganizations_put_organization: PUT /organizations/{organization_name}"]
+    pub async fn organizations_put_organization(
+        &self,
+        organization_name: &types::Name,
+        body: &types::OrganizationUpdate,
+    ) -> Result<types::Organization> {
+        let url = format!(
+            "{}/organizations/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+        );
+        let request = self.client.put(url).json(body).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Delete a specific organization.\n\norganizations_delete_organization: DELETE /organizations/{organization_name}"]
+    pub async fn organizations_delete_organization(
+        &self,
+        organization_name: &types::Name,
+    ) -> Result<()> {
+        let url = format!(
+            "{}/organizations/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+        );
+        let request = self.client.delete(url).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(())
+    }
+
+    #[doc = "List all projects.\n\norganization_projects_get: GET /organizations/{organization_name}/projects"]
+    pub async fn organization_projects_get(
+        &self,
+        organization_name: &types::Name,
+        limit: Option<std::num::NonZeroU32>,
+        page_token: Option<&str>,
+        sort_by: Option<types::NameOrIdSortMode>,
+    ) -> Result<types::ProjectResultsPage> {
+        let url = format!(
+            "{}/organizations/{}/projects",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+        );
+        let mut query = Vec::new();
+        if let Some(v) = &limit {
+            query.push(("limit", v.to_string()));
+        }
+
+        if let Some(v) = &page_token {
+            query.push(("page_token", v.to_string()));
+        }
+
+        if let Some(v) = &sort_by {
+            query.push(("sort_by", v.to_string()));
+        }
+
+        let request = self.client.get(url).query(&query).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Create a new project.\n\norganization_projects_post: POST /organizations/{organization_name}/projects"]
+    pub async fn organization_projects_post(
+        &self,
+        organization_name: &types::Name,
+        body: &types::ProjectCreate,
+    ) -> Result<types::Project> {
+        let url = format!(
+            "{}/organizations/{}/projects",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+        );
+        let request = self.client.post(url).json(body).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Fetch a specific project\n\norganization_projects_get_project: GET /organizations/{organization_name}/projects/{project_name}"]
+    pub async fn organization_projects_get_project(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+    ) -> Result<types::Project> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+        );
+        let request = self.client.get(url).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Update a specific project.\n * TODO-correctness: Is it valid for PUT to accept application/json that's a subset of what the resource actually represents?  If not, is that a problem? (HTTP may require that this be idempotent.)  If so, can we get around that having this be a slightly different content-type (e.g., \"application/json-patch\")?  We should see what other APIs do.\n\norganization_projects_put_project: PUT /organizations/{organization_name}/projects/{project_name}"]
+    pub async fn organization_projects_put_project(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        body: &types::ProjectUpdate,
+    ) -> Result<types::Project> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+        );
+        let request = self.client.put(url).json(body).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Delete a specific project.\n\norganization_projects_delete_project: DELETE /organizations/{organization_name}/projects/{project_name}"]
+    pub async fn organization_projects_delete_project(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+    ) -> Result<()> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+        );
+        let request = self.client.delete(url).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(())
+    }
+
+    #[doc = "List disks in a project.\n\nproject_disks_get: GET /organizations/{organization_name}/projects/{project_name}/disks"]
+    pub async fn project_disks_get(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        limit: Option<std::num::NonZeroU32>,
+        page_token: Option<&str>,
+        sort_by: Option<types::NameSortMode>,
+    ) -> Result<types::DiskResultsPage> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/disks",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+        );
+        let mut query = Vec::new();
+        if let Some(v) = &limit {
+            query.push(("limit", v.to_string()));
+        }
+
+        if let Some(v) = &page_token {
+            query.push(("page_token", v.to_string()));
+        }
+
+        if let Some(v) = &sort_by {
+            query.push(("sort_by", v.to_string()));
+        }
+
+        let request = self.client.get(url).query(&query).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Create a disk in a project.\n * TODO-correctness See note about instance create.  This should be async.\n\nproject_disks_post: POST /organizations/{organization_name}/projects/{project_name}/disks"]
+    pub async fn project_disks_post(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        body: &types::DiskCreate,
+    ) -> Result<types::Disk> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/disks",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+        );
+        let request = self.client.post(url).json(body).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Fetch a single disk in a project.\n\nproject_disks_get_disk: GET /organizations/{organization_name}/projects/{project_name}/disks/{disk_name}"]
+    pub async fn project_disks_get_disk(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        disk_name: &types::Name,
+    ) -> Result<types::Disk> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/disks/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&disk_name.to_string()),
+        );
+        let request = self.client.get(url).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Delete a disk from a project.\n\nproject_disks_delete_disk: DELETE /organizations/{organization_name}/projects/{project_name}/disks/{disk_name}"]
+    pub async fn project_disks_delete_disk(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        disk_name: &types::Name,
+    ) -> Result<()> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/disks/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&disk_name.to_string()),
+        );
+        let request = self.client.delete(url).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(())
+    }
+
+    #[doc = "List instances in a project.\n\nproject_instances_get: GET /organizations/{organization_name}/projects/{project_name}/instances"]
+    pub async fn project_instances_get(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        limit: Option<std::num::NonZeroU32>,
+        page_token: Option<&str>,
+        sort_by: Option<types::NameSortMode>,
+    ) -> Result<types::InstanceResultsPage> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/instances",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+        );
+        let mut query = Vec::new();
+        if let Some(v) = &limit {
+            query.push(("limit", v.to_string()));
+        }
+
+        if let Some(v) = &page_token {
+            query.push(("page_token", v.to_string()));
+        }
+
+        if let Some(v) = &sort_by {
+            query.push(("sort_by", v.to_string()));
+        }
+
+        let request = self.client.get(url).query(&query).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Create an instance in a project.\n * TODO-correctness This is supposed to be async.  Is that right?  We can create the instance immediately -- it's just not booted yet.  Maybe the boot operation is what's a separate operation_id.  What about the response code (201 Created vs 202 Accepted)?  Is that orthogonal?  Things can return a useful response, including an operation id, with either response code.  Maybe a \"reboot\" operation would return a 202 Accepted because there's no actual resource created?\n\nproject_instances_post: POST /organizations/{organization_name}/projects/{project_name}/instances"]
+    pub async fn project_instances_post(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        body: &types::InstanceCreate,
+    ) -> Result<types::Instance> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/instances",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+        );
+        let request = self.client.post(url).json(body).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Get an instance in a project.\n\nproject_instances_get_instance: GET /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}"]
+    pub async fn project_instances_get_instance(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        instance_name: &types::Name,
+    ) -> Result<types::Instance> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/instances/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&instance_name.to_string()),
+        );
+        let request = self.client.get(url).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Delete an instance from a project.\n\nproject_instances_delete_instance: DELETE /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}"]
+    pub async fn project_instances_delete_instance(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        instance_name: &types::Name,
+    ) -> Result<()> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/instances/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&instance_name.to_string()),
+        );
+        let request = self.client.delete(url).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(())
+    }
+
+    #[doc = "List disks attached to this instance.\n\ninstance_disks_get: GET /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks"]
+    pub async fn instance_disks_get(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        instance_name: &types::Name,
+    ) -> Result<Vec<types::DiskAttachment>> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/instances/{}/disks",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&instance_name.to_string()),
+        );
+        let request = self.client.get(url).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Fetch a description of the attachment of this disk to this instance.\n\ninstance_disks_get_disk: GET /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks/{disk_name}"]
+    pub async fn instance_disks_get_disk(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        instance_name: &types::Name,
+        disk_name: &types::Name,
+    ) -> Result<types::DiskAttachment> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/instances/{}/disks/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&instance_name.to_string()),
+            progenitor_support::encode_path(&disk_name.to_string()),
+        );
+        let request = self.client.get(url).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Attach a disk to this instance.\n\ninstance_disks_put_disk: PUT /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks/{disk_name}"]
+    pub async fn instance_disks_put_disk(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        instance_name: &types::Name,
+        disk_name: &types::Name,
+    ) -> Result<types::DiskAttachment> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/instances/{}/disks/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&instance_name.to_string()),
+            progenitor_support::encode_path(&disk_name.to_string()),
+        );
+        let request = self.client.put(url).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Detach a disk from this instance.\n\ninstance_disks_delete_disk: DELETE /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks/{disk_name}"]
+    pub async fn instance_disks_delete_disk(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        instance_name: &types::Name,
+        disk_name: &types::Name,
+    ) -> Result<()> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/instances/{}/disks/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&instance_name.to_string()),
+            progenitor_support::encode_path(&disk_name.to_string()),
+        );
+        let request = self.client.delete(url).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(())
+    }
+
+    #[doc = "Reboot an instance.\n\nproject_instances_instance_reboot: POST /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/reboot"]
+    pub async fn project_instances_instance_reboot(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        instance_name: &types::Name,
+    ) -> Result<types::Instance> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/instances/{}/reboot",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&instance_name.to_string()),
+        );
+        let request = self.client.post(url).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Boot an instance.\n\nproject_instances_instance_start: POST /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/start"]
+    pub async fn project_instances_instance_start(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        instance_name: &types::Name,
+    ) -> Result<types::Instance> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/instances/{}/start",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&instance_name.to_string()),
+        );
+        let request = self.client.post(url).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Halt an instance.\n\nproject_instances_instance_stop: POST /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/stop"]
+    pub async fn project_instances_instance_stop(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        instance_name: &types::Name,
+    ) -> Result<types::Instance> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/instances/{}/stop",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&instance_name.to_string()),
+        );
+        let request = self.client.post(url).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "List VPCs in a project.\n\nproject_vpcs_get: GET /organizations/{organization_name}/projects/{project_name}/vpcs"]
+    pub async fn project_vpcs_get(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        limit: Option<std::num::NonZeroU32>,
+        page_token: Option<&str>,
+        sort_by: Option<types::NameSortMode>,
+    ) -> Result<types::VpcResultsPage> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/vpcs",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+        );
+        let mut query = Vec::new();
+        if let Some(v) = &limit {
+            query.push(("limit", v.to_string()));
+        }
+
+        if let Some(v) = &page_token {
+            query.push(("page_token", v.to_string()));
+        }
+
+        if let Some(v) = &sort_by {
+            query.push(("sort_by", v.to_string()));
+        }
+
+        let request = self.client.get(url).query(&query).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Create a VPC in a project.\n\nproject_vpcs_post: POST /organizations/{organization_name}/projects/{project_name}/vpcs"]
+    pub async fn project_vpcs_post(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        body: &types::VpcCreate,
+    ) -> Result<types::Vpc> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/vpcs",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+        );
+        let request = self.client.post(url).json(body).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Get a VPC in a project.\n\nproject_vpcs_get_vpc: GET /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}"]
+    pub async fn project_vpcs_get_vpc(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        vpc_name: &types::Name,
+    ) -> Result<types::Vpc> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/vpcs/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&vpc_name.to_string()),
+        );
+        let request = self.client.get(url).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Update a VPC.\n\nproject_vpcs_put_vpc: PUT /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}"]
+    pub async fn project_vpcs_put_vpc(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        vpc_name: &types::Name,
+        body: &types::VpcUpdate,
+    ) -> Result<()> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/vpcs/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&vpc_name.to_string()),
+        );
+        let request = self.client.put(url).json(body).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(())
+    }
+
+    #[doc = "Delete a vpc from a project.\n\nproject_vpcs_delete_vpc: DELETE /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}"]
+    pub async fn project_vpcs_delete_vpc(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        vpc_name: &types::Name,
+    ) -> Result<()> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/vpcs/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&vpc_name.to_string()),
+        );
+        let request = self.client.delete(url).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(())
+    }
+
+    #[doc = "List firewall rules for a VPC.\n\nvpc_firewall_rules_get: GET /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/firewall/rules"]
+    pub async fn vpc_firewall_rules_get(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        vpc_name: &types::Name,
+        limit: Option<std::num::NonZeroU32>,
+        page_token: Option<&str>,
+        sort_by: Option<types::NameSortMode>,
+    ) -> Result<types::VpcFirewallRuleResultsPage> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&vpc_name.to_string()),
+        );
+        let mut query = Vec::new();
+        if let Some(v) = &limit {
+            query.push(("limit", v.to_string()));
+        }
+
+        if let Some(v) = &page_token {
+            query.push(("page_token", v.to_string()));
+        }
+
+        if let Some(v) = &sort_by {
+            query.push(("sort_by", v.to_string()));
+        }
+
+        let request = self.client.get(url).query(&query).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Replace the firewall rules for a VPC\n\nvpc_firewall_rules_put: PUT /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/firewall/rules"]
+    pub async fn vpc_firewall_rules_put(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        vpc_name: &types::Name,
+        body: &types::VpcFirewallRuleUpdateParams,
+    ) -> Result<types::VpcFirewallRuleUpdateResult> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&vpc_name.to_string()),
+        );
+        let request = self.client.put(url).json(body).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "List VPC Custom and System Routers\n\nvpc_routers_get: GET /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers"]
+    pub async fn vpc_routers_get(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        vpc_name: &types::Name,
+        limit: Option<std::num::NonZeroU32>,
+        page_token: Option<&str>,
+        sort_by: Option<types::NameSortMode>,
+    ) -> Result<types::VpcRouterResultsPage> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/vpcs/{}/routers",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&vpc_name.to_string()),
+        );
+        let mut query = Vec::new();
+        if let Some(v) = &limit {
+            query.push(("limit", v.to_string()));
+        }
+
+        if let Some(v) = &page_token {
+            query.push(("page_token", v.to_string()));
+        }
+
+        if let Some(v) = &sort_by {
+            query.push(("sort_by", v.to_string()));
+        }
+
+        let request = self.client.get(url).query(&query).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Create a VPC Router\n\nvpc_routers_post: POST /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers"]
+    pub async fn vpc_routers_post(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        vpc_name: &types::Name,
+        body: &types::VpcRouterCreate,
+    ) -> Result<types::VpcRouter> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/vpcs/{}/routers",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&vpc_name.to_string()),
+        );
+        let request = self.client.post(url).json(body).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Get a VPC Router\n\nvpc_routers_get_router: GET /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}"]
+    pub async fn vpc_routers_get_router(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        vpc_name: &types::Name,
+        router_name: &types::Name,
+    ) -> Result<types::VpcRouter> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&vpc_name.to_string()),
+            progenitor_support::encode_path(&router_name.to_string()),
+        );
+        let request = self.client.get(url).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Update a VPC Router\n\nvpc_routers_put_router: PUT /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}"]
+    pub async fn vpc_routers_put_router(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        vpc_name: &types::Name,
+        router_name: &types::Name,
+        body: &types::VpcRouterUpdate,
+    ) -> Result<()> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&vpc_name.to_string()),
+            progenitor_support::encode_path(&router_name.to_string()),
+        );
+        let request = self.client.put(url).json(body).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(())
+    }
+
+    #[doc = "Delete a router from its VPC\n\nvpc_routers_delete_router: DELETE /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}"]
+    pub async fn vpc_routers_delete_router(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        vpc_name: &types::Name,
+        router_name: &types::Name,
+    ) -> Result<()> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&vpc_name.to_string()),
+            progenitor_support::encode_path(&router_name.to_string()),
+        );
+        let request = self.client.delete(url).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(())
+    }
+
+    #[doc = "List a Router's routes\n\nrouters_routes_get: GET /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes"]
+    pub async fn routers_routes_get(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        vpc_name: &types::Name,
+        router_name: &types::Name,
+        limit: Option<std::num::NonZeroU32>,
+        page_token: Option<&str>,
+        sort_by: Option<types::NameSortMode>,
+    ) -> Result<types::RouterRouteResultsPage> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&vpc_name.to_string()),
+            progenitor_support::encode_path(&router_name.to_string()),
+        );
+        let mut query = Vec::new();
+        if let Some(v) = &limit {
+            query.push(("limit", v.to_string()));
+        }
+
+        if let Some(v) = &page_token {
+            query.push(("page_token", v.to_string()));
+        }
+
+        if let Some(v) = &sort_by {
+            query.push(("sort_by", v.to_string()));
+        }
+
+        let request = self.client.get(url).query(&query).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Create a VPC Router\n\nrouters_routes_post: POST /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes"]
+    pub async fn routers_routes_post(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        vpc_name: &types::Name,
+        router_name: &types::Name,
+        body: &types::RouterRouteCreateParams,
+    ) -> Result<types::RouterRoute> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&vpc_name.to_string()),
+            progenitor_support::encode_path(&router_name.to_string()),
+        );
+        let request = self.client.post(url).json(body).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Get a VPC Router route\n\nrouters_routes_get_route: GET /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes/{route_name}"]
+    pub async fn routers_routes_get_route(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        vpc_name: &types::Name,
+        router_name: &types::Name,
+        route_name: &types::Name,
+    ) -> Result<types::RouterRoute> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&vpc_name.to_string()),
+            progenitor_support::encode_path(&router_name.to_string()),
+            progenitor_support::encode_path(&route_name.to_string()),
+        );
+        let request = self.client.get(url).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Update a Router route\n\nrouters_routes_put_route: PUT /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes/{route_name}"]
+    pub async fn routers_routes_put_route(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        vpc_name: &types::Name,
+        router_name: &types::Name,
+        route_name: &types::Name,
+        body: &types::RouterRouteUpdateParams,
+    ) -> Result<()> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&vpc_name.to_string()),
+            progenitor_support::encode_path(&router_name.to_string()),
+            progenitor_support::encode_path(&route_name.to_string()),
+        );
+        let request = self.client.put(url).json(body).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(())
+    }
+
+    #[doc = "Delete a route from its router\n\nrouters_routes_delete_route: DELETE /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes/{route_name}"]
+    pub async fn routers_routes_delete_route(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        vpc_name: &types::Name,
+        router_name: &types::Name,
+        route_name: &types::Name,
+    ) -> Result<()> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&vpc_name.to_string()),
+            progenitor_support::encode_path(&router_name.to_string()),
+            progenitor_support::encode_path(&route_name.to_string()),
+        );
+        let request = self.client.delete(url).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(())
+    }
+
+    #[doc = "List subnets in a VPC.\n\nvpc_subnets_get: GET /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets"]
+    pub async fn vpc_subnets_get(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        vpc_name: &types::Name,
+        limit: Option<std::num::NonZeroU32>,
+        page_token: Option<&str>,
+        sort_by: Option<types::NameSortMode>,
+    ) -> Result<types::VpcSubnetResultsPage> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&vpc_name.to_string()),
+        );
+        let mut query = Vec::new();
+        if let Some(v) = &limit {
+            query.push(("limit", v.to_string()));
+        }
+
+        if let Some(v) = &page_token {
+            query.push(("page_token", v.to_string()));
+        }
+
+        if let Some(v) = &sort_by {
+            query.push(("sort_by", v.to_string()));
+        }
+
+        let request = self.client.get(url).query(&query).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Create a subnet in a VPC.\n\nvpc_subnets_post: POST /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets"]
+    pub async fn vpc_subnets_post(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        vpc_name: &types::Name,
+        body: &types::VpcSubnetCreate,
+    ) -> Result<types::VpcSubnet> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&vpc_name.to_string()),
+        );
+        let request = self.client.post(url).json(body).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Get subnet in a VPC.\n\nvpc_subnets_get_subnet: GET /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}"]
+    pub async fn vpc_subnets_get_subnet(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        vpc_name: &types::Name,
+        subnet_name: &types::Name,
+    ) -> Result<types::VpcSubnet> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&vpc_name.to_string()),
+            progenitor_support::encode_path(&subnet_name.to_string()),
+        );
+        let request = self.client.get(url).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Update a VPC Subnet.\n\nvpc_subnets_put_subnet: PUT /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}"]
+    pub async fn vpc_subnets_put_subnet(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        vpc_name: &types::Name,
+        subnet_name: &types::Name,
+        body: &types::VpcSubnetUpdate,
+    ) -> Result<()> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&vpc_name.to_string()),
+            progenitor_support::encode_path(&subnet_name.to_string()),
+        );
+        let request = self.client.put(url).json(body).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(())
+    }
+
+    #[doc = "Delete a subnet from a VPC.\n\nvpc_subnets_delete_subnet: DELETE /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}"]
+    pub async fn vpc_subnets_delete_subnet(
+        &self,
+        organization_name: &types::Name,
+        project_name: &types::Name,
+        vpc_name: &types::Name,
+        subnet_name: &types::Name,
+    ) -> Result<()> {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&vpc_name.to_string()),
+            progenitor_support::encode_path(&subnet_name.to_string()),
+        );
+        let request = self.client.delete(url).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(())
+    }
+
+    #[doc = "List all sagas (for debugging)\n\nsagas_get: GET /sagas"]
+    pub async fn sagas_get(
+        &self,
+        limit: Option<std::num::NonZeroU32>,
+        page_token: Option<&str>,
+        sort_by: Option<types::IdSortMode>,
+    ) -> Result<types::SagaResultsPage> {
+        let url = format!("{}/sagas", self.baseurl,);
+        let mut query = Vec::new();
+        if let Some(v) = &limit {
+            query.push(("limit", v.to_string()));
+        }
+
+        if let Some(v) = &page_token {
+            query.push(("page_token", v.to_string()));
+        }
+
+        if let Some(v) = &sort_by {
+            query.push(("sort_by", v.to_string()));
+        }
+
+        let request = self.client.get(url).query(&query).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Fetch information about a single saga (for debugging)\n\nsagas_get_saga: GET /sagas/{saga_id}"]
+    pub async fn sagas_get_saga(&self, saga_id: &uuid::Uuid) -> Result<types::Saga> {
+        let url = format!(
+            "{}/sagas/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&saga_id.to_string()),
+        );
+        let request = self.client.get(url).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "List the built-in system users\n\nusers_get: GET /users"]
+    pub async fn users_get(
+        &self,
+        limit: Option<std::num::NonZeroU32>,
+        page_token: Option<&str>,
+        sort_by: Option<types::NameSortMode>,
+    ) -> Result<types::UserResultsPage> {
+        let url = format!("{}/users", self.baseurl,);
+        let mut query = Vec::new();
+        if let Some(v) = &limit {
+            query.push(("limit", v.to_string()));
+        }
+
+        if let Some(v) = &page_token {
+            query.push(("page_token", v.to_string()));
+        }
+
+        if let Some(v) = &sort_by {
+            query.push(("sort_by", v.to_string()));
+        }
+
+        let request = self.client.get(url).query(&query).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+
+    #[doc = "Fetch a specific built-in system user\n\nusers_get_user: GET /users/{user_name}"]
+    pub async fn users_get_user(&self, user_name: &types::Name) -> Result<types::User> {
+        let url = format!(
+            "{}/users/{}",
+            self.baseurl,
+            progenitor_support::encode_path(&user_name.to_string()),
+        );
+        let request = self.client.get(url).build()?;
+        let result = self.client.execute(request).await;
+        let res = result?.error_for_status()?;
+        Ok(res.json().await?)
+    }
+}

--- a/progenitor-impl/tests/test_output.rs
+++ b/progenitor-impl/tests/test_output.rs
@@ -29,6 +29,11 @@ fn test_buildomat() {
     verify_file("buildomat");
 }
 
+#[test]
+fn test_nexus() {
+    verify_file("nexus");
+}
+
 // TODO this file is full of inconsistencies and incorrectly specified types.
 // It's an interesting test to consider whether we try to do our best to
 // interpret the intent or just fail.

--- a/sample_openapi/nexus.json
+++ b/sample_openapi/nexus.json
@@ -1,0 +1,4853 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Oxide Region API",
+    "description": "API for interacting with the Oxide control plane",
+    "contact": {
+      "url": "https://oxide.computer",
+      "email": "api@oxide.computer"
+    },
+    "version": "0.0.1"
+  },
+  "paths": {
+    "/hardware/racks": {
+      "get": {
+        "description": "List racks in the system.",
+        "operationId": "hardware_racks_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "nullable": true,
+              "description": "Maximum number of items returned by a single call",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "schema": {
+              "nullable": true,
+              "description": "Token returned by previous call to retreive the subsequent page",
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/IdSortMode"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RackResultsPage"
+                }
+              }
+            }
+          }
+        },
+        "x-dropshot-pagination": true
+      }
+    },
+    "/hardware/racks/{rack_id}": {
+      "get": {
+        "description": "Fetch information about a particular rack.",
+        "operationId": "hardware_racks_get_rack",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "rack_id",
+            "required": true,
+            "schema": {
+              "description": "The rack's unique ID.",
+              "type": "string",
+              "format": "uuid"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Rack"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/hardware/sleds": {
+      "get": {
+        "description": "List sleds in the system.",
+        "operationId": "hardware_sleds_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "nullable": true,
+              "description": "Maximum number of items returned by a single call",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "schema": {
+              "nullable": true,
+              "description": "Token returned by previous call to retreive the subsequent page",
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/IdSortMode"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SledResultsPage"
+                }
+              }
+            }
+          }
+        },
+        "x-dropshot-pagination": true
+      }
+    },
+    "/hardware/sleds/{sled_id}": {
+      "get": {
+        "description": "Fetch information about a sled in the system.",
+        "operationId": "hardware_sleds_get_sled",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "sled_id",
+            "required": true,
+            "schema": {
+              "description": "The sled's unique ID.",
+              "type": "string",
+              "format": "uuid"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Sled"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/login": {
+      "post": {
+        "operationId": "spoof_login",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginParams"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {}
+      }
+    },
+    "/logout": {
+      "post": {
+        "operationId": "logout",
+        "responses": {}
+      }
+    },
+    "/organizations": {
+      "get": {
+        "description": "List all organizations.",
+        "operationId": "organizations_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "nullable": true,
+              "description": "Maximum number of items returned by a single call",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "schema": {
+              "nullable": true,
+              "description": "Token returned by previous call to retreive the subsequent page",
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/NameOrIdSortMode"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationResultsPage"
+                }
+              }
+            }
+          }
+        },
+        "x-dropshot-pagination": true
+      },
+      "post": {
+        "description": "Create a new organization.",
+        "operationId": "organizations_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrganizationCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "successful creation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Organization"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{organization_name}": {
+      "get": {
+        "description": "Fetch a specific organization",
+        "operationId": "organizations_get_organization",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Organization"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Update a specific organization.\n * TODO-correctness: Is it valid for PUT to accept application/json that's a subset of what the resource actually represents?  If not, is that a problem? (HTTP may require that this be idempotent.)  If so, can we get around that having this be a slightly different content-type (e.g., \"application/json-patch\")?  We should see what other APIs do.",
+        "operationId": "organizations_put_organization",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrganizationUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Organization"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete a specific organization.",
+        "operationId": "organizations_delete_organization",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful deletion"
+          }
+        }
+      }
+    },
+    "/organizations/{organization_name}/projects": {
+      "get": {
+        "description": "List all projects.",
+        "operationId": "organization_projects_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "nullable": true,
+              "description": "Maximum number of items returned by a single call",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "schema": {
+              "nullable": true,
+              "description": "Token returned by previous call to retreive the subsequent page",
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/NameOrIdSortMode"
+            },
+            "style": "form"
+          },
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectResultsPage"
+                }
+              }
+            }
+          }
+        },
+        "x-dropshot-pagination": true
+      },
+      "post": {
+        "description": "Create a new project.",
+        "operationId": "organization_projects_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "successful creation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Project"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{organization_name}/projects/{project_name}": {
+      "get": {
+        "description": "Fetch a specific project",
+        "operationId": "organization_projects_get_project",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Project"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Update a specific project.\n * TODO-correctness: Is it valid for PUT to accept application/json that's a subset of what the resource actually represents?  If not, is that a problem? (HTTP may require that this be idempotent.)  If so, can we get around that having this be a slightly different content-type (e.g., \"application/json-patch\")?  We should see what other APIs do.",
+        "operationId": "organization_projects_put_project",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Project"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete a specific project.",
+        "operationId": "organization_projects_delete_project",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful deletion"
+          }
+        }
+      }
+    },
+    "/organizations/{organization_name}/projects/{project_name}/disks": {
+      "get": {
+        "description": "List disks in a project.",
+        "operationId": "project_disks_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "nullable": true,
+              "description": "Maximum number of items returned by a single call",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "schema": {
+              "nullable": true,
+              "description": "Token returned by previous call to retreive the subsequent page",
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/NameSortMode"
+            },
+            "style": "form"
+          },
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiskResultsPage"
+                }
+              }
+            }
+          }
+        },
+        "x-dropshot-pagination": true
+      },
+      "post": {
+        "description": "Create a disk in a project.\n * TODO-correctness See note about instance create.  This should be async.",
+        "operationId": "project_disks_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DiskCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "successful creation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Disk"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{organization_name}/projects/{project_name}/disks/{disk_name}": {
+      "get": {
+        "description": "Fetch a single disk in a project.",
+        "operationId": "project_disks_get_disk",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "disk_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Disk"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete a disk from a project.",
+        "operationId": "project_disks_delete_disk",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "disk_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful deletion"
+          }
+        }
+      }
+    },
+    "/organizations/{organization_name}/projects/{project_name}/instances": {
+      "get": {
+        "description": "List instances in a project.",
+        "operationId": "project_instances_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "nullable": true,
+              "description": "Maximum number of items returned by a single call",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "schema": {
+              "nullable": true,
+              "description": "Token returned by previous call to retreive the subsequent page",
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/NameSortMode"
+            },
+            "style": "form"
+          },
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstanceResultsPage"
+                }
+              }
+            }
+          }
+        },
+        "x-dropshot-pagination": true
+      },
+      "post": {
+        "description": "Create an instance in a project.\n * TODO-correctness This is supposed to be async.  Is that right?  We can create the instance immediately -- it's just not booted yet.  Maybe the boot operation is what's a separate operation_id.  What about the response code (201 Created vs 202 Accepted)?  Is that orthogonal?  Things can return a useful response, including an operation id, with either response code.  Maybe a \"reboot\" operation would return a 202 Accepted because there's no actual resource created?",
+        "operationId": "project_instances_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstanceCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "successful creation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Instance"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}": {
+      "get": {
+        "description": "Get an instance in a project.",
+        "operationId": "project_instances_get_instance",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "instance_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Instance"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete an instance from a project.",
+        "operationId": "project_instances_delete_instance",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "instance_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful deletion"
+          }
+        }
+      }
+    },
+    "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks": {
+      "get": {
+        "description": "List disks attached to this instance.",
+        "operationId": "instance_disks_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "instance_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_DiskAttachment",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DiskAttachment"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks/{disk_name}": {
+      "get": {
+        "description": "Fetch a description of the attachment of this disk to this instance.",
+        "operationId": "instance_disks_get_disk",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "disk_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "instance_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiskAttachment"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Attach a disk to this instance.",
+        "operationId": "instance_disks_put_disk",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "disk_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "instance_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "successful creation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiskAttachment"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Detach a disk from this instance.",
+        "operationId": "instance_disks_delete_disk",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "disk_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "instance_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful deletion"
+          }
+        }
+      }
+    },
+    "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/reboot": {
+      "post": {
+        "description": "Reboot an instance.",
+        "operationId": "project_instances_instance_reboot",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "instance_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "successfully enqueued operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Instance"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/start": {
+      "post": {
+        "description": "Boot an instance.",
+        "operationId": "project_instances_instance_start",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "instance_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "successfully enqueued operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Instance"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/stop": {
+      "post": {
+        "description": "Halt an instance.",
+        "operationId": "project_instances_instance_stop",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "instance_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "successfully enqueued operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Instance"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{organization_name}/projects/{project_name}/vpcs": {
+      "get": {
+        "description": "List VPCs in a project.",
+        "operationId": "project_vpcs_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "nullable": true,
+              "description": "Maximum number of items returned by a single call",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "schema": {
+              "nullable": true,
+              "description": "Token returned by previous call to retreive the subsequent page",
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/NameSortMode"
+            },
+            "style": "form"
+          },
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VpcResultsPage"
+                }
+              }
+            }
+          }
+        },
+        "x-dropshot-pagination": true
+      },
+      "post": {
+        "description": "Create a VPC in a project.",
+        "operationId": "project_vpcs_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VpcCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "successful creation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Vpc"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}": {
+      "get": {
+        "description": "Get a VPC in a project.",
+        "operationId": "project_vpcs_get_vpc",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "vpc_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Vpc"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Update a VPC.",
+        "operationId": "project_vpcs_put_vpc",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "vpc_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VpcUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete a vpc from a project.",
+        "operationId": "project_vpcs_delete_vpc",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "vpc_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful deletion"
+          }
+        }
+      }
+    },
+    "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/firewall/rules": {
+      "get": {
+        "description": "List firewall rules for a VPC.",
+        "operationId": "vpc_firewall_rules_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "nullable": true,
+              "description": "Maximum number of items returned by a single call",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "schema": {
+              "nullable": true,
+              "description": "Token returned by previous call to retreive the subsequent page",
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/NameSortMode"
+            },
+            "style": "form"
+          },
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "vpc_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VpcFirewallRuleResultsPage"
+                }
+              }
+            }
+          }
+        },
+        "x-dropshot-pagination": true
+      },
+      "put": {
+        "description": "Replace the firewall rules for a VPC",
+        "operationId": "vpc_firewall_rules_put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "vpc_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VpcFirewallRuleUpdateParams"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VpcFirewallRuleUpdateResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers": {
+      "get": {
+        "description": "List VPC Custom and System Routers",
+        "operationId": "vpc_routers_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "nullable": true,
+              "description": "Maximum number of items returned by a single call",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "schema": {
+              "nullable": true,
+              "description": "Token returned by previous call to retreive the subsequent page",
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/NameSortMode"
+            },
+            "style": "form"
+          },
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "vpc_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VpcRouterResultsPage"
+                }
+              }
+            }
+          }
+        },
+        "x-dropshot-pagination": true
+      },
+      "post": {
+        "description": "Create a VPC Router",
+        "operationId": "vpc_routers_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "vpc_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VpcRouterCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "successful creation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VpcRouter"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}": {
+      "get": {
+        "description": "Get a VPC Router",
+        "operationId": "vpc_routers_get_router",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "router_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "vpc_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VpcRouter"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Update a VPC Router",
+        "operationId": "vpc_routers_put_router",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "router_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "vpc_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VpcRouterUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete a router from its VPC",
+        "operationId": "vpc_routers_delete_router",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "router_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "vpc_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful deletion"
+          }
+        }
+      }
+    },
+    "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes": {
+      "get": {
+        "description": "List a Router's routes",
+        "operationId": "routers_routes_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "nullable": true,
+              "description": "Maximum number of items returned by a single call",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "schema": {
+              "nullable": true,
+              "description": "Token returned by previous call to retreive the subsequent page",
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/NameSortMode"
+            },
+            "style": "form"
+          },
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "router_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "vpc_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouterRouteResultsPage"
+                }
+              }
+            }
+          }
+        },
+        "x-dropshot-pagination": true
+      },
+      "post": {
+        "description": "Create a VPC Router",
+        "operationId": "routers_routes_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "router_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "vpc_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RouterRouteCreateParams"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "successful creation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouterRoute"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes/{route_name}": {
+      "get": {
+        "description": "Get a VPC Router route",
+        "operationId": "routers_routes_get_route",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "route_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "router_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "vpc_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouterRoute"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Update a Router route",
+        "operationId": "routers_routes_put_route",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "route_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "router_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "vpc_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RouterRouteUpdateParams"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete a route from its router",
+        "operationId": "routers_routes_delete_route",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "route_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "router_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "vpc_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful deletion"
+          }
+        }
+      }
+    },
+    "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets": {
+      "get": {
+        "description": "List subnets in a VPC.",
+        "operationId": "vpc_subnets_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "nullable": true,
+              "description": "Maximum number of items returned by a single call",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "schema": {
+              "nullable": true,
+              "description": "Token returned by previous call to retreive the subsequent page",
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/NameSortMode"
+            },
+            "style": "form"
+          },
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "vpc_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VpcSubnetResultsPage"
+                }
+              }
+            }
+          }
+        },
+        "x-dropshot-pagination": true
+      },
+      "post": {
+        "description": "Create a subnet in a VPC.",
+        "operationId": "vpc_subnets_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "vpc_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VpcSubnetCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "successful creation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VpcSubnet"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}": {
+      "get": {
+        "description": "Get subnet in a VPC.",
+        "operationId": "vpc_subnets_get_subnet",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "subnet_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "vpc_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VpcSubnet"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Update a VPC Subnet.",
+        "operationId": "vpc_subnets_put_subnet",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "subnet_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "vpc_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VpcSubnetUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete a subnet from a VPC.",
+        "operationId": "vpc_subnets_delete_subnet",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "subnet_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "vpc_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful deletion"
+          }
+        }
+      }
+    },
+    "/sagas": {
+      "get": {
+        "description": "List all sagas (for debugging)",
+        "operationId": "sagas_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "nullable": true,
+              "description": "Maximum number of items returned by a single call",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "schema": {
+              "nullable": true,
+              "description": "Token returned by previous call to retreive the subsequent page",
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/IdSortMode"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SagaResultsPage"
+                }
+              }
+            }
+          }
+        },
+        "x-dropshot-pagination": true
+      }
+    },
+    "/sagas/{saga_id}": {
+      "get": {
+        "description": "Fetch information about a single saga (for debugging)",
+        "operationId": "sagas_get_saga",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "saga_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Saga"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users": {
+      "get": {
+        "description": "List the built-in system users",
+        "operationId": "users_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "nullable": true,
+              "description": "Maximum number of items returned by a single call",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "schema": {
+              "nullable": true,
+              "description": "Token returned by previous call to retreive the subsequent page",
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/NameSortMode"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserResultsPage"
+                }
+              }
+            }
+          }
+        },
+        "x-dropshot-pagination": true
+      }
+    },
+    "/users/{user_name}": {
+      "get": {
+        "description": "Fetch a specific built-in system user",
+        "operationId": "users_get_user",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "user_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ByteCount": {
+        "description": "A count of bytes, typically used either for memory or storage capacity\n\nThe maximum supported byte count is [`i64::MAX`].  This makes it somewhat inconvenient to define constructors: a u32 constructor can be infallible, but an i64 constructor can fail (if the value is negative) and a u64 constructor can fail (if the value is larger than i64::MAX).  We provide all of these for consumers' convenience.",
+        "type": "integer",
+        "format": "uint64",
+        "minimum": 0
+      },
+      "Disk": {
+        "description": "Client view of an [`Disk`]",
+        "type": "object",
+        "properties": {
+          "description": {
+            "description": "human-readable free-form text about a resource",
+            "type": "string"
+          },
+          "devicePath": {
+            "type": "string"
+          },
+          "id": {
+            "description": "unique, immutable, system-controlled identifier for each resource",
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "description": "unique, mutable, user-controlled identifier for each resource",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          },
+          "projectId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "size": {
+            "$ref": "#/components/schemas/ByteCount"
+          },
+          "snapshotId": {
+            "nullable": true,
+            "type": "string",
+            "format": "uuid"
+          },
+          "state": {
+            "$ref": "#/components/schemas/DiskState"
+          },
+          "timeCreated": {
+            "description": "timestamp when this resource was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "timeModified": {
+            "description": "timestamp when this resource was last modified",
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "description",
+          "devicePath",
+          "id",
+          "name",
+          "projectId",
+          "size",
+          "state",
+          "timeCreated",
+          "timeModified"
+        ]
+      },
+      "DiskAttachment": {
+        "description": "Describes a Disk's attachment to an Instance",
+        "type": "object",
+        "properties": {
+          "diskId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "diskName": {
+            "$ref": "#/components/schemas/Name"
+          },
+          "diskState": {
+            "$ref": "#/components/schemas/DiskState"
+          },
+          "instanceId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "diskId",
+          "diskName",
+          "diskState",
+          "instanceId"
+        ]
+      },
+      "DiskCreate": {
+        "description": "Create-time parameters for a [`Disk`]",
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "$ref": "#/components/schemas/Name"
+          },
+          "size": {
+            "description": "size of the Disk",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ByteCount"
+              }
+            ]
+          },
+          "snapshotId": {
+            "nullable": true,
+            "description": "id for snapshot from which the Disk should be created, if any",
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "description",
+          "name",
+          "size"
+        ]
+      },
+      "DiskResultsPage": {
+        "description": "A single page of results",
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "list of items on this page of results",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Disk"
+            }
+          },
+          "next_page": {
+            "nullable": true,
+            "description": "token used to fetch the next page of results (if any)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "DiskState": {
+        "description": "State of a Disk (primarily: attached or not)",
+        "oneOf": [
+          {
+            "description": "Disk is being initialized",
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "creating"
+                ]
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          {
+            "description": "Disk is ready but detached from any Instance",
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "detached"
+                ]
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          {
+            "description": "Disk is being attached to the given Instance",
+            "type": "object",
+            "properties": {
+              "instance": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "attaching"
+                ]
+              }
+            },
+            "required": [
+              "instance",
+              "state"
+            ]
+          },
+          {
+            "description": "Disk is attached to the given Instance",
+            "type": "object",
+            "properties": {
+              "instance": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "attached"
+                ]
+              }
+            },
+            "required": [
+              "instance",
+              "state"
+            ]
+          },
+          {
+            "description": "Disk is being detached from the given Instance",
+            "type": "object",
+            "properties": {
+              "instance": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "detaching"
+                ]
+              }
+            },
+            "required": [
+              "instance",
+              "state"
+            ]
+          },
+          {
+            "description": "Disk has been destroyed",
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "destroyed"
+                ]
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          {
+            "description": "Disk is unavailable",
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "faulted"
+                ]
+              }
+            },
+            "required": [
+              "state"
+            ]
+          }
+        ]
+      },
+      "IdentityMetadata": {
+        "description": "Identity-related metadata that's included in nearly all public API objects",
+        "type": "object",
+        "properties": {
+          "description": {
+            "description": "human-readable free-form text about a resource",
+            "type": "string"
+          },
+          "id": {
+            "description": "unique, immutable, system-controlled identifier for each resource",
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "description": "unique, mutable, user-controlled identifier for each resource",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          },
+          "timeCreated": {
+            "description": "timestamp when this resource was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "timeModified": {
+            "description": "timestamp when this resource was last modified",
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "description",
+          "id",
+          "name",
+          "timeCreated",
+          "timeModified"
+        ]
+      },
+      "Instance": {
+        "description": "Client view of an [`Instance`]",
+        "type": "object",
+        "properties": {
+          "description": {
+            "description": "human-readable free-form text about a resource",
+            "type": "string"
+          },
+          "hostname": {
+            "description": "RFC1035-compliant hostname for the Instance.",
+            "type": "string"
+          },
+          "id": {
+            "description": "unique, immutable, system-controlled identifier for each resource",
+            "type": "string",
+            "format": "uuid"
+          },
+          "memory": {
+            "description": "memory allocated for this Instance",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ByteCount"
+              }
+            ]
+          },
+          "name": {
+            "description": "unique, mutable, user-controlled identifier for each resource",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          },
+          "ncpus": {
+            "description": "number of CPUs allocated for this Instance",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InstanceCpuCount"
+              }
+            ]
+          },
+          "projectId": {
+            "description": "id for the project containing this Instance",
+            "type": "string",
+            "format": "uuid"
+          },
+          "runState": {
+            "$ref": "#/components/schemas/InstanceState"
+          },
+          "timeCreated": {
+            "description": "timestamp when this resource was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "timeModified": {
+            "description": "timestamp when this resource was last modified",
+            "type": "string",
+            "format": "date-time"
+          },
+          "timeRunStateUpdated": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "description",
+          "hostname",
+          "id",
+          "memory",
+          "name",
+          "ncpus",
+          "projectId",
+          "runState",
+          "timeCreated",
+          "timeModified",
+          "timeRunStateUpdated"
+        ]
+      },
+      "InstanceCpuCount": {
+        "description": "The number of CPUs in an Instance",
+        "type": "integer",
+        "format": "uint16",
+        "minimum": 0
+      },
+      "InstanceCreate": {
+        "description": "Create-time parameters for an [`Instance`]",
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "hostname": {
+            "type": "string"
+          },
+          "memory": {
+            "$ref": "#/components/schemas/ByteCount"
+          },
+          "name": {
+            "$ref": "#/components/schemas/Name"
+          },
+          "ncpus": {
+            "$ref": "#/components/schemas/InstanceCpuCount"
+          }
+        },
+        "required": [
+          "description",
+          "hostname",
+          "memory",
+          "name",
+          "ncpus"
+        ]
+      },
+      "InstanceResultsPage": {
+        "description": "A single page of results",
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "list of items on this page of results",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Instance"
+            }
+          },
+          "next_page": {
+            "nullable": true,
+            "description": "token used to fetch the next page of results (if any)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "InstanceState": {
+        "description": "Running state of an Instance (primarily: booted or stopped)\n\nThis typically reflects whether it's starting, running, stopping, or stopped, but also includes states related to the Instance's lifecycle",
+        "type": "string",
+        "enum": [
+          "creating",
+          "starting",
+          "running",
+          "stopping",
+          "stopped",
+          "rebooting",
+          "repairing",
+          "failed",
+          "destroyed"
+        ]
+      },
+      "Ipv4Net": {
+        "title": "An IPv4 subnet",
+        "description": "An IPv4 subnet, including prefix and subnet mask",
+        "type": "string",
+        "pattern": "^(10\\.(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9]\\.){2}(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9])/(1[0-9]|2[0-8]|[8-9]))$^(172\\.16\\.(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9])\\.(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9])/(1[2-9]|2[0-8]))$^(192\\.168\\.(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9])\\.(25[0-5]|[1-2][0-4][0-9]|[1-9][0-9]|[0-9])/(1[6-9]|2[0-8]))$",
+        "maxLength": 18
+      },
+      "Ipv6Net": {
+        "title": "An IPv6 subnet",
+        "description": "An IPv6 subnet, including prefix and subnet mask",
+        "type": "string",
+        "pattern": "^(fd|FD)00:((([0-9a-fA-F]{1,4}\\:){6}[0-9a-fA-F]{1,4})|(([0-9a-fA-F]{1,4}:){1,6}:))/(6[4-9]|[7-9][0-9]|1[0-1][0-9]|12[0-6])$",
+        "maxLength": 43
+      },
+      "L4PortRange": {
+        "title": "A range of IP ports",
+        "description": "An inclusive-inclusive range of IP ports. The second port may be omitted to represent a single port",
+        "type": "string",
+        "pattern": "^[0-9]{1,5}(-[0-9]{1,5})?$",
+        "minLength": 1,
+        "maxLength": 11
+      },
+      "LoginParams": {
+        "type": "object",
+        "properties": {
+          "username": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "username"
+        ]
+      },
+      "Name": {
+        "title": "A name used in the API",
+        "description": "Names must begin with a lower case ASCII letter, be composed exclusively of lowercase ASCII, uppercase ASCII, numbers, and '-', and may not end with a '-'.",
+        "type": "string",
+        "pattern": "[a-z](|[a-zA-Z0-9-]*[a-zA-Z0-9])",
+        "maxLength": 63
+      },
+      "Organization": {
+        "description": "Client view of an [`Organization`]",
+        "type": "object",
+        "properties": {
+          "description": {
+            "description": "human-readable free-form text about a resource",
+            "type": "string"
+          },
+          "id": {
+            "description": "unique, immutable, system-controlled identifier for each resource",
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "description": "unique, mutable, user-controlled identifier for each resource",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          },
+          "timeCreated": {
+            "description": "timestamp when this resource was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "timeModified": {
+            "description": "timestamp when this resource was last modified",
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "description",
+          "id",
+          "name",
+          "timeCreated",
+          "timeModified"
+        ]
+      },
+      "OrganizationCreate": {
+        "description": "Create-time parameters for an [`Organization`]",
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "$ref": "#/components/schemas/Name"
+          }
+        },
+        "required": [
+          "description",
+          "name"
+        ]
+      },
+      "OrganizationResultsPage": {
+        "description": "A single page of results",
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "list of items on this page of results",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Organization"
+            }
+          },
+          "next_page": {
+            "nullable": true,
+            "description": "token used to fetch the next page of results (if any)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "OrganizationUpdate": {
+        "description": "Updateable properties of an [`Organization`]",
+        "type": "object",
+        "properties": {
+          "description": {
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          }
+        }
+      },
+      "Project": {
+        "description": "Client view of a [`Project`]",
+        "type": "object",
+        "properties": {
+          "description": {
+            "description": "human-readable free-form text about a resource",
+            "type": "string"
+          },
+          "id": {
+            "description": "unique, immutable, system-controlled identifier for each resource",
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "description": "unique, mutable, user-controlled identifier for each resource",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          },
+          "organizationId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "timeCreated": {
+            "description": "timestamp when this resource was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "timeModified": {
+            "description": "timestamp when this resource was last modified",
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "description",
+          "id",
+          "name",
+          "organizationId",
+          "timeCreated",
+          "timeModified"
+        ]
+      },
+      "ProjectCreate": {
+        "description": "Create-time parameters for a [`Project`]",
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "$ref": "#/components/schemas/Name"
+          }
+        },
+        "required": [
+          "description",
+          "name"
+        ]
+      },
+      "ProjectResultsPage": {
+        "description": "A single page of results",
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "list of items on this page of results",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Project"
+            }
+          },
+          "next_page": {
+            "nullable": true,
+            "description": "token used to fetch the next page of results (if any)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "ProjectUpdate": {
+        "description": "Updateable properties of a [`Project`]",
+        "type": "object",
+        "properties": {
+          "description": {
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          }
+        }
+      },
+      "Rack": {
+        "description": "Client view of an [`Rack`]",
+        "type": "object",
+        "properties": {
+          "identity": {
+            "$ref": "#/components/schemas/IdentityMetadata"
+          }
+        },
+        "required": [
+          "identity"
+        ]
+      },
+      "RackResultsPage": {
+        "description": "A single page of results",
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "list of items on this page of results",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Rack"
+            }
+          },
+          "next_page": {
+            "nullable": true,
+            "description": "token used to fetch the next page of results (if any)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "RouteDestination": {
+        "description": "A subset of [`NetworkTarget`], `RouteDestination` specifies the kind of network traffic that will be matched to be forwarded to the [`RouteTarget`].",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ip"
+                ]
+              },
+              "value": {
+                "type": "string",
+                "format": "ip"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "vpc"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/Name"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "subnet"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/Name"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          }
+        ]
+      },
+      "RouteTarget": {
+        "description": "A subset of [`NetworkTarget`], `RouteTarget` specifies all possible targets that a route can forward to.",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ip"
+                ]
+              },
+              "value": {
+                "type": "string",
+                "format": "ip"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "vpc"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/Name"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "subnet"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/Name"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "instance"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/Name"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "internetGateway"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/Name"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          }
+        ]
+      },
+      "RouterRoute": {
+        "description": "A route defines a rule that governs where traffic should be sent based on its destination.",
+        "type": "object",
+        "properties": {
+          "destination": {
+            "$ref": "#/components/schemas/RouteDestination"
+          },
+          "identity": {
+            "description": "common identifying metadata",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IdentityMetadata"
+              }
+            ]
+          },
+          "kind": {
+            "description": "Describes the kind of router. Set at creation. `read-only`",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RouterRouteKind"
+              }
+            ]
+          },
+          "router_id": {
+            "description": "The VPC Router to which the route belongs.",
+            "type": "string",
+            "format": "uuid"
+          },
+          "target": {
+            "$ref": "#/components/schemas/RouteTarget"
+          }
+        },
+        "required": [
+          "destination",
+          "identity",
+          "kind",
+          "router_id",
+          "target"
+        ]
+      },
+      "RouterRouteCreateParams": {
+        "description": "Create-time parameters for a [`RouterRoute`]",
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "destination": {
+            "$ref": "#/components/schemas/RouteDestination"
+          },
+          "name": {
+            "$ref": "#/components/schemas/Name"
+          },
+          "target": {
+            "$ref": "#/components/schemas/RouteTarget"
+          }
+        },
+        "required": [
+          "description",
+          "destination",
+          "name",
+          "target"
+        ]
+      },
+      "RouterRouteKind": {
+        "description": "The classification of a [`RouterRoute`] as defined by the system. The kind determines certain attributes such as if the route is modifiable and describes how or where the route was created.\n\nSee [RFD-21](https://rfd.shared.oxide.computer/rfd/0021#concept-router) for more context",
+        "type": "string",
+        "enum": [
+          "Default",
+          "VpcSubnet",
+          "VpcPeering",
+          "Custom"
+        ]
+      },
+      "RouterRouteResultsPage": {
+        "description": "A single page of results",
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "list of items on this page of results",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RouterRoute"
+            }
+          },
+          "next_page": {
+            "nullable": true,
+            "description": "token used to fetch the next page of results (if any)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "RouterRouteUpdateParams": {
+        "description": "Updateable properties of a [`RouterRoute`]",
+        "type": "object",
+        "properties": {
+          "description": {
+            "nullable": true,
+            "type": "string"
+          },
+          "destination": {
+            "$ref": "#/components/schemas/RouteDestination"
+          },
+          "name": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          },
+          "target": {
+            "$ref": "#/components/schemas/RouteTarget"
+          }
+        },
+        "required": [
+          "destination",
+          "target"
+        ]
+      },
+      "Saga": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "state": {
+            "$ref": "#/components/schemas/SagaState"
+          }
+        },
+        "required": [
+          "id",
+          "state"
+        ]
+      },
+      "SagaErrorInfo": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "actionFailed"
+                ]
+              },
+              "source_error": {}
+            },
+            "required": [
+              "error",
+              "source_error"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "deserializeFailed"
+                ]
+              },
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "error",
+              "message"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "injectedError"
+                ]
+              }
+            },
+            "required": [
+              "error"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "serializeFailed"
+                ]
+              },
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "error",
+              "message"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "error": {
+                "type": "string",
+                "enum": [
+                  "subsagaCreateFailed"
+                ]
+              },
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "error",
+              "message"
+            ]
+          }
+        ]
+      },
+      "SagaResultsPage": {
+        "description": "A single page of results",
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "list of items on this page of results",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Saga"
+            }
+          },
+          "next_page": {
+            "nullable": true,
+            "description": "token used to fetch the next page of results (if any)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "SagaState": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "running"
+                ]
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "succeeded"
+                ]
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "error_info": {
+                "$ref": "#/components/schemas/SagaErrorInfo"
+              },
+              "error_node_name": {
+                "type": "string"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "failed"
+                ]
+              }
+            },
+            "required": [
+              "error_info",
+              "error_node_name",
+              "state"
+            ]
+          }
+        ]
+      },
+      "Sled": {
+        "description": "Client view of an [`Sled`]",
+        "type": "object",
+        "properties": {
+          "description": {
+            "description": "human-readable free-form text about a resource",
+            "type": "string"
+          },
+          "id": {
+            "description": "unique, immutable, system-controlled identifier for each resource",
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "description": "unique, mutable, user-controlled identifier for each resource",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          },
+          "serviceAddress": {
+            "type": "string"
+          },
+          "timeCreated": {
+            "description": "timestamp when this resource was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "timeModified": {
+            "description": "timestamp when this resource was last modified",
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "description",
+          "id",
+          "name",
+          "serviceAddress",
+          "timeCreated",
+          "timeModified"
+        ]
+      },
+      "SledResultsPage": {
+        "description": "A single page of results",
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "list of items on this page of results",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Sled"
+            }
+          },
+          "next_page": {
+            "nullable": true,
+            "description": "token used to fetch the next page of results (if any)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "User": {
+        "description": "Client view of a [`User`]",
+        "type": "object",
+        "properties": {
+          "description": {
+            "description": "human-readable free-form text about a resource",
+            "type": "string"
+          },
+          "id": {
+            "description": "unique, immutable, system-controlled identifier for each resource",
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "description": "unique, mutable, user-controlled identifier for each resource",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          },
+          "timeCreated": {
+            "description": "timestamp when this resource was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "timeModified": {
+            "description": "timestamp when this resource was last modified",
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "description",
+          "id",
+          "name",
+          "timeCreated",
+          "timeModified"
+        ]
+      },
+      "UserResultsPage": {
+        "description": "A single page of results",
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "list of items on this page of results",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/User"
+            }
+          },
+          "next_page": {
+            "nullable": true,
+            "description": "token used to fetch the next page of results (if any)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "Vpc": {
+        "description": "Client view of a [`Vpc`]",
+        "type": "object",
+        "properties": {
+          "description": {
+            "description": "human-readable free-form text about a resource",
+            "type": "string"
+          },
+          "dnsName": {
+            "description": "The name used for the VPC in DNS.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          },
+          "id": {
+            "description": "unique, immutable, system-controlled identifier for each resource",
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "description": "unique, mutable, user-controlled identifier for each resource",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          },
+          "projectId": {
+            "description": "id for the project containing this VPC",
+            "type": "string",
+            "format": "uuid"
+          },
+          "systemRouterId": {
+            "description": "id for the system router where subnet default routes are registered",
+            "type": "string",
+            "format": "uuid"
+          },
+          "timeCreated": {
+            "description": "timestamp when this resource was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "timeModified": {
+            "description": "timestamp when this resource was last modified",
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "description",
+          "dnsName",
+          "id",
+          "name",
+          "projectId",
+          "systemRouterId",
+          "timeCreated",
+          "timeModified"
+        ]
+      },
+      "VpcCreate": {
+        "description": "Create-time parameters for a [`Vpc`]",
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "dnsName": {
+            "$ref": "#/components/schemas/Name"
+          },
+          "name": {
+            "$ref": "#/components/schemas/Name"
+          }
+        },
+        "required": [
+          "description",
+          "dnsName",
+          "name"
+        ]
+      },
+      "VpcFirewallRule": {
+        "description": "A single rule in a VPC firewall",
+        "type": "object",
+        "properties": {
+          "action": {
+            "description": "whether traffic matching the rule should be allowed or dropped",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VpcFirewallRuleAction"
+              }
+            ]
+          },
+          "direction": {
+            "description": "whether this rule is for incoming or outgoing traffic",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VpcFirewallRuleDirection"
+              }
+            ]
+          },
+          "filters": {
+            "description": "reductions on the scope of the rule",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VpcFirewallRuleFilter"
+              }
+            ]
+          },
+          "identity": {
+            "description": "common identifying metadata",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IdentityMetadata"
+              }
+            ]
+          },
+          "priority": {
+            "description": "the relative priority of this rule",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          },
+          "status": {
+            "description": "whether this rule is in effect",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VpcFirewallRuleStatus"
+              }
+            ]
+          },
+          "targets": {
+            "description": "list of sets of instances that the rule applies to",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VpcFirewallRuleTarget"
+            }
+          }
+        },
+        "required": [
+          "action",
+          "direction",
+          "filters",
+          "identity",
+          "priority",
+          "status",
+          "targets"
+        ]
+      },
+      "VpcFirewallRuleAction": {
+        "type": "string",
+        "enum": [
+          "allow",
+          "deny"
+        ]
+      },
+      "VpcFirewallRuleDirection": {
+        "type": "string",
+        "enum": [
+          "inbound",
+          "outbound"
+        ]
+      },
+      "VpcFirewallRuleFilter": {
+        "description": "Filter for a firewall rule. A given packet must match every field that is present for the rule to apply to it. A packet matches a field if any entry in that field matches the packet.",
+        "type": "object",
+        "properties": {
+          "hosts": {
+            "nullable": true,
+            "description": "If present, the sources (if incoming) or destinations (if outgoing) this rule applies to.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VpcFirewallRuleHostFilter"
+            }
+          },
+          "ports": {
+            "nullable": true,
+            "description": "If present, the destination ports this rule applies to.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/L4PortRange"
+            }
+          },
+          "protocols": {
+            "nullable": true,
+            "description": "If present, the networking protocols this rule applies to.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VpcFirewallRuleProtocol"
+            }
+          }
+        }
+      },
+      "VpcFirewallRuleHostFilter": {
+        "description": "A subset of [`NetworkTarget`], `VpcFirewallRuleHostFilter` specifies all possible targets that a route can forward to.",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "vpc"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/Name"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "subnet"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/Name"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "instance"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/Name"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ip"
+                ]
+              },
+              "value": {
+                "type": "string",
+                "format": "ip"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "internetGateway"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/Name"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          }
+        ]
+      },
+      "VpcFirewallRuleProtocol": {
+        "description": "The protocols that may be specified in a firewall rule's filter",
+        "type": "string",
+        "enum": [
+          "TCP",
+          "UDP",
+          "ICMP"
+        ]
+      },
+      "VpcFirewallRuleResultsPage": {
+        "description": "A single page of results",
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "list of items on this page of results",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VpcFirewallRule"
+            }
+          },
+          "next_page": {
+            "nullable": true,
+            "description": "token used to fetch the next page of results (if any)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "VpcFirewallRuleStatus": {
+        "type": "string",
+        "enum": [
+          "disabled",
+          "enabled"
+        ]
+      },
+      "VpcFirewallRuleTarget": {
+        "description": "A subset of [`NetworkTarget`], `VpcFirewallRuleTarget` specifies all possible targets that a firewall rule can be attached to.",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "vpc"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/Name"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "subnet"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/Name"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "instance"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/Name"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          }
+        ]
+      },
+      "VpcFirewallRuleUpdate": {
+        "description": "A single rule in a VPC firewall",
+        "type": "object",
+        "properties": {
+          "action": {
+            "description": "whether traffic matching the rule should be allowed or dropped",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VpcFirewallRuleAction"
+              }
+            ]
+          },
+          "description": {
+            "description": "human-readable free-form text about a resource",
+            "type": "string"
+          },
+          "direction": {
+            "description": "whether this rule is for incoming or outgoing traffic",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VpcFirewallRuleDirection"
+              }
+            ]
+          },
+          "filters": {
+            "description": "reductions on the scope of the rule",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VpcFirewallRuleFilter"
+              }
+            ]
+          },
+          "priority": {
+            "description": "the relative priority of this rule",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          },
+          "status": {
+            "description": "whether this rule is in effect",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VpcFirewallRuleStatus"
+              }
+            ]
+          },
+          "targets": {
+            "description": "list of sets of instances that the rule applies to",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VpcFirewallRuleTarget"
+            }
+          }
+        },
+        "required": [
+          "action",
+          "description",
+          "direction",
+          "filters",
+          "priority",
+          "status",
+          "targets"
+        ]
+      },
+      "VpcFirewallRuleUpdateParams": {
+        "description": "Updateable properties of a [`Vpc`]'s firewall Note that VpcFirewallRules are implicitly created along with a Vpc, so there is no explicit creation.",
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/VpcFirewallRuleUpdate"
+        }
+      },
+      "VpcFirewallRuleUpdateResult": {
+        "description": "Response to an update replacing [`Vpc`]'s firewall",
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/VpcFirewallRule"
+        }
+      },
+      "VpcResultsPage": {
+        "description": "A single page of results",
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "list of items on this page of results",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Vpc"
+            }
+          },
+          "next_page": {
+            "nullable": true,
+            "description": "token used to fetch the next page of results (if any)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "VpcRouter": {
+        "description": "A VPC router defines a series of rules that indicate where traffic should be sent depending on its destination.",
+        "type": "object",
+        "properties": {
+          "identity": {
+            "description": "common identifying metadata",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IdentityMetadata"
+              }
+            ]
+          },
+          "kind": {
+            "$ref": "#/components/schemas/VpcRouterKind"
+          },
+          "vpc_id": {
+            "description": "The VPC to which the router belongs.",
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "identity",
+          "kind",
+          "vpc_id"
+        ]
+      },
+      "VpcRouterCreate": {
+        "description": "Create-time parameters for a [`VpcRouter`]",
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "$ref": "#/components/schemas/Name"
+          }
+        },
+        "required": [
+          "description",
+          "name"
+        ]
+      },
+      "VpcRouterKind": {
+        "type": "string",
+        "enum": [
+          "system",
+          "custom"
+        ]
+      },
+      "VpcRouterResultsPage": {
+        "description": "A single page of results",
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "list of items on this page of results",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VpcRouter"
+            }
+          },
+          "next_page": {
+            "nullable": true,
+            "description": "token used to fetch the next page of results (if any)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "VpcRouterUpdate": {
+        "description": "Updateable properties of a [`VpcRouter`]",
+        "type": "object",
+        "properties": {
+          "description": {
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          }
+        }
+      },
+      "VpcSubnet": {
+        "description": "A VPC subnet represents a logical grouping for instances that allows network traffic between them, within a IPv4 subnetwork or optionall an IPv6 subnetwork.",
+        "type": "object",
+        "properties": {
+          "identity": {
+            "description": "common identifying metadata",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IdentityMetadata"
+              }
+            ]
+          },
+          "ipv4_block": {
+            "nullable": true,
+            "description": "The IPv4 subnet CIDR block.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Ipv4Net"
+              }
+            ]
+          },
+          "ipv6_block": {
+            "nullable": true,
+            "description": "The IPv6 subnet CIDR block.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Ipv6Net"
+              }
+            ]
+          },
+          "vpc_id": {
+            "description": "The VPC to which the subnet belongs.",
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "identity",
+          "vpc_id"
+        ]
+      },
+      "VpcSubnetCreate": {
+        "description": "Create-time parameters for a [`VpcSubnet`]",
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "ipv4Block": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Ipv4Net"
+              }
+            ]
+          },
+          "ipv6Block": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Ipv6Net"
+              }
+            ]
+          },
+          "name": {
+            "$ref": "#/components/schemas/Name"
+          }
+        },
+        "required": [
+          "description",
+          "name"
+        ]
+      },
+      "VpcSubnetResultsPage": {
+        "description": "A single page of results",
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "list of items on this page of results",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VpcSubnet"
+            }
+          },
+          "next_page": {
+            "nullable": true,
+            "description": "token used to fetch the next page of results (if any)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "VpcSubnetUpdate": {
+        "description": "Updateable properties of a [`VpcSubnet`]",
+        "type": "object",
+        "properties": {
+          "description": {
+            "nullable": true,
+            "type": "string"
+          },
+          "ipv4Block": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Ipv4Net"
+              }
+            ]
+          },
+          "ipv6Block": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Ipv6Net"
+              }
+            ]
+          },
+          "name": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          }
+        }
+      },
+      "VpcUpdate": {
+        "description": "Updateable properties of a [`Vpc`]",
+        "type": "object",
+        "properties": {
+          "description": {
+            "nullable": true,
+            "type": "string"
+          },
+          "dnsName": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          },
+          "name": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          }
+        }
+      },
+      "IdSortMode": {
+        "description": "Supported set of sort modes for scanning by id only.\n\nCurrently, we only support scanning in ascending order.",
+        "type": "string",
+        "enum": [
+          "id-ascending"
+        ]
+      },
+      "NameOrIdSortMode": {
+        "description": "Supported set of sort modes for scanning by name or id",
+        "type": "string",
+        "enum": [
+          "name-ascending",
+          "name-descending",
+          "id-ascending"
+        ]
+      },
+      "NameSortMode": {
+        "description": "Supported set of sort modes for scanning by name only\n\nCurrently, we only support scanning in ascending order.",
+        "type": "string",
+        "enum": [
+          "name-ascending"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
introduce an intermediate form; this is going to be used to generate a few different things:
- an interator interface for paginated APIs; the IR will let us re-use
  the typify types
- a CLI generator that will generate calls into the generated client
- an automated test harness that will validate the generated client
  against a mock server

Note this PR also includes nexus.json as a target for client generation validation, and it includes an update to the generated method doc comments that uses doc comments from the OpenAPI spec document.