### PR TITLE
Add a wrapper types for success and error responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,10 +120,10 @@ dependencies = [
 name = "example-build"
 version = "0.0.1"
 dependencies = [
- "anyhow",
  "chrono",
  "percent-encoding",
  "progenitor",
+ "progenitor-client",
  "reqwest",
  "serde",
  "serde_json",
@@ -681,6 +681,7 @@ dependencies = [
  "getopts",
  "openapiv3",
  "percent-encoding",
+ "progenitor-client",
  "progenitor-impl",
  "progenitor-macro",
  "reqwest",
@@ -695,6 +696,7 @@ name = "progenitor-client"
 version = "0.0.0"
 dependencies = [
  "reqwest",
+ "serde",
  "serde_json",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,6 @@ name = "example-build"
 version = "0.0.1"
 dependencies = [
  "chrono",
- "percent-encoding",
  "progenitor",
  "progenitor-client",
  "reqwest",
@@ -695,6 +694,7 @@ dependencies = [
 name = "progenitor-client"
 version = "0.0.0"
 dependencies = [
+ "percent-encoding",
  "reqwest",
  "serde",
  "serde_json",

--- a/docs/generated_methods.md
+++ b/docs/generated_methods.md
@@ -1,0 +1,66 @@
+# Generated Methods
+
+Progenitor generates methods according to operations within an OpenAPI document. Each method takes the following general form:
+
+```rust
+impl Client {
+    pub async fn operation_name<'a>(
+        &'a self,
+	// Path parameters (if any) come first and are always mandatory
+	path_parameter_1: String,
+	path_parameter_2: u32,
+	// Query parameters (if any) come next and may be optional
+	query_parameter_1: String,
+	query_parameter_2: Option<u32>,
+	// A body parameter (if specified) comes last
+	body: &ThisOperationBody,
+    ) -> Result<
+        ResponseValue<types::SuccessResponseType>,
+        Error<types::ErrorResponseType>
+    > {
+        ..
+```
+
+For more info on the `ResponseValue<T>` and `Error<E>` types, see
+[progenitor_client](./progenitor_client).
+
+Note that methods are `async` so must be `await`ed to get the response.
+
+### Dropshot Paginated Operations
+
+The Dropshot crate defines a mechanism for pagination. If that mechanism is
+used for a particular operation, Progenitor will generate an additional method
+that produces a `Stream`. Consumers can iterate over all items in the paginated
+collection without manually fetching individual pages.
+
+Here's the signature for a typical generated method:
+
+```rust
+    pub fn operation_name_stream<'a>(
+        &'a self,
+        // Specific parameters...
+        limit: Option<std::num::NonZeroU32>,
+    ) -> impl futures::Stream<
+	    Item = Result<types::SuccessResponseType, Error<types::ErrorResponseType>>
+    > + Unpin + '_ {
+        ..
+```
+
+A typical consumer of this method might look like this:
+
+```rust
+    let mut stream = client.operation_name_stream(None);
+    loop {
+        match stream.try_next().await {
+            Ok(Some(item)) => println!("item {:?}", item),
+            Ok(None) => {
+                println!("done.");
+                break;
+            }
+            Err(_) => {
+                println!("error!");
+                break;
+            }
+        }
+    }
+```

--- a/docs/generated_methods.md
+++ b/docs/generated_methods.md
@@ -1,6 +1,7 @@
 # Generated Methods
 
-Progenitor generates methods according to operations within an OpenAPI document. Each method takes the following general form:
+Progenitor generates methods according to operations within an OpenAPI
+document. Each method takes the following general form:
 
 ```rust
 impl Client {

--- a/docs/progenitor-client.md
+++ b/docs/progenitor-client.md
@@ -1,0 +1,87 @@
+# Progenitor Client
+
+The `progenitor-client` crate contains types that are exported by generated
+clients as well as functions that are used internally by generated clients.
+Depending on how `progenitor` is being used, the crate will be included in
+different ways (see XXX).
+
+- For macro consumers, it comes from the `progenitor` dependency.
+
+- For builder consumers, it must be specified under `[dependencies]` (while `progenitor` is under `[build-dependencies]`).
+
+- For statically generated consumers, the code is emitted into
+`src/progenitor_client.rs`.
+
+The two types that `progenitor-client` exports are `Error<E>` and
+`ResponseValue<T>`. A typical generated method will use these types in its
+signature:
+
+```rust
+impl Client {
+    pub async fn operation_name<'a>(
+        &'a self,
+        // parameters ...
+    ) -> Result<
+        ResponseValue<types::SuccessResponseType>,
+        Error<types::ErrorResponseType>>
+    {
+        ..
+```
+
+## `ResponseValue<T>`
+
+OpenAPI documents defines the types that an operation returns. Generated
+methods wrap these types in `ResponseValue<T>` for two reasons: there is
+additional information that may be included in a response such as the specific
+status code and headers, and that information cannot simply be included in the
+response type because that type may be used in other context (e.g. as a body
+parameter).
+
+These are the relevant implementations for `ResponseValue<T>`:
+
+```rust
+/// Success value returned by generated client methods.
+pub struct ResponseValue<T> { .. }
+
+impl<T> ResponseValue<T> {
+    pub fn status(&self) -> &reqwest::StatusCode { .. }
+    pub fn headers(&self) -> &reqwest::header::HeaderMap { .. }
+    pub fn into_inner(self) -> T { .. }
+}
+impl<T> std::ops::Deref for ResponseValue<T> {
+    type Target = T;
+    ..
+}
+impl<T> std::ops::DerefMut for ResponseValue<T> { .. }
+
+impl<T: std::fmt::Debug> std::fmt::Debug for ResponseValue<T> { .. }
+```
+
+It can be used as the type `T` in most instances and extracted as a `T` using
+`into_inner()`.
+
+## `Error<E>`
+
+There are four sub-categories of error covered by the error type variants:
+- A communication error
+
+- An expected error response, defined by the OpenAPI document with a 4xx or 5xx
+status code
+
+- An expected status code (whose payload didn't deserialize as expected (this
+could be viewed as a sub-type of communication error), but it is separately
+identified as there's more information; note that this covers both success and
+error status codes
+
+- An unexpected status code in the response
+
+These errors are covered by the variants of the `Error<E>` type:
+
+```rust
+pub enum Error<E> {
+    CommunicationError(reqwest::Error),
+    ErrorResponse(ResponseValue<E>),
+    InvalidResponsePayload(reqwest::Error),
+    UnexpectedResponse(reqwest::Response),
+}
+```

--- a/example-build/Cargo.toml
+++ b/example-build/Cargo.toml
@@ -5,12 +5,13 @@ authors = ["Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 percent-encoding = "2.1"
 reqwest = { version = "0.11", features = ["json", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
+
+progenitor-client = { path = "../progenitor-client" }
 
 [build-dependencies]
 progenitor = { path = "../progenitor" }

--- a/example-build/Cargo.toml
+++ b/example-build/Cargo.toml
@@ -6,12 +6,10 @@ edition = "2018"
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
-percent-encoding = "2.1"
+progenitor-client = { path = "../progenitor-client" }
 reqwest = { version = "0.11", features = ["json", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
-
-progenitor-client = { path = "../progenitor-client" }
 
 [build-dependencies]
 progenitor = { path = "../progenitor" }

--- a/progenitor-client/Cargo.toml
+++ b/progenitor-client/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/oxidecomputer/progenitor.git"
 description = "An OpenAPI client generator - client support"
 
 [dependencies]
+percent-encoding = "2.1"
 reqwest = { version = "0.11", features = ["json"] }
 serde = "1.0"
 serde_json = "1.0"

--- a/progenitor-client/Cargo.toml
+++ b/progenitor-client/Cargo.toml
@@ -7,5 +7,6 @@ repository = "https://github.com/oxidecomputer/progenitor.git"
 description = "An OpenAPI client generator - client support"
 
 [dependencies]
-reqwest = "0.11"
+reqwest = { version = "0.11", features = ["json"] }
+serde = "1.0"
 serde_json = "1.0"

--- a/progenitor-client/src/lib.rs
+++ b/progenitor-client/src/lib.rs
@@ -4,33 +4,100 @@
 
 use std::ops::Deref;
 
-/// Error produced by generated client methods.
+use serde::de::DeserializeOwned;
+
+/// Error produced by generated client methods. The type parameter may be a
+/// struct if there's a single expected error type or an enum if there are
+/// multiple valid error types.
 pub enum Error<E> {
-    /// Indicates an error from the server, with the data, or with the
-    /// connection.
+    /// A server error either with the data, or with the connection.
     CommunicationError(reqwest::Error),
 
-    /// A documented error response.
+    /// A documented, expected error response.
     ErrorResponse(ResponseValue<E>),
 
+    /// An expected response code whose deserialization failed.
+    // TODO we have stuff from the response; should we include it?
+    InvalidResponsePayload(reqwest::Error),
+
     /// A response not listed in the API description. This may represent a
-    /// success or failure response; check `status()::is_success()`.
+    /// success or failure response; check `status().is_success()`.
     UnexpectedResponse(reqwest::Response),
+}
+
+impl<E> From<reqwest::Error> for Error<E> {
+    fn from(e: reqwest::Error) -> Self {
+        Self::CommunicationError(e)
+    }
 }
 
 pub struct ResponseValue<T> {
     inner: T,
-    response: reqwest::Response,
+    status: reqwest::StatusCode,
+    headers: reqwest::header::HeaderMap,
+    // TODO cookies?
+}
+
+impl<T: DeserializeOwned> ResponseValue<T> {
+    pub async fn from_response<E>(
+        response: reqwest::Response,
+    ) -> Result<Self, Error<E>> {
+        let status = response.status();
+        let headers = response.headers().clone();
+        let inner = response
+            .json()
+            .await
+            .map_err(Error::InvalidResponsePayload)?;
+
+        Ok(Self {
+            inner,
+            status,
+            headers,
+        })
+    }
+}
+
+impl ResponseValue<()> {
+    pub fn empty<E>(response: reqwest::Response) -> Result<Self, E> {
+        let status = response.status();
+        let headers = response.headers().clone();
+        // TODO is there anything we want to do to confirm that there is no
+        // content?
+        Ok(Self {
+            inner: (),
+            status,
+            headers,
+        })
+    }
 }
 
 impl<T> ResponseValue<T> {
-    #[doc(hidden)]
-    pub fn new(inner: T, response: reqwest::Response) -> Self {
-        Self { inner, response }
+    pub fn status(&self) -> &reqwest::StatusCode {
+        &self.status
+    }
+    pub fn headers(&self) -> &reqwest::header::HeaderMap {
+        &self.headers
     }
 
-    pub fn request(&self) -> &reqwest::Response {
-        &self.response
+    pub fn map<U, F, E>(self, f: F) -> Result<ResponseValue<U>, E>
+    where
+        F: FnOnce(T) -> U,
+    {
+        let Self {
+            inner,
+            status,
+            headers,
+        } = self;
+
+        Ok(ResponseValue {
+            inner: f(inner),
+            status,
+            headers,
+        })
+    }
+
+    pub fn to_error<U>(self) -> Result<U, Error<T>> {
+        Err(Error::ErrorResponse(self))
     }
 }
 

--- a/progenitor-client/src/lib.rs
+++ b/progenitor-client/src/lib.rs
@@ -34,16 +34,16 @@ impl<T: DeserializeOwned> ResponseValue<T> {
 }
 
 impl ResponseValue<()> {
-    pub fn empty<E>(response: reqwest::Response) -> Result<Self, E> {
+    pub fn empty(response: reqwest::Response) -> Self {
         let status = response.status();
         let headers = response.headers().clone();
         // TODO is there anything we want to do to confirm that there is no
         // content?
-        Ok(Self {
+        Self {
             inner: (),
             status,
             headers,
-        })
+        }
     }
 }
 

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -746,7 +746,7 @@ impl Generator {
                 }
                 OperationResponseType::None => {
                     quote!{
-                        progenitor_client::ResponseValue::empty(response)
+                        Ok(progenitor_client::ResponseValue::empty(response))
                     }
                 }
                 OperationResponseType::Raw => quote! { Ok(response) },
@@ -817,7 +817,7 @@ impl Generator {
                 OperationResponseType::None => {
                     quote!{
                         Err(progenitor_client::Error::ErrorResponse(
-                            progenitor_client::ResponseValue::empty(response)?
+                            progenitor_client::ResponseValue::empty(response)
                         ))
                     }
                 }
@@ -858,7 +858,7 @@ impl Generator {
                     OperationResponseType::None => {
                         quote!{
                             Err(progenitor_client::Error::ErrorResponse(
-                                progenitor_client::ResponseValue::empty(response)?
+                                progenitor_client::ResponseValue::empty(response)
                             ))
                         }
                     }

--- a/progenitor-impl/src/template.rs
+++ b/progenitor-impl/src/template.rs
@@ -32,7 +32,7 @@ impl PathTemplate {
             if let Component::Parameter(n) = &component {
                 let param = format_ident!("{}", n);
                 Some(quote! {
-                    progenitor_support::encode_path(&#param.to_string())
+                    progenitor_client::encode_path(&#param.to_string())
                 })
             } else {
                 None
@@ -226,7 +226,7 @@ mod test {
         let want = quote::quote! {
             let url = format!("{}/measure/{}",
                 self.baseurl,
-                progenitor_support::encode_path(&number.to_string()),
+                progenitor_client::encode_path(&number.to_string()),
             );
         };
         assert_eq!(want.to_string(), out.to_string());

--- a/progenitor-impl/tests/output/buildomat.out
+++ b/progenitor-impl/tests/output/buildomat.out
@@ -1,4 +1,5 @@
-use anyhow::Result;
+pub use progenitor_client::Error;
+pub use progenitor_client::ResponseValue;
 mod progenitor_support {
     use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
     #[allow(dead_code)]
@@ -182,25 +183,38 @@ impl Client {
     }
 
     #[doc = "control_hold: POST /v1/control/hold"]
-    pub async fn control_hold<'a>(&'a self) -> Result<()> {
+    pub async fn control_hold<'a>(
+        &'a self,
+    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<()>> {
         let url = format!("{}/v1/control/hold", self.baseurl,);
         let request = self.client.post(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
     #[doc = "control_resume: POST /v1/control/resume"]
-    pub async fn control_resume<'a>(&'a self) -> Result<reqwest::Response> {
+    pub async fn control_resume<'a>(
+        &'a self,
+    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<()>> {
         let url = format!("{}/v1/control/resume", self.baseurl,);
         let request = self.client.post(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => Ok(progenitor_client::ResponseValue::empty(response)),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
     #[doc = "task_get: GET /v1/task/{task}"]
-    pub async fn task_get<'a>(&'a self, task: &'a str) -> Result<types::Task> {
+    pub async fn task_get<'a>(
+        &'a self,
+        task: &'a str,
+    ) -> Result<progenitor_client::ResponseValue<types::Task>, progenitor_client::Error<()>> {
         let url = format!(
             "{}/v1/task/{}",
             self.baseurl,
@@ -208,29 +222,44 @@ impl Client {
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
     #[doc = "tasks_get: GET /v1/tasks"]
-    pub async fn tasks_get<'a>(&'a self) -> Result<Vec<types::Task>> {
+    pub async fn tasks_get<'a>(
+        &'a self,
+    ) -> Result<progenitor_client::ResponseValue<Vec<types::Task>>, progenitor_client::Error<()>>
+    {
         let url = format!("{}/v1/tasks", self.baseurl,);
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
     #[doc = "task_submit: POST /v1/tasks"]
     pub async fn task_submit<'a>(
         &'a self,
         body: &'a types::TaskSubmit,
-    ) -> Result<types::TaskSubmitResult> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::TaskSubmitResult>,
+        progenitor_client::Error<()>,
+    > {
         let url = format!("{}/v1/tasks", self.baseurl,);
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => progenitor_client::ResponseValue::from_response(response).await,
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
     #[doc = "task_events_get: GET /v1/tasks/{task}/events"]
@@ -238,7 +267,8 @@ impl Client {
         &'a self,
         task: &'a str,
         minseq: Option<u32>,
-    ) -> Result<Vec<types::TaskEvent>> {
+    ) -> Result<progenitor_client::ResponseValue<Vec<types::TaskEvent>>, progenitor_client::Error<()>>
+    {
         let url = format!(
             "{}/v1/tasks/{}/events",
             self.baseurl,
@@ -251,12 +281,21 @@ impl Client {
 
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
     #[doc = "task_outputs_get: GET /v1/tasks/{task}/outputs"]
-    pub async fn task_outputs_get<'a>(&'a self, task: &'a str) -> Result<Vec<types::TaskOutput>> {
+    pub async fn task_outputs_get<'a>(
+        &'a self,
+        task: &'a str,
+    ) -> Result<
+        progenitor_client::ResponseValue<Vec<types::TaskOutput>>,
+        progenitor_client::Error<()>,
+    > {
         let url = format!(
             "{}/v1/tasks/{}/outputs",
             self.baseurl,
@@ -264,8 +303,11 @@ impl Client {
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
     #[doc = "task_output_download: GET /v1/tasks/{task}/outputs/{output}"]
@@ -273,7 +315,7 @@ impl Client {
         &'a self,
         task: &'a str,
         output: &'a str,
-    ) -> Result<reqwest::Response> {
+    ) -> Result<reqwest::Response, progenitor_client::Error<()>> {
         let url = format!(
             "{}/v1/tasks/{}/outputs/{}",
             self.baseurl,
@@ -282,50 +324,79 @@ impl Client {
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res)
+        let response = result?;
+        match response.status().as_u16() {
+            200..=299 => Ok(response),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
     #[doc = "user_create: POST /v1/users"]
     pub async fn user_create<'a>(
         &'a self,
         body: &'a types::UserCreate,
-    ) -> Result<types::UserCreateResult> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::UserCreateResult>,
+        progenitor_client::Error<()>,
+    > {
         let url = format!("{}/v1/users", self.baseurl,);
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => progenitor_client::ResponseValue::from_response(response).await,
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
     #[doc = "whoami: GET /v1/whoami"]
-    pub async fn whoami<'a>(&'a self) -> Result<types::WhoamiResult> {
+    pub async fn whoami<'a>(
+        &'a self,
+    ) -> Result<progenitor_client::ResponseValue<types::WhoamiResult>, progenitor_client::Error<()>>
+    {
         let url = format!("{}/v1/whoami", self.baseurl,);
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
     #[doc = "worker_bootstrap: POST /v1/worker/bootstrap"]
     pub async fn worker_bootstrap<'a>(
         &'a self,
         body: &'a types::WorkerBootstrap,
-    ) -> Result<types::WorkerBootstrapResult> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::WorkerBootstrapResult>,
+        progenitor_client::Error<()>,
+    > {
         let url = format!("{}/v1/worker/bootstrap", self.baseurl,);
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => progenitor_client::ResponseValue::from_response(response).await,
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
     #[doc = "worker_ping: GET /v1/worker/ping"]
-    pub async fn worker_ping<'a>(&'a self) -> Result<types::WorkerPingResult> {
+    pub async fn worker_ping<'a>(
+        &'a self,
+    ) -> Result<
+        progenitor_client::ResponseValue<types::WorkerPingResult>,
+        progenitor_client::Error<()>,
+    > {
         let url = format!("{}/v1/worker/ping", self.baseurl,);
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
     #[doc = "worker_task_append: POST /v1/worker/task/{task}/append"]
@@ -333,7 +404,7 @@ impl Client {
         &'a self,
         task: &'a str,
         body: &'a types::WorkerAppendTask,
-    ) -> Result<reqwest::Response> {
+    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<()>> {
         let url = format!(
             "{}/v1/worker/task/{}/append",
             self.baseurl,
@@ -341,8 +412,11 @@ impl Client {
         );
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res)
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => Ok(progenitor_client::ResponseValue::empty(response)),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
     #[doc = "worker_task_upload_chunk: POST /v1/worker/task/{task}/chunk"]
@@ -350,7 +424,8 @@ impl Client {
         &'a self,
         task: &'a str,
         body: B,
-    ) -> Result<types::UploadedChunk> {
+    ) -> Result<progenitor_client::ResponseValue<types::UploadedChunk>, progenitor_client::Error<()>>
+    {
         let url = format!(
             "{}/v1/worker/task/{}/chunk",
             self.baseurl,
@@ -358,8 +433,11 @@ impl Client {
         );
         let request = self.client.post(url).body(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => progenitor_client::ResponseValue::from_response(response).await,
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
     #[doc = "worker_task_complete: POST /v1/worker/task/{task}/complete"]
@@ -367,7 +445,7 @@ impl Client {
         &'a self,
         task: &'a str,
         body: &'a types::WorkerCompleteTask,
-    ) -> Result<reqwest::Response> {
+    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<()>> {
         let url = format!(
             "{}/v1/worker/task/{}/complete",
             self.baseurl,
@@ -375,8 +453,11 @@ impl Client {
         );
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => Ok(progenitor_client::ResponseValue::empty(response)),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
     #[doc = "worker_task_add_output: POST /v1/worker/task/{task}/output"]
@@ -384,7 +465,7 @@ impl Client {
         &'a self,
         task: &'a str,
         body: &'a types::WorkerAddOutput,
-    ) -> Result<reqwest::Response> {
+    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<()>> {
         let url = format!(
             "{}/v1/worker/task/{}/output",
             self.baseurl,
@@ -392,25 +473,39 @@ impl Client {
         );
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res)
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => Ok(progenitor_client::ResponseValue::empty(response)),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
     #[doc = "workers_list: GET /v1/workers"]
-    pub async fn workers_list<'a>(&'a self) -> Result<types::WorkersResult> {
+    pub async fn workers_list<'a>(
+        &'a self,
+    ) -> Result<progenitor_client::ResponseValue<types::WorkersResult>, progenitor_client::Error<()>>
+    {
         let url = format!("{}/v1/workers", self.baseurl,);
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
     #[doc = "workers_recycle: POST /v1/workers/recycle"]
-    pub async fn workers_recycle<'a>(&'a self) -> Result<reqwest::Response> {
+    pub async fn workers_recycle<'a>(
+        &'a self,
+    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<()>> {
         let url = format!("{}/v1/workers/recycle", self.baseurl,);
         let request = self.client.post(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => Ok(progenitor_client::ResponseValue::empty(response)),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 }

--- a/progenitor-impl/tests/output/buildomat.out
+++ b/progenitor-impl/tests/output/buildomat.out
@@ -1,24 +1,4 @@
-pub use progenitor_client::Error;
-pub use progenitor_client::ResponseValue;
-mod progenitor_support {
-    use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
-    #[allow(dead_code)]
-    const PATH_SET: &AsciiSet = &CONTROLS
-        .add(b' ')
-        .add(b'"')
-        .add(b'#')
-        .add(b'<')
-        .add(b'>')
-        .add(b'?')
-        .add(b'`')
-        .add(b'{')
-        .add(b'}');
-    #[allow(dead_code)]
-    pub(crate) fn encode_path(pc: &str) -> String {
-        utf8_percent_encode(pc, PATH_SET).to_string()
-    }
-}
-
+pub use progenitor_client::{Error, ResponseValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -183,30 +163,26 @@ impl Client {
     }
 
     #[doc = "control_hold: POST /v1/control/hold"]
-    pub async fn control_hold<'a>(
-        &'a self,
-    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<()>> {
+    pub async fn control_hold<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/v1/control/hold", self.baseurl,);
         let request = self.client.post(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            200u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
     #[doc = "control_resume: POST /v1/control/resume"]
-    pub async fn control_resume<'a>(
-        &'a self,
-    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<()>> {
+    pub async fn control_resume<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/v1/control/resume", self.baseurl,);
         let request = self.client.post(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => Ok(progenitor_client::ResponseValue::empty(response)),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            200u16 => Ok(ResponseValue::empty(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -214,33 +190,30 @@ impl Client {
     pub async fn task_get<'a>(
         &'a self,
         task: &'a str,
-    ) -> Result<progenitor_client::ResponseValue<types::Task>, progenitor_client::Error<()>> {
+    ) -> Result<ResponseValue<types::Task>, Error<()>> {
         let url = format!(
             "{}/v1/task/{}",
             self.baseurl,
-            progenitor_support::encode_path(&task.to_string()),
+            progenitor_client::encode_path(&task.to_string()),
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            200u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
     #[doc = "tasks_get: GET /v1/tasks"]
-    pub async fn tasks_get<'a>(
-        &'a self,
-    ) -> Result<progenitor_client::ResponseValue<Vec<types::Task>>, progenitor_client::Error<()>>
-    {
+    pub async fn tasks_get<'a>(&'a self) -> Result<ResponseValue<Vec<types::Task>>, Error<()>> {
         let url = format!("{}/v1/tasks", self.baseurl,);
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            200u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -248,17 +221,14 @@ impl Client {
     pub async fn task_submit<'a>(
         &'a self,
         body: &'a types::TaskSubmit,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::TaskSubmitResult>,
-        progenitor_client::Error<()>,
-    > {
+    ) -> Result<ResponseValue<types::TaskSubmitResult>, Error<()>> {
         let url = format!("{}/v1/tasks", self.baseurl,);
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            201u16 => progenitor_client::ResponseValue::from_response(response).await,
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            201u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -267,12 +237,11 @@ impl Client {
         &'a self,
         task: &'a str,
         minseq: Option<u32>,
-    ) -> Result<progenitor_client::ResponseValue<Vec<types::TaskEvent>>, progenitor_client::Error<()>>
-    {
+    ) -> Result<ResponseValue<Vec<types::TaskEvent>>, Error<()>> {
         let url = format!(
             "{}/v1/tasks/{}/events",
             self.baseurl,
-            progenitor_support::encode_path(&task.to_string()),
+            progenitor_client::encode_path(&task.to_string()),
         );
         let mut query = Vec::new();
         if let Some(v) = &minseq {
@@ -283,8 +252,8 @@ impl Client {
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            200u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -292,21 +261,18 @@ impl Client {
     pub async fn task_outputs_get<'a>(
         &'a self,
         task: &'a str,
-    ) -> Result<
-        progenitor_client::ResponseValue<Vec<types::TaskOutput>>,
-        progenitor_client::Error<()>,
-    > {
+    ) -> Result<ResponseValue<Vec<types::TaskOutput>>, Error<()>> {
         let url = format!(
             "{}/v1/tasks/{}/outputs",
             self.baseurl,
-            progenitor_support::encode_path(&task.to_string()),
+            progenitor_client::encode_path(&task.to_string()),
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            200u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -315,19 +281,19 @@ impl Client {
         &'a self,
         task: &'a str,
         output: &'a str,
-    ) -> Result<reqwest::Response, progenitor_client::Error<()>> {
+    ) -> Result<reqwest::Response, Error<()>> {
         let url = format!(
             "{}/v1/tasks/{}/outputs/{}",
             self.baseurl,
-            progenitor_support::encode_path(&task.to_string()),
-            progenitor_support::encode_path(&output.to_string()),
+            progenitor_client::encode_path(&task.to_string()),
+            progenitor_client::encode_path(&output.to_string()),
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
             200..=299 => Ok(response),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -335,32 +301,26 @@ impl Client {
     pub async fn user_create<'a>(
         &'a self,
         body: &'a types::UserCreate,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::UserCreateResult>,
-        progenitor_client::Error<()>,
-    > {
+    ) -> Result<ResponseValue<types::UserCreateResult>, Error<()>> {
         let url = format!("{}/v1/users", self.baseurl,);
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            201u16 => progenitor_client::ResponseValue::from_response(response).await,
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            201u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
     #[doc = "whoami: GET /v1/whoami"]
-    pub async fn whoami<'a>(
-        &'a self,
-    ) -> Result<progenitor_client::ResponseValue<types::WhoamiResult>, progenitor_client::Error<()>>
-    {
+    pub async fn whoami<'a>(&'a self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
         let url = format!("{}/v1/whoami", self.baseurl,);
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            200u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -368,34 +328,28 @@ impl Client {
     pub async fn worker_bootstrap<'a>(
         &'a self,
         body: &'a types::WorkerBootstrap,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::WorkerBootstrapResult>,
-        progenitor_client::Error<()>,
-    > {
+    ) -> Result<ResponseValue<types::WorkerBootstrapResult>, Error<()>> {
         let url = format!("{}/v1/worker/bootstrap", self.baseurl,);
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            201u16 => progenitor_client::ResponseValue::from_response(response).await,
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            201u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
     #[doc = "worker_ping: GET /v1/worker/ping"]
     pub async fn worker_ping<'a>(
         &'a self,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::WorkerPingResult>,
-        progenitor_client::Error<()>,
-    > {
+    ) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
         let url = format!("{}/v1/worker/ping", self.baseurl,);
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            200u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -404,18 +358,18 @@ impl Client {
         &'a self,
         task: &'a str,
         body: &'a types::WorkerAppendTask,
-    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<()>> {
+    ) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!(
             "{}/v1/worker/task/{}/append",
             self.baseurl,
-            progenitor_support::encode_path(&task.to_string()),
+            progenitor_client::encode_path(&task.to_string()),
         );
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            201u16 => Ok(progenitor_client::ResponseValue::empty(response)),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            201u16 => Ok(ResponseValue::empty(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -424,19 +378,18 @@ impl Client {
         &'a self,
         task: &'a str,
         body: B,
-    ) -> Result<progenitor_client::ResponseValue<types::UploadedChunk>, progenitor_client::Error<()>>
-    {
+    ) -> Result<ResponseValue<types::UploadedChunk>, Error<()>> {
         let url = format!(
             "{}/v1/worker/task/{}/chunk",
             self.baseurl,
-            progenitor_support::encode_path(&task.to_string()),
+            progenitor_client::encode_path(&task.to_string()),
         );
         let request = self.client.post(url).body(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            201u16 => progenitor_client::ResponseValue::from_response(response).await,
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            201u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -445,18 +398,18 @@ impl Client {
         &'a self,
         task: &'a str,
         body: &'a types::WorkerCompleteTask,
-    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<()>> {
+    ) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!(
             "{}/v1/worker/task/{}/complete",
             self.baseurl,
-            progenitor_support::encode_path(&task.to_string()),
+            progenitor_client::encode_path(&task.to_string()),
         );
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => Ok(progenitor_client::ResponseValue::empty(response)),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            200u16 => Ok(ResponseValue::empty(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -465,47 +418,44 @@ impl Client {
         &'a self,
         task: &'a str,
         body: &'a types::WorkerAddOutput,
-    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<()>> {
+    ) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!(
             "{}/v1/worker/task/{}/output",
             self.baseurl,
-            progenitor_support::encode_path(&task.to_string()),
+            progenitor_client::encode_path(&task.to_string()),
         );
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            201u16 => Ok(progenitor_client::ResponseValue::empty(response)),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            201u16 => Ok(ResponseValue::empty(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
     #[doc = "workers_list: GET /v1/workers"]
     pub async fn workers_list<'a>(
         &'a self,
-    ) -> Result<progenitor_client::ResponseValue<types::WorkersResult>, progenitor_client::Error<()>>
-    {
+    ) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
         let url = format!("{}/v1/workers", self.baseurl,);
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            200u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
     #[doc = "workers_recycle: POST /v1/workers/recycle"]
-    pub async fn workers_recycle<'a>(
-        &'a self,
-    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<()>> {
+    pub async fn workers_recycle<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/v1/workers/recycle", self.baseurl,);
         let request = self.client.post(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => Ok(progenitor_client::ResponseValue::empty(response)),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            200u16 => Ok(ResponseValue::empty(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 }

--- a/progenitor-impl/tests/output/keeper.out
+++ b/progenitor-impl/tests/output/keeper.out
@@ -1,4 +1,5 @@
-use anyhow::Result;
+pub use progenitor_client::Error;
+pub use progenitor_client::ResponseValue;
 mod progenitor_support {
     use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
     #[allow(dead_code)]
@@ -123,65 +124,97 @@ impl Client {
     }
 
     #[doc = "enrol: POST /enrol"]
-    pub async fn enrol<'a>(&'a self, body: &'a types::EnrolBody) -> Result<reqwest::Response> {
+    pub async fn enrol<'a>(
+        &'a self,
+        body: &'a types::EnrolBody,
+    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<()>> {
         let url = format!("{}/enrol", self.baseurl,);
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res)
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => Ok(progenitor_client::ResponseValue::empty(response)),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
     #[doc = "global_jobs: GET /global/jobs"]
-    pub async fn global_jobs<'a>(&'a self) -> Result<types::GlobalJobsResult> {
+    pub async fn global_jobs<'a>(
+        &'a self,
+    ) -> Result<
+        progenitor_client::ResponseValue<types::GlobalJobsResult>,
+        progenitor_client::Error<()>,
+    > {
         let url = format!("{}/global/jobs", self.baseurl,);
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => progenitor_client::ResponseValue::from_response(response).await,
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
     #[doc = "ping: GET /ping"]
-    pub async fn ping<'a>(&'a self) -> Result<types::PingResult> {
+    pub async fn ping<'a>(
+        &'a self,
+    ) -> Result<progenitor_client::ResponseValue<types::PingResult>, progenitor_client::Error<()>>
+    {
         let url = format!("{}/ping", self.baseurl,);
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => progenitor_client::ResponseValue::from_response(response).await,
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
     #[doc = "report_finish: POST /report/finish"]
     pub async fn report_finish<'a>(
         &'a self,
         body: &'a types::ReportFinishBody,
-    ) -> Result<types::ReportResult> {
+    ) -> Result<progenitor_client::ResponseValue<types::ReportResult>, progenitor_client::Error<()>>
+    {
         let url = format!("{}/report/finish", self.baseurl,);
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => progenitor_client::ResponseValue::from_response(response).await,
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
     #[doc = "report_output: POST /report/output"]
     pub async fn report_output<'a>(
         &'a self,
         body: &'a types::ReportOutputBody,
-    ) -> Result<types::ReportResult> {
+    ) -> Result<progenitor_client::ResponseValue<types::ReportResult>, progenitor_client::Error<()>>
+    {
         let url = format!("{}/report/output", self.baseurl,);
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => progenitor_client::ResponseValue::from_response(response).await,
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
     #[doc = "report_start: POST /report/start"]
     pub async fn report_start<'a>(
         &'a self,
         body: &'a types::ReportStartBody,
-    ) -> Result<types::ReportResult> {
+    ) -> Result<progenitor_client::ResponseValue<types::ReportResult>, progenitor_client::Error<()>>
+    {
         let url = format!("{}/report/start", self.baseurl,);
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => progenitor_client::ResponseValue::from_response(response).await,
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 }

--- a/progenitor-impl/tests/output/keeper.out
+++ b/progenitor-impl/tests/output/keeper.out
@@ -1,24 +1,4 @@
-pub use progenitor_client::Error;
-pub use progenitor_client::ResponseValue;
-mod progenitor_support {
-    use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
-    #[allow(dead_code)]
-    const PATH_SET: &AsciiSet = &CONTROLS
-        .add(b' ')
-        .add(b'"')
-        .add(b'#')
-        .add(b'<')
-        .add(b'>')
-        .add(b'?')
-        .add(b'`')
-        .add(b'{')
-        .add(b'}');
-    #[allow(dead_code)]
-    pub(crate) fn encode_path(pc: &str) -> String {
-        utf8_percent_encode(pc, PATH_SET).to_string()
-    }
-}
-
+pub use progenitor_client::{Error, ResponseValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -127,46 +107,40 @@ impl Client {
     pub async fn enrol<'a>(
         &'a self,
         body: &'a types::EnrolBody,
-    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<()>> {
+    ) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/enrol", self.baseurl,);
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            201u16 => Ok(progenitor_client::ResponseValue::empty(response)),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            201u16 => Ok(ResponseValue::empty(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
     #[doc = "global_jobs: GET /global/jobs"]
     pub async fn global_jobs<'a>(
         &'a self,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::GlobalJobsResult>,
-        progenitor_client::Error<()>,
-    > {
+    ) -> Result<ResponseValue<types::GlobalJobsResult>, Error<()>> {
         let url = format!("{}/global/jobs", self.baseurl,);
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            201u16 => progenitor_client::ResponseValue::from_response(response).await,
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            201u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
     #[doc = "ping: GET /ping"]
-    pub async fn ping<'a>(
-        &'a self,
-    ) -> Result<progenitor_client::ResponseValue<types::PingResult>, progenitor_client::Error<()>>
-    {
+    pub async fn ping<'a>(&'a self) -> Result<ResponseValue<types::PingResult>, Error<()>> {
         let url = format!("{}/ping", self.baseurl,);
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            201u16 => progenitor_client::ResponseValue::from_response(response).await,
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            201u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -174,15 +148,14 @@ impl Client {
     pub async fn report_finish<'a>(
         &'a self,
         body: &'a types::ReportFinishBody,
-    ) -> Result<progenitor_client::ResponseValue<types::ReportResult>, progenitor_client::Error<()>>
-    {
+    ) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
         let url = format!("{}/report/finish", self.baseurl,);
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            201u16 => progenitor_client::ResponseValue::from_response(response).await,
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            201u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -190,15 +163,14 @@ impl Client {
     pub async fn report_output<'a>(
         &'a self,
         body: &'a types::ReportOutputBody,
-    ) -> Result<progenitor_client::ResponseValue<types::ReportResult>, progenitor_client::Error<()>>
-    {
+    ) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
         let url = format!("{}/report/output", self.baseurl,);
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            201u16 => progenitor_client::ResponseValue::from_response(response).await,
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            201u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -206,15 +178,14 @@ impl Client {
     pub async fn report_start<'a>(
         &'a self,
         body: &'a types::ReportStartBody,
-    ) -> Result<progenitor_client::ResponseValue<types::ReportResult>, progenitor_client::Error<()>>
-    {
+    ) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
         let url = format!("{}/report/start", self.baseurl,);
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            201u16 => progenitor_client::ResponseValue::from_response(response).await,
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            201u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 }

--- a/progenitor-impl/tests/output/nexus.out
+++ b/progenitor-impl/tests/output/nexus.out
@@ -1,4 +1,5 @@
-use anyhow::Result;
+pub use progenitor_client::Error;
+pub use progenitor_client::ResponseValue;
 mod progenitor_support {
     use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
     #[allow(dead_code)]
@@ -65,26 +66,18 @@ pub mod types {
     pub struct Disk {
         #[doc = "human-readable free-form text about a resource"]
         pub description: String,
-        #[serde(rename = "devicePath")]
         pub device_path: String,
         #[doc = "unique, immutable, system-controlled identifier for each resource"]
         pub id: uuid::Uuid,
         pub name: Name,
-        #[serde(rename = "projectId")]
         pub project_id: uuid::Uuid,
         pub size: ByteCount,
-        #[serde(
-            rename = "snapshotId",
-            default,
-            skip_serializing_if = "Option::is_none"
-        )]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub snapshot_id: Option<uuid::Uuid>,
         pub state: DiskState,
         #[doc = "timestamp when this resource was created"]
-        #[serde(rename = "timeCreated")]
         pub time_created: chrono::DateTime<chrono::offset::Utc>,
         #[doc = "timestamp when this resource was last modified"]
-        #[serde(rename = "timeModified")]
         pub time_modified: chrono::DateTime<chrono::offset::Utc>,
     }
 
@@ -95,11 +88,7 @@ pub mod types {
         pub name: Name,
         pub size: ByteCount,
         #[doc = "id for snapshot from which the Disk should be created, if any"]
-        #[serde(
-            rename = "snapshotId",
-            default,
-            skip_serializing_if = "Option::is_none"
-        )]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub snapshot_id: Option<uuid::Uuid>,
     }
 
@@ -136,6 +125,15 @@ pub mod types {
         Destroyed,
         #[serde(rename = "faulted")]
         Faulted,
+    }
+
+    #[doc = "Body of an HTTP response for an `HttpError`.  This type can be used to deserialize an HTTP response corresponding to an error in order to access the error code, message, etc."]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Error {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub error_code: Option<String>,
+        pub message: String,
+        pub request_id: String,
     }
 
     #[doc = "The name and type information for a field of a timeseries schema."]
@@ -199,22 +197,6 @@ pub mod types {
         }
     }
 
-    #[doc = "Identity-related metadata that's included in nearly all public API objects"]
-    #[derive(Serialize, Deserialize, Debug, Clone)]
-    pub struct IdentityMetadata {
-        #[doc = "human-readable free-form text about a resource"]
-        pub description: String,
-        #[doc = "unique, immutable, system-controlled identifier for each resource"]
-        pub id: uuid::Uuid,
-        pub name: Name,
-        #[doc = "timestamp when this resource was created"]
-        #[serde(rename = "timeCreated")]
-        pub time_created: chrono::DateTime<chrono::offset::Utc>,
-        #[doc = "timestamp when this resource was last modified"]
-        #[serde(rename = "timeModified")]
-        pub time_modified: chrono::DateTime<chrono::offset::Utc>,
-    }
-
     #[doc = "Client view of an [`Instance`]"]
     #[derive(Serialize, Deserialize, Debug, Clone)]
     pub struct Instance {
@@ -228,17 +210,12 @@ pub mod types {
         pub name: Name,
         pub ncpus: InstanceCpuCount,
         #[doc = "id for the project containing this Instance"]
-        #[serde(rename = "projectId")]
         pub project_id: uuid::Uuid,
-        #[serde(rename = "runState")]
         pub run_state: InstanceState,
         #[doc = "timestamp when this resource was created"]
-        #[serde(rename = "timeCreated")]
         pub time_created: chrono::DateTime<chrono::offset::Utc>,
         #[doc = "timestamp when this resource was last modified"]
-        #[serde(rename = "timeModified")]
         pub time_modified: chrono::DateTime<chrono::offset::Utc>,
-        #[serde(rename = "timeRunStateUpdated")]
         pub time_run_state_updated: chrono::DateTime<chrono::offset::Utc>,
     }
 
@@ -260,6 +237,12 @@ pub mod types {
         pub memory: ByteCount,
         pub name: Name,
         pub ncpus: InstanceCpuCount,
+    }
+
+    #[doc = "Migration parameters for an [`Instance`]"]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct InstanceMigrate {
+        pub dst_sled_uuid: uuid::Uuid,
     }
 
     #[doc = "A single page of results"]
@@ -287,6 +270,8 @@ pub mod types {
         Stopped,
         #[serde(rename = "rebooting")]
         Rebooting,
+        #[serde(rename = "migrating")]
+        Migrating,
         #[serde(rename = "repairing")]
         Repairing,
         #[serde(rename = "failed")]
@@ -304,6 +289,7 @@ pub mod types {
                 InstanceState::Stopping => "stopping".to_string(),
                 InstanceState::Stopped => "stopped".to_string(),
                 InstanceState::Rebooting => "rebooting".to_string(),
+                InstanceState::Migrating => "migrating".to_string(),
                 InstanceState::Repairing => "repairing".to_string(),
                 InstanceState::Failed => "failed".to_string(),
                 InstanceState::Destroyed => "destroyed".to_string(),
@@ -405,14 +391,22 @@ pub mod types {
     #[doc = "A `NetworkInterface` represents a virtual network interface device."]
     #[derive(Serialize, Deserialize, Debug, Clone)]
     pub struct NetworkInterface {
-        pub identity: IdentityMetadata,
+        #[doc = "human-readable free-form text about a resource"]
+        pub description: String,
+        #[doc = "unique, immutable, system-controlled identifier for each resource"]
+        pub id: uuid::Uuid,
         #[doc = "The Instance to which the interface belongs."]
         pub instance_id: uuid::Uuid,
         #[doc = "The IP address assigned to this interface."]
         pub ip: String,
         pub mac: MacAddr,
+        pub name: Name,
         #[doc = "The subnet to which the interface belongs."]
         pub subnet_id: uuid::Uuid,
+        #[doc = "timestamp when this resource was created"]
+        pub time_created: chrono::DateTime<chrono::offset::Utc>,
+        #[doc = "timestamp when this resource was last modified"]
+        pub time_modified: chrono::DateTime<chrono::offset::Utc>,
         #[doc = "The VPC to which the interface belongs."]
         pub vpc_id: uuid::Uuid,
     }
@@ -436,10 +430,8 @@ pub mod types {
         pub id: uuid::Uuid,
         pub name: Name,
         #[doc = "timestamp when this resource was created"]
-        #[serde(rename = "timeCreated")]
         pub time_created: chrono::DateTime<chrono::offset::Utc>,
         #[doc = "timestamp when this resource was last modified"]
-        #[serde(rename = "timeModified")]
         pub time_modified: chrono::DateTime<chrono::offset::Utc>,
     }
 
@@ -477,13 +469,10 @@ pub mod types {
         #[doc = "unique, immutable, system-controlled identifier for each resource"]
         pub id: uuid::Uuid,
         pub name: Name,
-        #[serde(rename = "organizationId")]
         pub organization_id: uuid::Uuid,
         #[doc = "timestamp when this resource was created"]
-        #[serde(rename = "timeCreated")]
         pub time_created: chrono::DateTime<chrono::offset::Utc>,
         #[doc = "timestamp when this resource was last modified"]
-        #[serde(rename = "timeModified")]
         pub time_modified: chrono::DateTime<chrono::offset::Utc>,
     }
 
@@ -516,7 +505,15 @@ pub mod types {
     #[doc = "Client view of an [`Rack`]"]
     #[derive(Serialize, Deserialize, Debug, Clone)]
     pub struct Rack {
-        pub identity: IdentityMetadata,
+        #[doc = "human-readable free-form text about a resource"]
+        pub description: String,
+        #[doc = "unique, immutable, system-controlled identifier for each resource"]
+        pub id: uuid::Uuid,
+        pub name: Name,
+        #[doc = "timestamp when this resource was created"]
+        pub time_created: chrono::DateTime<chrono::offset::Utc>,
+        #[doc = "timestamp when this resource was last modified"]
+        pub time_modified: chrono::DateTime<chrono::offset::Utc>,
     }
 
     #[doc = "A single page of results"]
@@ -578,19 +575,27 @@ pub mod types {
         Subnet(Name),
         #[serde(rename = "instance")]
         Instance(Name),
-        #[serde(rename = "internetGateway")]
+        #[serde(rename = "internet_gateway")]
         InternetGateway(Name),
     }
 
     #[doc = "A route defines a rule that governs where traffic should be sent based on its destination."]
     #[derive(Serialize, Deserialize, Debug, Clone)]
     pub struct RouterRoute {
+        #[doc = "human-readable free-form text about a resource"]
+        pub description: String,
         pub destination: RouteDestination,
-        pub identity: IdentityMetadata,
+        #[doc = "unique, immutable, system-controlled identifier for each resource"]
+        pub id: uuid::Uuid,
         pub kind: RouterRouteKind,
+        pub name: Name,
         #[doc = "The VPC Router to which the route belongs."]
         pub router_id: uuid::Uuid,
         pub target: RouteTarget,
+        #[doc = "timestamp when this resource was created"]
+        pub time_created: chrono::DateTime<chrono::offset::Utc>,
+        #[doc = "timestamp when this resource was last modified"]
+        pub time_modified: chrono::DateTime<chrono::offset::Utc>,
     }
 
     #[doc = "Create-time parameters for a [`RouterRoute`]"]
@@ -605,19 +610,23 @@ pub mod types {
     #[doc = "The classification of a [`RouterRoute`] as defined by the system. The kind determines certain attributes such as if the route is modifiable and describes how or where the route was created.\n\nSee [RFD-21](https://rfd.shared.oxide.computer/rfd/0021#concept-router) for more context"]
     #[derive(Serialize, Deserialize, Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
     pub enum RouterRouteKind {
+        #[serde(rename = "default")]
         Default,
+        #[serde(rename = "vpc_subnet")]
         VpcSubnet,
+        #[serde(rename = "vpc_peering")]
         VpcPeering,
+        #[serde(rename = "custom")]
         Custom,
     }
 
     impl ToString for RouterRouteKind {
         fn to_string(&self) -> String {
             match self {
-                RouterRouteKind::Default => "Default".to_string(),
-                RouterRouteKind::VpcSubnet => "VpcSubnet".to_string(),
-                RouterRouteKind::VpcPeering => "VpcPeering".to_string(),
-                RouterRouteKind::Custom => "Custom".to_string(),
+                RouterRouteKind::Default => "default".to_string(),
+                RouterRouteKind::VpcSubnet => "vpc_subnet".to_string(),
+                RouterRouteKind::VpcPeering => "vpc_peering".to_string(),
+                RouterRouteKind::Custom => "custom".to_string(),
             }
         }
     }
@@ -652,15 +661,15 @@ pub mod types {
     #[derive(Serialize, Deserialize, Debug, Clone)]
     #[serde(tag = "error")]
     pub enum SagaErrorInfo {
-        #[serde(rename = "actionFailed")]
+        #[serde(rename = "action_failed")]
         ActionFailed { source_error: serde_json::Value },
-        #[serde(rename = "deserializeFailed")]
+        #[serde(rename = "deserialize_failed")]
         DeserializeFailed { message: String },
-        #[serde(rename = "injectedError")]
+        #[serde(rename = "injected_error")]
         InjectedError,
-        #[serde(rename = "serializeFailed")]
+        #[serde(rename = "serialize_failed")]
         SerializeFailed { message: String },
-        #[serde(rename = "subsagaCreateFailed")]
+        #[serde(rename = "subsaga_create_failed")]
         SubsagaCreateFailed { message: String },
     }
 
@@ -688,6 +697,12 @@ pub mod types {
         },
     }
 
+    #[doc = "Client view of currently authed user."]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct SessionUser {
+        pub id: uuid::Uuid,
+    }
+
     #[doc = "Client view of an [`Sled`]"]
     #[derive(Serialize, Deserialize, Debug, Clone)]
     pub struct Sled {
@@ -696,13 +711,10 @@ pub mod types {
         #[doc = "unique, immutable, system-controlled identifier for each resource"]
         pub id: uuid::Uuid,
         pub name: Name,
-        #[serde(rename = "serviceAddress")]
         pub service_address: String,
         #[doc = "timestamp when this resource was created"]
-        #[serde(rename = "timeCreated")]
         pub time_created: chrono::DateTime<chrono::offset::Utc>,
         #[doc = "timestamp when this resource was last modified"]
-        #[serde(rename = "timeModified")]
         pub time_modified: chrono::DateTime<chrono::offset::Utc>,
     }
 
@@ -754,10 +766,8 @@ pub mod types {
         pub id: uuid::Uuid,
         pub name: Name,
         #[doc = "timestamp when this resource was created"]
-        #[serde(rename = "timeCreated")]
         pub time_created: chrono::DateTime<chrono::offset::Utc>,
         #[doc = "timestamp when this resource was last modified"]
-        #[serde(rename = "timeModified")]
         pub time_modified: chrono::DateTime<chrono::offset::Utc>,
     }
 
@@ -776,22 +786,17 @@ pub mod types {
     pub struct Vpc {
         #[doc = "human-readable free-form text about a resource"]
         pub description: String,
-        #[serde(rename = "dnsName")]
         pub dns_name: Name,
         #[doc = "unique, immutable, system-controlled identifier for each resource"]
         pub id: uuid::Uuid,
         pub name: Name,
         #[doc = "id for the project containing this VPC"]
-        #[serde(rename = "projectId")]
         pub project_id: uuid::Uuid,
         #[doc = "id for the system router where subnet default routes are registered"]
-        #[serde(rename = "systemRouterId")]
         pub system_router_id: uuid::Uuid,
         #[doc = "timestamp when this resource was created"]
-        #[serde(rename = "timeCreated")]
         pub time_created: chrono::DateTime<chrono::offset::Utc>,
         #[doc = "timestamp when this resource was last modified"]
-        #[serde(rename = "timeModified")]
         pub time_modified: chrono::DateTime<chrono::offset::Utc>,
     }
 
@@ -799,7 +804,6 @@ pub mod types {
     #[derive(Serialize, Deserialize, Debug, Clone)]
     pub struct VpcCreate {
         pub description: String,
-        #[serde(rename = "dnsName")]
         pub dns_name: Name,
         pub name: Name,
     }
@@ -808,14 +812,22 @@ pub mod types {
     #[derive(Serialize, Deserialize, Debug, Clone)]
     pub struct VpcFirewallRule {
         pub action: VpcFirewallRuleAction,
+        #[doc = "human-readable free-form text about a resource"]
+        pub description: String,
         pub direction: VpcFirewallRuleDirection,
         pub filters: VpcFirewallRuleFilter,
-        pub identity: IdentityMetadata,
+        #[doc = "unique, immutable, system-controlled identifier for each resource"]
+        pub id: uuid::Uuid,
+        pub name: Name,
         #[doc = "the relative priority of this rule"]
         pub priority: u16,
         pub status: VpcFirewallRuleStatus,
         #[doc = "list of sets of instances that the rule applies to"]
         pub targets: Vec<VpcFirewallRuleTarget>,
+        #[doc = "timestamp when this resource was created"]
+        pub time_created: chrono::DateTime<chrono::offset::Utc>,
+        #[doc = "timestamp when this resource was last modified"]
+        pub time_modified: chrono::DateTime<chrono::offset::Utc>,
     }
 
     #[derive(Serialize, Deserialize, Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
@@ -877,7 +889,7 @@ pub mod types {
         Instance(Name),
         #[serde(rename = "ip")]
         Ip(String),
-        #[serde(rename = "internetGateway")]
+        #[serde(rename = "internet_gateway")]
         InternetGateway(Name),
     }
 
@@ -988,8 +1000,16 @@ pub mod types {
     #[doc = "A VPC router defines a series of rules that indicate where traffic should be sent depending on its destination."]
     #[derive(Serialize, Deserialize, Debug, Clone)]
     pub struct VpcRouter {
-        pub identity: IdentityMetadata,
+        #[doc = "human-readable free-form text about a resource"]
+        pub description: String,
+        #[doc = "unique, immutable, system-controlled identifier for each resource"]
+        pub id: uuid::Uuid,
         pub kind: VpcRouterKind,
+        pub name: Name,
+        #[doc = "timestamp when this resource was created"]
+        pub time_created: chrono::DateTime<chrono::offset::Utc>,
+        #[doc = "timestamp when this resource was last modified"]
+        pub time_modified: chrono::DateTime<chrono::offset::Utc>,
         #[doc = "The VPC to which the router belongs."]
         pub vpc_id: uuid::Uuid,
     }
@@ -1040,7 +1060,10 @@ pub mod types {
     #[doc = "A VPC subnet represents a logical grouping for instances that allows network traffic between them, within a IPv4 subnetwork or optionall an IPv6 subnetwork."]
     #[derive(Serialize, Deserialize, Debug, Clone)]
     pub struct VpcSubnet {
-        pub identity: IdentityMetadata,
+        #[doc = "human-readable free-form text about a resource"]
+        pub description: String,
+        #[doc = "unique, immutable, system-controlled identifier for each resource"]
+        pub id: uuid::Uuid,
         #[serde(
             rename = "ipv4_block",
             default,
@@ -1053,6 +1076,11 @@ pub mod types {
             skip_serializing_if = "Option::is_none"
         )]
         pub ipv_6_block: Option<Ipv6Net>,
+        pub name: Name,
+        #[doc = "timestamp when this resource was created"]
+        pub time_created: chrono::DateTime<chrono::offset::Utc>,
+        #[doc = "timestamp when this resource was last modified"]
+        pub time_modified: chrono::DateTime<chrono::offset::Utc>,
         #[doc = "The VPC to which the subnet belongs."]
         pub vpc_id: uuid::Uuid,
     }
@@ -1061,9 +1089,17 @@ pub mod types {
     #[derive(Serialize, Deserialize, Debug, Clone)]
     pub struct VpcSubnetCreate {
         pub description: String,
-        #[serde(rename = "ipv4Block", default, skip_serializing_if = "Option::is_none")]
+        #[serde(
+            rename = "ipv4_block",
+            default,
+            skip_serializing_if = "Option::is_none"
+        )]
         pub ipv_4_block: Option<Ipv4Net>,
-        #[serde(rename = "ipv6Block", default, skip_serializing_if = "Option::is_none")]
+        #[serde(
+            rename = "ipv6_block",
+            default,
+            skip_serializing_if = "Option::is_none"
+        )]
         pub ipv_6_block: Option<Ipv6Net>,
         pub name: Name,
     }
@@ -1083,9 +1119,17 @@ pub mod types {
     pub struct VpcSubnetUpdate {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub description: Option<String>,
-        #[serde(rename = "ipv4Block", default, skip_serializing_if = "Option::is_none")]
+        #[serde(
+            rename = "ipv4_block",
+            default,
+            skip_serializing_if = "Option::is_none"
+        )]
         pub ipv_4_block: Option<Ipv4Net>,
-        #[serde(rename = "ipv6Block", default, skip_serializing_if = "Option::is_none")]
+        #[serde(
+            rename = "ipv6_block",
+            default,
+            skip_serializing_if = "Option::is_none"
+        )]
         pub ipv_6_block: Option<Ipv6Net>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub name: Option<Name>,
@@ -1096,7 +1140,7 @@ pub mod types {
     pub struct VpcUpdate {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub description: Option<String>,
-        #[serde(rename = "dnsName", default, skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub dns_name: Option<Name>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub name: Option<Name>,
@@ -1135,13 +1179,16 @@ impl Client {
         &self.client
     }
 
-    #[doc = "List racks in the system.\n\nhardware_racks_get: GET /hardware/racks"]
+    #[doc = "\n\nhardware_racks_get: GET /hardware/racks"]
     pub async fn hardware_racks_get<'a>(
         &'a self,
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
-    ) -> Result<types::RackResultsPage> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::RackResultsPage>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!("{}/hardware/racks", self.baseurl,);
         let mut query = Vec::new();
         if let Some(v) = &limit {
@@ -1158,21 +1205,33 @@ impl Client {
 
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List racks in the system.\n\nreturns a Stream<Item = Rack> by making successive calls to hardware_racks_get"]
+    #[doc = "\n\nreturns a Stream<Item = Rack> by making successive calls to hardware_racks_get"]
     pub fn hardware_racks_get_stream<'a>(
         &'a self,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::IdSortMode>,
-    ) -> impl futures::Stream<Item = Result<types::Rack>> + Unpin + '_ {
+    ) -> impl futures::Stream<Item = Result<types::Rack, progenitor_client::Error<types::Error>>>
+           + Unpin
+           + '_ {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
         self.hardware_racks_get(limit, None, sort_by)
             .map_ok(move |page| {
+                let page = page.into_inner();
                 let first = futures::stream::iter(page.items.into_iter().map(Ok));
                 let rest = futures::stream::try_unfold(page.next_page, move |state| async move {
                     if state.is_none() {
@@ -1180,6 +1239,7 @@ impl Client {
                     } else {
                         self.hardware_racks_get(None, state.as_deref(), None)
                             .map_ok(|page| {
+                                let page = page.into_inner();
                                 Some((
                                     futures::stream::iter(page.items.into_iter().map(Ok)),
                                     page.next_page,
@@ -1195,11 +1255,12 @@ impl Client {
             .boxed()
     }
 
-    #[doc = "Fetch information about a particular rack.\n\nhardware_racks_get_rack: GET /hardware/racks/{rack_id}"]
+    #[doc = "\n\nhardware_racks_get_rack: GET /hardware/racks/{rack_id}"]
     pub async fn hardware_racks_get_rack<'a>(
         &'a self,
         rack_id: &'a uuid::Uuid,
-    ) -> Result<types::Rack> {
+    ) -> Result<progenitor_client::ResponseValue<types::Rack>, progenitor_client::Error<types::Error>>
+    {
         let url = format!(
             "{}/hardware/racks/{}",
             self.baseurl,
@@ -1207,17 +1268,29 @@ impl Client {
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List sleds in the system.\n\nhardware_sleds_get: GET /hardware/sleds"]
+    #[doc = "\n\nhardware_sleds_get: GET /hardware/sleds"]
     pub async fn hardware_sleds_get<'a>(
         &'a self,
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
-    ) -> Result<types::SledResultsPage> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::SledResultsPage>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!("{}/hardware/sleds", self.baseurl,);
         let mut query = Vec::new();
         if let Some(v) = &limit {
@@ -1234,21 +1307,33 @@ impl Client {
 
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List sleds in the system.\n\nreturns a Stream<Item = Sled> by making successive calls to hardware_sleds_get"]
+    #[doc = "\n\nreturns a Stream<Item = Sled> by making successive calls to hardware_sleds_get"]
     pub fn hardware_sleds_get_stream<'a>(
         &'a self,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::IdSortMode>,
-    ) -> impl futures::Stream<Item = Result<types::Sled>> + Unpin + '_ {
+    ) -> impl futures::Stream<Item = Result<types::Sled, progenitor_client::Error<types::Error>>>
+           + Unpin
+           + '_ {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
         self.hardware_sleds_get(limit, None, sort_by)
             .map_ok(move |page| {
+                let page = page.into_inner();
                 let first = futures::stream::iter(page.items.into_iter().map(Ok));
                 let rest = futures::stream::try_unfold(page.next_page, move |state| async move {
                     if state.is_none() {
@@ -1256,6 +1341,7 @@ impl Client {
                     } else {
                         self.hardware_sleds_get(None, state.as_deref(), None)
                             .map_ok(|page| {
+                                let page = page.into_inner();
                                 Some((
                                     futures::stream::iter(page.items.into_iter().map(Ok)),
                                     page.next_page,
@@ -1271,11 +1357,12 @@ impl Client {
             .boxed()
     }
 
-    #[doc = "Fetch information about a sled in the system.\n\nhardware_sleds_get_sled: GET /hardware/sleds/{sled_id}"]
+    #[doc = "\n\nhardware_sleds_get_sled: GET /hardware/sleds/{sled_id}"]
     pub async fn hardware_sleds_get_sled<'a>(
         &'a self,
         sled_id: &'a uuid::Uuid,
-    ) -> Result<types::Sled> {
+    ) -> Result<progenitor_client::ResponseValue<types::Sled>, progenitor_client::Error<types::Error>>
+    {
         let url = format!(
             "{}/hardware/sleds/{}",
             self.baseurl,
@@ -1283,38 +1370,62 @@ impl Client {
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
     #[doc = "spoof_login: POST /login"]
     pub async fn spoof_login<'a>(
         &'a self,
         body: &'a types::LoginParams,
-    ) -> Result<reqwest::Response> {
+    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<()>> {
         let url = format!("{}/login", self.baseurl,);
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res)
+        let response = result?;
+        match response.status().as_u16() {
+            200..=299 => Ok(progenitor_client::ResponseValue::empty(response)),
+            _ => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::empty(response),
+            )),
+        }
     }
 
     #[doc = "logout: POST /logout"]
-    pub async fn logout<'a>(&'a self) -> Result<reqwest::Response> {
+    pub async fn logout<'a>(
+        &'a self,
+    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<()>> {
         let url = format!("{}/logout", self.baseurl,);
         let request = self.client.post(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res)
+        let response = result?;
+        match response.status().as_u16() {
+            200..=299 => Ok(progenitor_client::ResponseValue::empty(response)),
+            _ => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::empty(response),
+            )),
+        }
     }
 
-    #[doc = "List all organizations.\n\norganizations_get: GET /organizations"]
+    #[doc = "\n\norganizations_get: GET /organizations"]
     pub async fn organizations_get<'a>(
         &'a self,
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
-    ) -> Result<types::OrganizationResultsPage> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::OrganizationResultsPage>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!("{}/organizations", self.baseurl,);
         let mut query = Vec::new();
         if let Some(v) = &limit {
@@ -1331,21 +1442,34 @@ impl Client {
 
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List all organizations.\n\nreturns a Stream<Item = Organization> by making successive calls to organizations_get"]
+    #[doc = "\n\nreturns a Stream<Item = Organization> by making successive calls to organizations_get"]
     pub fn organizations_get_stream<'a>(
         &'a self,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::NameOrIdSortMode>,
-    ) -> impl futures::Stream<Item = Result<types::Organization>> + Unpin + '_ {
+    ) -> impl futures::Stream<
+        Item = Result<types::Organization, progenitor_client::Error<types::Error>>,
+    > + Unpin
+           + '_ {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
         self.organizations_get(limit, None, sort_by)
             .map_ok(move |page| {
+                let page = page.into_inner();
                 let first = futures::stream::iter(page.items.into_iter().map(Ok));
                 let rest = futures::stream::try_unfold(page.next_page, move |state| async move {
                     if state.is_none() {
@@ -1353,6 +1477,7 @@ impl Client {
                     } else {
                         self.organizations_get(None, state.as_deref(), None)
                             .map_ok(|page| {
+                                let page = page.into_inner();
                                 Some((
                                     futures::stream::iter(page.items.into_iter().map(Ok)),
                                     page.next_page,
@@ -1368,23 +1493,38 @@ impl Client {
             .boxed()
     }
 
-    #[doc = "Create a new organization.\n\norganizations_post: POST /organizations"]
+    #[doc = "\n\norganizations_post: POST /organizations"]
     pub async fn organizations_post<'a>(
         &'a self,
         body: &'a types::OrganizationCreate,
-    ) -> Result<types::Organization> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::Organization>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!("{}/organizations", self.baseurl,);
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "Fetch a specific organization\n\norganizations_get_organization: GET /organizations/{organization_name}"]
+    #[doc = "\n\norganizations_get_organization: GET /organizations/{organization_name}"]
     pub async fn organizations_get_organization<'a>(
         &'a self,
         organization_name: &'a types::Name,
-    ) -> Result<types::Organization> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::Organization>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!(
             "{}/organizations/{}",
             self.baseurl,
@@ -1392,16 +1532,28 @@ impl Client {
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "Update a specific organization.\n * TODO-correctness: Is it valid for PUT to accept application/json that's a subset of what the resource actually represents?  If not, is that a problem? (HTTP may require that this be idempotent.)  If so, can we get around that having this be a slightly different content-type (e.g., \"application/json-patch\")?  We should see what other APIs do.\n\norganizations_put_organization: PUT /organizations/{organization_name}"]
+    #[doc = "\n\norganizations_put_organization: PUT /organizations/{organization_name}"]
     pub async fn organizations_put_organization<'a>(
         &'a self,
         organization_name: &'a types::Name,
         body: &'a types::OrganizationUpdate,
-    ) -> Result<types::Organization> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::Organization>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!(
             "{}/organizations/{}",
             self.baseurl,
@@ -1409,15 +1561,24 @@ impl Client {
         );
         let request = self.client.put(url).json(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "Delete a specific organization.\n\norganizations_delete_organization: DELETE /organizations/{organization_name}"]
+    #[doc = "\n\norganizations_delete_organization: DELETE /organizations/{organization_name}"]
     pub async fn organizations_delete_organization<'a>(
         &'a self,
         organization_name: &'a types::Name,
-    ) -> Result<reqwest::Response> {
+    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}",
             self.baseurl,
@@ -1425,18 +1586,30 @@ impl Client {
         );
         let request = self.client.delete(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res)
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(progenitor_client::ResponseValue::empty(response)),
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List all projects.\n\norganization_projects_get: GET /organizations/{organization_name}/projects"]
+    #[doc = "\n\norganization_projects_get: GET /organizations/{organization_name}/projects"]
     pub async fn organization_projects_get<'a>(
         &'a self,
         organization_name: &'a types::Name,
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
-    ) -> Result<types::ProjectResultsPage> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::ProjectResultsPage>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!(
             "{}/organizations/{}/projects",
             self.baseurl,
@@ -1457,22 +1630,34 @@ impl Client {
 
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List all projects.\n\nreturns a Stream<Item = Project> by making successive calls to organization_projects_get"]
+    #[doc = "\n\nreturns a Stream<Item = Project> by making successive calls to organization_projects_get"]
     pub fn organization_projects_get_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::NameOrIdSortMode>,
-    ) -> impl futures::Stream<Item = Result<types::Project>> + Unpin + '_ {
+    ) -> impl futures::Stream<Item = Result<types::Project, progenitor_client::Error<types::Error>>>
+           + Unpin
+           + '_ {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
         self.organization_projects_get(organization_name, limit, None, sort_by)
             .map_ok(move |page| {
+                let page = page.into_inner();
                 let first = futures::stream::iter(page.items.into_iter().map(Ok));
                 let rest = futures::stream::try_unfold(page.next_page, move |state| async move {
                     if state.is_none() {
@@ -1485,6 +1670,7 @@ impl Client {
                             None,
                         )
                         .map_ok(|page| {
+                            let page = page.into_inner();
                             Some((
                                 futures::stream::iter(page.items.into_iter().map(Ok)),
                                 page.next_page,
@@ -1500,12 +1686,15 @@ impl Client {
             .boxed()
     }
 
-    #[doc = "Create a new project.\n\norganization_projects_post: POST /organizations/{organization_name}/projects"]
+    #[doc = "\n\norganization_projects_post: POST /organizations/{organization_name}/projects"]
     pub async fn organization_projects_post<'a>(
         &'a self,
         organization_name: &'a types::Name,
         body: &'a types::ProjectCreate,
-    ) -> Result<types::Project> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::Project>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!(
             "{}/organizations/{}/projects",
             self.baseurl,
@@ -1513,16 +1702,28 @@ impl Client {
         );
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "Fetch a specific project\n\norganization_projects_get_project: GET /organizations/{organization_name}/projects/{project_name}"]
+    #[doc = "\n\norganization_projects_get_project: GET /organizations/{organization_name}/projects/{project_name}"]
     pub async fn organization_projects_get_project<'a>(
         &'a self,
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
-    ) -> Result<types::Project> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::Project>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!(
             "{}/organizations/{}/projects/{}",
             self.baseurl,
@@ -1531,17 +1732,29 @@ impl Client {
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "Update a specific project.\n * TODO-correctness: Is it valid for PUT to accept application/json that's a subset of what the resource actually represents?  If not, is that a problem? (HTTP may require that this be idempotent.)  If so, can we get around that having this be a slightly different content-type (e.g., \"application/json-patch\")?  We should see what other APIs do.\n\norganization_projects_put_project: PUT /organizations/{organization_name}/projects/{project_name}"]
+    #[doc = "\n\norganization_projects_put_project: PUT /organizations/{organization_name}/projects/{project_name}"]
     pub async fn organization_projects_put_project<'a>(
         &'a self,
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         body: &'a types::ProjectUpdate,
-    ) -> Result<types::Project> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::Project>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!(
             "{}/organizations/{}/projects/{}",
             self.baseurl,
@@ -1550,16 +1763,25 @@ impl Client {
         );
         let request = self.client.put(url).json(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "Delete a specific project.\n\norganization_projects_delete_project: DELETE /organizations/{organization_name}/projects/{project_name}"]
+    #[doc = "\n\norganization_projects_delete_project: DELETE /organizations/{organization_name}/projects/{project_name}"]
     pub async fn organization_projects_delete_project<'a>(
         &'a self,
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
-    ) -> Result<reqwest::Response> {
+    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}",
             self.baseurl,
@@ -1568,11 +1790,20 @@ impl Client {
         );
         let request = self.client.delete(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res)
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(progenitor_client::ResponseValue::empty(response)),
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List disks in a project.\n\nproject_disks_get: GET /organizations/{organization_name}/projects/{project_name}/disks"]
+    #[doc = "\n\nproject_disks_get: GET /organizations/{organization_name}/projects/{project_name}/disks"]
     pub async fn project_disks_get<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -1580,7 +1811,10 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
-    ) -> Result<types::DiskResultsPage> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::DiskResultsPage>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!(
             "{}/organizations/{}/projects/{}/disks",
             self.baseurl,
@@ -1602,23 +1836,35 @@ impl Client {
 
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List disks in a project.\n\nreturns a Stream<Item = Disk> by making successive calls to project_disks_get"]
+    #[doc = "\n\nreturns a Stream<Item = Disk> by making successive calls to project_disks_get"]
     pub fn project_disks_get_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::NameSortMode>,
-    ) -> impl futures::Stream<Item = Result<types::Disk>> + Unpin + '_ {
+    ) -> impl futures::Stream<Item = Result<types::Disk, progenitor_client::Error<types::Error>>>
+           + Unpin
+           + '_ {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
         self.project_disks_get(organization_name, project_name, limit, None, sort_by)
             .map_ok(move |page| {
+                let page = page.into_inner();
                 let first = futures::stream::iter(page.items.into_iter().map(Ok));
                 let rest = futures::stream::try_unfold(page.next_page, move |state| async move {
                     if state.is_none() {
@@ -1632,6 +1878,7 @@ impl Client {
                             None,
                         )
                         .map_ok(|page| {
+                            let page = page.into_inner();
                             Some((
                                 futures::stream::iter(page.items.into_iter().map(Ok)),
                                 page.next_page,
@@ -1647,13 +1894,14 @@ impl Client {
             .boxed()
     }
 
-    #[doc = "Create a disk in a project.\n * TODO-correctness See note about instance create.  This should be async.\n\nproject_disks_post: POST /organizations/{organization_name}/projects/{project_name}/disks"]
+    #[doc = "\n\nproject_disks_post: POST /organizations/{organization_name}/projects/{project_name}/disks"]
     pub async fn project_disks_post<'a>(
         &'a self,
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         body: &'a types::DiskCreate,
-    ) -> Result<types::Disk> {
+    ) -> Result<progenitor_client::ResponseValue<types::Disk>, progenitor_client::Error<types::Error>>
+    {
         let url = format!(
             "{}/organizations/{}/projects/{}/disks",
             self.baseurl,
@@ -1662,17 +1910,27 @@ impl Client {
         );
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "Fetch a single disk in a project.\n\nproject_disks_get_disk: GET /organizations/{organization_name}/projects/{project_name}/disks/{disk_name}"]
+    #[doc = "\n\nproject_disks_get_disk: GET /organizations/{organization_name}/projects/{project_name}/disks/{disk_name}"]
     pub async fn project_disks_get_disk<'a>(
         &'a self,
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         disk_name: &'a types::Name,
-    ) -> Result<types::Disk> {
+    ) -> Result<progenitor_client::ResponseValue<types::Disk>, progenitor_client::Error<types::Error>>
+    {
         let url = format!(
             "{}/organizations/{}/projects/{}/disks/{}",
             self.baseurl,
@@ -1682,17 +1940,26 @@ impl Client {
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "Delete a disk from a project.\n\nproject_disks_delete_disk: DELETE /organizations/{organization_name}/projects/{project_name}/disks/{disk_name}"]
+    #[doc = "\n\nproject_disks_delete_disk: DELETE /organizations/{organization_name}/projects/{project_name}/disks/{disk_name}"]
     pub async fn project_disks_delete_disk<'a>(
         &'a self,
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         disk_name: &'a types::Name,
-    ) -> Result<reqwest::Response> {
+    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/disks/{}",
             self.baseurl,
@@ -1702,11 +1969,20 @@ impl Client {
         );
         let request = self.client.delete(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res)
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(progenitor_client::ResponseValue::empty(response)),
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List instances in a project.\n\nproject_instances_get: GET /organizations/{organization_name}/projects/{project_name}/instances"]
+    #[doc = "\n\nproject_instances_get: GET /organizations/{organization_name}/projects/{project_name}/instances"]
     pub async fn project_instances_get<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -1714,7 +1990,10 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
-    ) -> Result<types::InstanceResultsPage> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::InstanceResultsPage>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!(
             "{}/organizations/{}/projects/{}/instances",
             self.baseurl,
@@ -1736,23 +2015,35 @@ impl Client {
 
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List instances in a project.\n\nreturns a Stream<Item = Instance> by making successive calls to project_instances_get"]
+    #[doc = "\n\nreturns a Stream<Item = Instance> by making successive calls to project_instances_get"]
     pub fn project_instances_get_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::NameSortMode>,
-    ) -> impl futures::Stream<Item = Result<types::Instance>> + Unpin + '_ {
+    ) -> impl futures::Stream<Item = Result<types::Instance, progenitor_client::Error<types::Error>>>
+           + Unpin
+           + '_ {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
         self.project_instances_get(organization_name, project_name, limit, None, sort_by)
             .map_ok(move |page| {
+                let page = page.into_inner();
                 let first = futures::stream::iter(page.items.into_iter().map(Ok));
                 let rest = futures::stream::try_unfold(page.next_page, move |state| async move {
                     if state.is_none() {
@@ -1766,6 +2057,7 @@ impl Client {
                             None,
                         )
                         .map_ok(|page| {
+                            let page = page.into_inner();
                             Some((
                                 futures::stream::iter(page.items.into_iter().map(Ok)),
                                 page.next_page,
@@ -1781,13 +2073,16 @@ impl Client {
             .boxed()
     }
 
-    #[doc = "Create an instance in a project.\n * TODO-correctness This is supposed to be async.  Is that right?  We can create the instance immediately -- it's just not booted yet.  Maybe the boot operation is what's a separate operation_id.  What about the response code (201 Created vs 202 Accepted)?  Is that orthogonal?  Things can return a useful response, including an operation id, with either response code.  Maybe a \"reboot\" operation would return a 202 Accepted because there's no actual resource created?\n\nproject_instances_post: POST /organizations/{organization_name}/projects/{project_name}/instances"]
+    #[doc = "\n\nproject_instances_post: POST /organizations/{organization_name}/projects/{project_name}/instances"]
     pub async fn project_instances_post<'a>(
         &'a self,
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         body: &'a types::InstanceCreate,
-    ) -> Result<types::Instance> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::Instance>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!(
             "{}/organizations/{}/projects/{}/instances",
             self.baseurl,
@@ -1796,17 +2091,29 @@ impl Client {
         );
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "Get an instance in a project.\n\nproject_instances_get_instance: GET /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}"]
+    #[doc = "\n\nproject_instances_get_instance: GET /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}"]
     pub async fn project_instances_get_instance<'a>(
         &'a self,
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
-    ) -> Result<types::Instance> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::Instance>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}",
             self.baseurl,
@@ -1816,17 +2123,26 @@ impl Client {
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "Delete an instance from a project.\n\nproject_instances_delete_instance: DELETE /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}"]
+    #[doc = "\n\nproject_instances_delete_instance: DELETE /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}"]
     pub async fn project_instances_delete_instance<'a>(
         &'a self,
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
-    ) -> Result<reqwest::Response> {
+    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}",
             self.baseurl,
@@ -1836,11 +2152,20 @@ impl Client {
         );
         let request = self.client.delete(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res)
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(progenitor_client::ResponseValue::empty(response)),
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List disks attached to this instance.\n\ninstance_disks_get: GET /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks"]
+    #[doc = "\n\ninstance_disks_get: GET /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks"]
     pub async fn instance_disks_get<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -1849,7 +2174,10 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
-    ) -> Result<types::DiskResultsPage> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::DiskResultsPage>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/disks",
             self.baseurl,
@@ -1872,11 +2200,20 @@ impl Client {
 
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List disks attached to this instance.\n\nreturns a Stream<Item = Disk> by making successive calls to instance_disks_get"]
+    #[doc = "\n\nreturns a Stream<Item = Disk> by making successive calls to instance_disks_get"]
     pub fn instance_disks_get_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -1884,7 +2221,9 @@ impl Client {
         instance_name: &'a types::Name,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::NameSortMode>,
-    ) -> impl futures::Stream<Item = Result<types::Disk>> + Unpin + '_ {
+    ) -> impl futures::Stream<Item = Result<types::Disk, progenitor_client::Error<types::Error>>>
+           + Unpin
+           + '_ {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
@@ -1897,6 +2236,7 @@ impl Client {
             sort_by,
         )
         .map_ok(move |page| {
+            let page = page.into_inner();
             let first = futures::stream::iter(page.items.into_iter().map(Ok));
             let rest = futures::stream::try_unfold(page.next_page, move |state| async move {
                 if state.is_none() {
@@ -1911,6 +2251,7 @@ impl Client {
                         None,
                     )
                     .map_ok(|page| {
+                        let page = page.into_inner();
                         Some((
                             futures::stream::iter(page.items.into_iter().map(Ok)),
                             page.next_page,
@@ -1933,7 +2274,8 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
         body: &'a types::DiskIdentifier,
-    ) -> Result<types::Disk> {
+    ) -> Result<progenitor_client::ResponseValue<types::Disk>, progenitor_client::Error<types::Error>>
+    {
         let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/disks/attach",
             self.baseurl,
@@ -1943,8 +2285,17 @@ impl Client {
         );
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            202u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
     #[doc = "instance_disks_detach: POST /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks/detach"]
@@ -1954,7 +2305,8 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
         body: &'a types::DiskIdentifier,
-    ) -> Result<types::Disk> {
+    ) -> Result<progenitor_client::ResponseValue<types::Disk>, progenitor_client::Error<types::Error>>
+    {
         let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/disks/detach",
             self.baseurl,
@@ -1964,17 +2316,62 @@ impl Client {
         );
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            202u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "Reboot an instance.\n\nproject_instances_instance_reboot: POST /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/reboot"]
+    #[doc = "\n\nproject_instances_migrate_instance: POST /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/migrate"]
+    pub async fn project_instances_migrate_instance<'a>(
+        &'a self,
+        organization_name: &'a types::Name,
+        project_name: &'a types::Name,
+        instance_name: &'a types::Name,
+        body: &'a types::InstanceMigrate,
+    ) -> Result<
+        progenitor_client::ResponseValue<types::Instance>,
+        progenitor_client::Error<types::Error>,
+    > {
+        let url = format!(
+            "{}/organizations/{}/projects/{}/instances/{}/migrate",
+            self.baseurl,
+            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_support::encode_path(&instance_name.to_string()),
+        );
+        let request = self.client.post(url).json(body).build()?;
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
+    }
+
+    #[doc = "\n\nproject_instances_instance_reboot: POST /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/reboot"]
     pub async fn project_instances_instance_reboot<'a>(
         &'a self,
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
-    ) -> Result<types::Instance> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::Instance>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/reboot",
             self.baseurl,
@@ -1984,17 +2381,29 @@ impl Client {
         );
         let request = self.client.post(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            202u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "Boot an instance.\n\nproject_instances_instance_start: POST /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/start"]
+    #[doc = "\n\nproject_instances_instance_start: POST /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/start"]
     pub async fn project_instances_instance_start<'a>(
         &'a self,
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
-    ) -> Result<types::Instance> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::Instance>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/start",
             self.baseurl,
@@ -2004,17 +2413,29 @@ impl Client {
         );
         let request = self.client.post(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            202u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "Halt an instance.\n\nproject_instances_instance_stop: POST /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/stop"]
+    #[doc = "\n\nproject_instances_instance_stop: POST /organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/stop"]
     pub async fn project_instances_instance_stop<'a>(
         &'a self,
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
-    ) -> Result<types::Instance> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::Instance>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/stop",
             self.baseurl,
@@ -2024,11 +2445,20 @@ impl Client {
         );
         let request = self.client.post(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            202u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List VPCs in a project.\n\nproject_vpcs_get: GET /organizations/{organization_name}/projects/{project_name}/vpcs"]
+    #[doc = "\n\nproject_vpcs_get: GET /organizations/{organization_name}/projects/{project_name}/vpcs"]
     pub async fn project_vpcs_get<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -2036,7 +2466,10 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
-    ) -> Result<types::VpcResultsPage> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::VpcResultsPage>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs",
             self.baseurl,
@@ -2058,23 +2491,35 @@ impl Client {
 
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List VPCs in a project.\n\nreturns a Stream<Item = Vpc> by making successive calls to project_vpcs_get"]
+    #[doc = "\n\nreturns a Stream<Item = Vpc> by making successive calls to project_vpcs_get"]
     pub fn project_vpcs_get_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::NameSortMode>,
-    ) -> impl futures::Stream<Item = Result<types::Vpc>> + Unpin + '_ {
+    ) -> impl futures::Stream<Item = Result<types::Vpc, progenitor_client::Error<types::Error>>>
+           + Unpin
+           + '_ {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
         self.project_vpcs_get(organization_name, project_name, limit, None, sort_by)
             .map_ok(move |page| {
+                let page = page.into_inner();
                 let first = futures::stream::iter(page.items.into_iter().map(Ok));
                 let rest = futures::stream::try_unfold(page.next_page, move |state| async move {
                     if state.is_none() {
@@ -2088,6 +2533,7 @@ impl Client {
                             None,
                         )
                         .map_ok(|page| {
+                            let page = page.into_inner();
                             Some((
                                 futures::stream::iter(page.items.into_iter().map(Ok)),
                                 page.next_page,
@@ -2103,13 +2549,14 @@ impl Client {
             .boxed()
     }
 
-    #[doc = "Create a VPC in a project.\n\nproject_vpcs_post: POST /organizations/{organization_name}/projects/{project_name}/vpcs"]
+    #[doc = "\n\nproject_vpcs_post: POST /organizations/{organization_name}/projects/{project_name}/vpcs"]
     pub async fn project_vpcs_post<'a>(
         &'a self,
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         body: &'a types::VpcCreate,
-    ) -> Result<types::Vpc> {
+    ) -> Result<progenitor_client::ResponseValue<types::Vpc>, progenitor_client::Error<types::Error>>
+    {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs",
             self.baseurl,
@@ -2118,17 +2565,27 @@ impl Client {
         );
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "Get a VPC in a project.\n\nproject_vpcs_get_vpc: GET /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}"]
+    #[doc = "\n\nproject_vpcs_get_vpc: GET /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}"]
     pub async fn project_vpcs_get_vpc<'a>(
         &'a self,
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
-    ) -> Result<types::Vpc> {
+    ) -> Result<progenitor_client::ResponseValue<types::Vpc>, progenitor_client::Error<types::Error>>
+    {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}",
             self.baseurl,
@@ -2138,18 +2595,27 @@ impl Client {
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "Update a VPC.\n\nproject_vpcs_put_vpc: PUT /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}"]
+    #[doc = "\n\nproject_vpcs_put_vpc: PUT /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}"]
     pub async fn project_vpcs_put_vpc<'a>(
         &'a self,
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
         body: &'a types::VpcUpdate,
-    ) -> Result<reqwest::Response> {
+    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}",
             self.baseurl,
@@ -2159,17 +2625,26 @@ impl Client {
         );
         let request = self.client.put(url).json(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res)
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(progenitor_client::ResponseValue::empty(response)),
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "Delete a vpc from a project.\n\nproject_vpcs_delete_vpc: DELETE /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}"]
+    #[doc = "\n\nproject_vpcs_delete_vpc: DELETE /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}"]
     pub async fn project_vpcs_delete_vpc<'a>(
         &'a self,
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
-    ) -> Result<reqwest::Response> {
+    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}",
             self.baseurl,
@@ -2179,11 +2654,20 @@ impl Client {
         );
         let request = self.client.delete(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res)
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(progenitor_client::ResponseValue::empty(response)),
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List firewall rules for a VPC.\n\nvpc_firewall_rules_get: GET /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/firewall/rules"]
+    #[doc = "\n\nvpc_firewall_rules_get: GET /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/firewall/rules"]
     pub async fn vpc_firewall_rules_get<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -2192,7 +2676,10 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
-    ) -> Result<types::VpcFirewallRuleResultsPage> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::VpcFirewallRuleResultsPage>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
             self.baseurl,
@@ -2215,11 +2702,20 @@ impl Client {
 
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List firewall rules for a VPC.\n\nreturns a Stream<Item = VpcFirewallRule> by making successive calls to vpc_firewall_rules_get"]
+    #[doc = "\n\nreturns a Stream<Item = VpcFirewallRule> by making successive calls to vpc_firewall_rules_get"]
     pub fn vpc_firewall_rules_get_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -2227,7 +2723,10 @@ impl Client {
         vpc_name: &'a types::Name,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::NameSortMode>,
-    ) -> impl futures::Stream<Item = Result<types::VpcFirewallRule>> + Unpin + '_ {
+    ) -> impl futures::Stream<
+        Item = Result<types::VpcFirewallRule, progenitor_client::Error<types::Error>>,
+    > + Unpin
+           + '_ {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
@@ -2240,6 +2739,7 @@ impl Client {
             sort_by,
         )
         .map_ok(move |page| {
+            let page = page.into_inner();
             let first = futures::stream::iter(page.items.into_iter().map(Ok));
             let rest = futures::stream::try_unfold(page.next_page, move |state| async move {
                 if state.is_none() {
@@ -2254,6 +2754,7 @@ impl Client {
                         None,
                     )
                     .map_ok(|page| {
+                        let page = page.into_inner();
                         Some((
                             futures::stream::iter(page.items.into_iter().map(Ok)),
                             page.next_page,
@@ -2269,14 +2770,17 @@ impl Client {
         .boxed()
     }
 
-    #[doc = "Replace the firewall rules for a VPC\n\nvpc_firewall_rules_put: PUT /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/firewall/rules"]
+    #[doc = "\n\nvpc_firewall_rules_put: PUT /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/firewall/rules"]
     pub async fn vpc_firewall_rules_put<'a>(
         &'a self,
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
         body: &'a types::VpcFirewallRuleUpdateParams,
-    ) -> Result<types::VpcFirewallRuleUpdateResult> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::VpcFirewallRuleUpdateResult>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
             self.baseurl,
@@ -2286,11 +2790,20 @@ impl Client {
         );
         let request = self.client.put(url).json(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List VPC Custom and System Routers\n\nvpc_routers_get: GET /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers"]
+    #[doc = "\n\nvpc_routers_get: GET /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers"]
     pub async fn vpc_routers_get<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -2299,7 +2812,10 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
-    ) -> Result<types::VpcRouterResultsPage> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::VpcRouterResultsPage>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers",
             self.baseurl,
@@ -2322,11 +2838,20 @@ impl Client {
 
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List VPC Custom and System Routers\n\nreturns a Stream<Item = VpcRouter> by making successive calls to vpc_routers_get"]
+    #[doc = "\n\nreturns a Stream<Item = VpcRouter> by making successive calls to vpc_routers_get"]
     pub fn vpc_routers_get_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -2334,7 +2859,9 @@ impl Client {
         vpc_name: &'a types::Name,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::NameSortMode>,
-    ) -> impl futures::Stream<Item = Result<types::VpcRouter>> + Unpin + '_ {
+    ) -> impl futures::Stream<Item = Result<types::VpcRouter, progenitor_client::Error<types::Error>>>
+           + Unpin
+           + '_ {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
@@ -2347,6 +2874,7 @@ impl Client {
             sort_by,
         )
         .map_ok(move |page| {
+            let page = page.into_inner();
             let first = futures::stream::iter(page.items.into_iter().map(Ok));
             let rest = futures::stream::try_unfold(page.next_page, move |state| async move {
                 if state.is_none() {
@@ -2361,6 +2889,7 @@ impl Client {
                         None,
                     )
                     .map_ok(|page| {
+                        let page = page.into_inner();
                         Some((
                             futures::stream::iter(page.items.into_iter().map(Ok)),
                             page.next_page,
@@ -2376,14 +2905,17 @@ impl Client {
         .boxed()
     }
 
-    #[doc = "Create a VPC Router\n\nvpc_routers_post: POST /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers"]
+    #[doc = "\n\nvpc_routers_post: POST /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers"]
     pub async fn vpc_routers_post<'a>(
         &'a self,
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
         body: &'a types::VpcRouterCreate,
-    ) -> Result<types::VpcRouter> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::VpcRouter>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers",
             self.baseurl,
@@ -2393,18 +2925,30 @@ impl Client {
         );
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "Get a VPC Router\n\nvpc_routers_get_router: GET /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}"]
+    #[doc = "\n\nvpc_routers_get_router: GET /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}"]
     pub async fn vpc_routers_get_router<'a>(
         &'a self,
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
         router_name: &'a types::Name,
-    ) -> Result<types::VpcRouter> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::VpcRouter>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
             self.baseurl,
@@ -2415,11 +2959,20 @@ impl Client {
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "Update a VPC Router\n\nvpc_routers_put_router: PUT /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}"]
+    #[doc = "\n\nvpc_routers_put_router: PUT /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}"]
     pub async fn vpc_routers_put_router<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -2427,7 +2980,7 @@ impl Client {
         vpc_name: &'a types::Name,
         router_name: &'a types::Name,
         body: &'a types::VpcRouterUpdate,
-    ) -> Result<reqwest::Response> {
+    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
             self.baseurl,
@@ -2438,18 +2991,27 @@ impl Client {
         );
         let request = self.client.put(url).json(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res)
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(progenitor_client::ResponseValue::empty(response)),
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "Delete a router from its VPC\n\nvpc_routers_delete_router: DELETE /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}"]
+    #[doc = "\n\nvpc_routers_delete_router: DELETE /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}"]
     pub async fn vpc_routers_delete_router<'a>(
         &'a self,
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
         router_name: &'a types::Name,
-    ) -> Result<reqwest::Response> {
+    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
             self.baseurl,
@@ -2460,11 +3022,20 @@ impl Client {
         );
         let request = self.client.delete(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res)
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(progenitor_client::ResponseValue::empty(response)),
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List a Router's routes\n\nrouters_routes_get: GET /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes"]
+    #[doc = "\n\nrouters_routes_get: GET /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes"]
     pub async fn routers_routes_get<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -2474,7 +3045,10 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
-    ) -> Result<types::RouterRouteResultsPage> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::RouterRouteResultsPage>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
             self.baseurl,
@@ -2498,11 +3072,20 @@ impl Client {
 
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List a Router's routes\n\nreturns a Stream<Item = RouterRoute> by making successive calls to routers_routes_get"]
+    #[doc = "\n\nreturns a Stream<Item = RouterRoute> by making successive calls to routers_routes_get"]
     pub fn routers_routes_get_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -2511,7 +3094,10 @@ impl Client {
         router_name: &'a types::Name,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::NameSortMode>,
-    ) -> impl futures::Stream<Item = Result<types::RouterRoute>> + Unpin + '_ {
+    ) -> impl futures::Stream<
+        Item = Result<types::RouterRoute, progenitor_client::Error<types::Error>>,
+    > + Unpin
+           + '_ {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
@@ -2525,6 +3111,7 @@ impl Client {
             sort_by,
         )
         .map_ok(move |page| {
+            let page = page.into_inner();
             let first = futures::stream::iter(page.items.into_iter().map(Ok));
             let rest = futures::stream::try_unfold(page.next_page, move |state| async move {
                 if state.is_none() {
@@ -2540,6 +3127,7 @@ impl Client {
                         None,
                     )
                     .map_ok(|page| {
+                        let page = page.into_inner();
                         Some((
                             futures::stream::iter(page.items.into_iter().map(Ok)),
                             page.next_page,
@@ -2555,7 +3143,7 @@ impl Client {
         .boxed()
     }
 
-    #[doc = "Create a VPC Router\n\nrouters_routes_post: POST /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes"]
+    #[doc = "\n\nrouters_routes_post: POST /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes"]
     pub async fn routers_routes_post<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -2563,7 +3151,10 @@ impl Client {
         vpc_name: &'a types::Name,
         router_name: &'a types::Name,
         body: &'a types::RouterRouteCreateParams,
-    ) -> Result<types::RouterRoute> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::RouterRoute>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
             self.baseurl,
@@ -2574,11 +3165,20 @@ impl Client {
         );
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "Get a VPC Router route\n\nrouters_routes_get_route: GET /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes/{route_name}"]
+    #[doc = "\n\nrouters_routes_get_route: GET /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes/{route_name}"]
     pub async fn routers_routes_get_route<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -2586,7 +3186,10 @@ impl Client {
         vpc_name: &'a types::Name,
         router_name: &'a types::Name,
         route_name: &'a types::Name,
-    ) -> Result<types::RouterRoute> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::RouterRoute>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
             self.baseurl,
@@ -2598,11 +3201,20 @@ impl Client {
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "Update a Router route\n\nrouters_routes_put_route: PUT /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes/{route_name}"]
+    #[doc = "\n\nrouters_routes_put_route: PUT /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes/{route_name}"]
     pub async fn routers_routes_put_route<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -2611,7 +3223,7 @@ impl Client {
         router_name: &'a types::Name,
         route_name: &'a types::Name,
         body: &'a types::RouterRouteUpdateParams,
-    ) -> Result<reqwest::Response> {
+    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
             self.baseurl,
@@ -2623,11 +3235,20 @@ impl Client {
         );
         let request = self.client.put(url).json(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res)
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(progenitor_client::ResponseValue::empty(response)),
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "Delete a route from its router\n\nrouters_routes_delete_route: DELETE /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes/{route_name}"]
+    #[doc = "\n\nrouters_routes_delete_route: DELETE /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes/{route_name}"]
     pub async fn routers_routes_delete_route<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -2635,7 +3256,7 @@ impl Client {
         vpc_name: &'a types::Name,
         router_name: &'a types::Name,
         route_name: &'a types::Name,
-    ) -> Result<reqwest::Response> {
+    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
             self.baseurl,
@@ -2647,11 +3268,20 @@ impl Client {
         );
         let request = self.client.delete(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res)
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(progenitor_client::ResponseValue::empty(response)),
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List subnets in a VPC.\n\nvpc_subnets_get: GET /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets"]
+    #[doc = "\n\nvpc_subnets_get: GET /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets"]
     pub async fn vpc_subnets_get<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -2660,7 +3290,10 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
-    ) -> Result<types::VpcSubnetResultsPage> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::VpcSubnetResultsPage>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
             self.baseurl,
@@ -2683,11 +3316,20 @@ impl Client {
 
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List subnets in a VPC.\n\nreturns a Stream<Item = VpcSubnet> by making successive calls to vpc_subnets_get"]
+    #[doc = "\n\nreturns a Stream<Item = VpcSubnet> by making successive calls to vpc_subnets_get"]
     pub fn vpc_subnets_get_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -2695,7 +3337,9 @@ impl Client {
         vpc_name: &'a types::Name,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::NameSortMode>,
-    ) -> impl futures::Stream<Item = Result<types::VpcSubnet>> + Unpin + '_ {
+    ) -> impl futures::Stream<Item = Result<types::VpcSubnet, progenitor_client::Error<types::Error>>>
+           + Unpin
+           + '_ {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
@@ -2708,6 +3352,7 @@ impl Client {
             sort_by,
         )
         .map_ok(move |page| {
+            let page = page.into_inner();
             let first = futures::stream::iter(page.items.into_iter().map(Ok));
             let rest = futures::stream::try_unfold(page.next_page, move |state| async move {
                 if state.is_none() {
@@ -2722,6 +3367,7 @@ impl Client {
                         None,
                     )
                     .map_ok(|page| {
+                        let page = page.into_inner();
                         Some((
                             futures::stream::iter(page.items.into_iter().map(Ok)),
                             page.next_page,
@@ -2737,14 +3383,17 @@ impl Client {
         .boxed()
     }
 
-    #[doc = "Create a subnet in a VPC.\n\nvpc_subnets_post: POST /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets"]
+    #[doc = "\n\nvpc_subnets_post: POST /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets"]
     pub async fn vpc_subnets_post<'a>(
         &'a self,
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
         body: &'a types::VpcSubnetCreate,
-    ) -> Result<types::VpcSubnet> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::VpcSubnet>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
             self.baseurl,
@@ -2754,18 +3403,30 @@ impl Client {
         );
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "Get subnet in a VPC.\n\nvpc_subnets_get_subnet: GET /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}"]
+    #[doc = "\n\nvpc_subnets_get_subnet: GET /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}"]
     pub async fn vpc_subnets_get_subnet<'a>(
         &'a self,
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
         subnet_name: &'a types::Name,
-    ) -> Result<types::VpcSubnet> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::VpcSubnet>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
             self.baseurl,
@@ -2776,11 +3437,20 @@ impl Client {
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "Update a VPC Subnet.\n\nvpc_subnets_put_subnet: PUT /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}"]
+    #[doc = "\n\nvpc_subnets_put_subnet: PUT /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}"]
     pub async fn vpc_subnets_put_subnet<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -2788,7 +3458,7 @@ impl Client {
         vpc_name: &'a types::Name,
         subnet_name: &'a types::Name,
         body: &'a types::VpcSubnetUpdate,
-    ) -> Result<reqwest::Response> {
+    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
             self.baseurl,
@@ -2799,18 +3469,27 @@ impl Client {
         );
         let request = self.client.put(url).json(body).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res)
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(progenitor_client::ResponseValue::empty(response)),
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "Delete a subnet from a VPC.\n\nvpc_subnets_delete_subnet: DELETE /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}"]
+    #[doc = "\n\nvpc_subnets_delete_subnet: DELETE /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}"]
     pub async fn vpc_subnets_delete_subnet<'a>(
         &'a self,
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
         subnet_name: &'a types::Name,
-    ) -> Result<reqwest::Response> {
+    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
             self.baseurl,
@@ -2821,11 +3500,20 @@ impl Client {
         );
         let request = self.client.delete(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res)
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(progenitor_client::ResponseValue::empty(response)),
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List IP addresses on a VPC subnet.\n\nsubnets_ips_get: GET /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}/ips"]
+    #[doc = "\n\nsubnets_ips_get: GET /organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}/ips"]
     pub async fn subnets_ips_get<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -2835,7 +3523,10 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
-    ) -> Result<types::NetworkInterfaceResultsPage> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::NetworkInterfaceResultsPage>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}/ips",
             self.baseurl,
@@ -2859,11 +3550,20 @@ impl Client {
 
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List IP addresses on a VPC subnet.\n\nreturns a Stream<Item = NetworkInterface> by making successive calls to subnets_ips_get"]
+    #[doc = "\n\nreturns a Stream<Item = NetworkInterface> by making successive calls to subnets_ips_get"]
     pub fn subnets_ips_get_stream<'a>(
         &'a self,
         organization_name: &'a types::Name,
@@ -2872,7 +3572,10 @@ impl Client {
         subnet_name: &'a types::Name,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::NameSortMode>,
-    ) -> impl futures::Stream<Item = Result<types::NetworkInterface>> + Unpin + '_ {
+    ) -> impl futures::Stream<
+        Item = Result<types::NetworkInterface, progenitor_client::Error<types::Error>>,
+    > + Unpin
+           + '_ {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
@@ -2886,6 +3589,7 @@ impl Client {
             sort_by,
         )
         .map_ok(move |page| {
+            let page = page.into_inner();
             let first = futures::stream::iter(page.items.into_iter().map(Ok));
             let rest = futures::stream::try_unfold(page.next_page, move |state| async move {
                 if state.is_none() {
@@ -2901,6 +3605,7 @@ impl Client {
                         None,
                     )
                     .map_ok(|page| {
+                        let page = page.into_inner();
                         Some((
                             futures::stream::iter(page.items.into_iter().map(Ok)),
                             page.next_page,
@@ -2916,12 +3621,15 @@ impl Client {
         .boxed()
     }
 
-    #[doc = "List the built-in roles\n\nroles_get: GET /roles"]
+    #[doc = "\n\nroles_get: GET /roles"]
     pub async fn roles_get<'a>(
         &'a self,
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
-    ) -> Result<types::RoleResultsPage> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::RoleResultsPage>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!("{}/roles", self.baseurl,);
         let mut query = Vec::new();
         if let Some(v) = &limit {
@@ -2934,20 +3642,32 @@ impl Client {
 
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List the built-in roles\n\nreturns a Stream<Item = Role> by making successive calls to roles_get"]
+    #[doc = "\n\nreturns a Stream<Item = Role> by making successive calls to roles_get"]
     pub fn roles_get_stream<'a>(
         &'a self,
         limit: Option<std::num::NonZeroU32>,
-    ) -> impl futures::Stream<Item = Result<types::Role>> + Unpin + '_ {
+    ) -> impl futures::Stream<Item = Result<types::Role, progenitor_client::Error<types::Error>>>
+           + Unpin
+           + '_ {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
         self.roles_get(limit, None)
             .map_ok(move |page| {
+                let page = page.into_inner();
                 let first = futures::stream::iter(page.items.into_iter().map(Ok));
                 let rest = futures::stream::try_unfold(page.next_page, move |state| async move {
                     if state.is_none() {
@@ -2955,6 +3675,7 @@ impl Client {
                     } else {
                         self.roles_get(None, state.as_deref())
                             .map_ok(|page| {
+                                let page = page.into_inner();
                                 Some((
                                     futures::stream::iter(page.items.into_iter().map(Ok)),
                                     page.next_page,
@@ -2970,8 +3691,12 @@ impl Client {
             .boxed()
     }
 
-    #[doc = "Fetch a specific built-in role\n\nroles_get_role: GET /roles/{role_name}"]
-    pub async fn roles_get_role<'a>(&'a self, role_name: &'a str) -> Result<types::Role> {
+    #[doc = "\n\nroles_get_role: GET /roles/{role_name}"]
+    pub async fn roles_get_role<'a>(
+        &'a self,
+        role_name: &'a str,
+    ) -> Result<progenitor_client::ResponseValue<types::Role>, progenitor_client::Error<types::Error>>
+    {
         let url = format!(
             "{}/roles/{}",
             self.baseurl,
@@ -2979,17 +3704,29 @@ impl Client {
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List all sagas (for debugging)\n\nsagas_get: GET /sagas"]
+    #[doc = "\n\nsagas_get: GET /sagas"]
     pub async fn sagas_get<'a>(
         &'a self,
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
-    ) -> Result<types::SagaResultsPage> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::SagaResultsPage>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!("{}/sagas", self.baseurl,);
         let mut query = Vec::new();
         if let Some(v) = &limit {
@@ -3006,21 +3743,33 @@ impl Client {
 
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List all sagas (for debugging)\n\nreturns a Stream<Item = Saga> by making successive calls to sagas_get"]
+    #[doc = "\n\nreturns a Stream<Item = Saga> by making successive calls to sagas_get"]
     pub fn sagas_get_stream<'a>(
         &'a self,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::IdSortMode>,
-    ) -> impl futures::Stream<Item = Result<types::Saga>> + Unpin + '_ {
+    ) -> impl futures::Stream<Item = Result<types::Saga, progenitor_client::Error<types::Error>>>
+           + Unpin
+           + '_ {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
         self.sagas_get(limit, None, sort_by)
             .map_ok(move |page| {
+                let page = page.into_inner();
                 let first = futures::stream::iter(page.items.into_iter().map(Ok));
                 let rest = futures::stream::try_unfold(page.next_page, move |state| async move {
                     if state.is_none() {
@@ -3028,6 +3777,7 @@ impl Client {
                     } else {
                         self.sagas_get(None, state.as_deref(), None)
                             .map_ok(|page| {
+                                let page = page.into_inner();
                                 Some((
                                     futures::stream::iter(page.items.into_iter().map(Ok)),
                                     page.next_page,
@@ -3043,8 +3793,12 @@ impl Client {
             .boxed()
     }
 
-    #[doc = "Fetch information about a single saga (for debugging)\n\nsagas_get_saga: GET /sagas/{saga_id}"]
-    pub async fn sagas_get_saga<'a>(&'a self, saga_id: &'a uuid::Uuid) -> Result<types::Saga> {
+    #[doc = "\n\nsagas_get_saga: GET /sagas/{saga_id}"]
+    pub async fn sagas_get_saga<'a>(
+        &'a self,
+        saga_id: &'a uuid::Uuid,
+    ) -> Result<progenitor_client::ResponseValue<types::Saga>, progenitor_client::Error<types::Error>>
+    {
         let url = format!(
             "{}/sagas/{}",
             self.baseurl,
@@ -3052,16 +3806,51 @@ impl Client {
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List all timeseries schema\n\ntimeseries_schema_get: GET /timeseries/schema"]
+    #[doc = "session_me: GET /session/me"]
+    pub async fn session_me<'a>(
+        &'a self,
+    ) -> Result<
+        progenitor_client::ResponseValue<types::SessionUser>,
+        progenitor_client::Error<types::Error>,
+    > {
+        let url = format!("{}/session/me", self.baseurl,);
+        let request = self.client.get(url).build()?;
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
+    }
+
+    #[doc = "\n\ntimeseries_schema_get: GET /timeseries/schema"]
     pub async fn timeseries_schema_get<'a>(
         &'a self,
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
-    ) -> Result<types::TimeseriesSchemaResultsPage> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::TimeseriesSchemaResultsPage>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!("{}/timeseries/schema", self.baseurl,);
         let mut query = Vec::new();
         if let Some(v) = &limit {
@@ -3074,20 +3863,33 @@ impl Client {
 
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List all timeseries schema\n\nreturns a Stream<Item = TimeseriesSchema> by making successive calls to timeseries_schema_get"]
+    #[doc = "\n\nreturns a Stream<Item = TimeseriesSchema> by making successive calls to timeseries_schema_get"]
     pub fn timeseries_schema_get_stream<'a>(
         &'a self,
         limit: Option<std::num::NonZeroU32>,
-    ) -> impl futures::Stream<Item = Result<types::TimeseriesSchema>> + Unpin + '_ {
+    ) -> impl futures::Stream<
+        Item = Result<types::TimeseriesSchema, progenitor_client::Error<types::Error>>,
+    > + Unpin
+           + '_ {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
         self.timeseries_schema_get(limit, None)
             .map_ok(move |page| {
+                let page = page.into_inner();
                 let first = futures::stream::iter(page.items.into_iter().map(Ok));
                 let rest = futures::stream::try_unfold(page.next_page, move |state| async move {
                     if state.is_none() {
@@ -3095,6 +3897,7 @@ impl Client {
                     } else {
                         self.timeseries_schema_get(None, state.as_deref())
                             .map_ok(|page| {
+                                let page = page.into_inner();
                                 Some((
                                     futures::stream::iter(page.items.into_iter().map(Ok)),
                                     page.next_page,
@@ -3110,13 +3913,16 @@ impl Client {
             .boxed()
     }
 
-    #[doc = "List the built-in system users\n\nusers_get: GET /users"]
+    #[doc = "\n\nusers_get: GET /users"]
     pub async fn users_get<'a>(
         &'a self,
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
-    ) -> Result<types::UserResultsPage> {
+    ) -> Result<
+        progenitor_client::ResponseValue<types::UserResultsPage>,
+        progenitor_client::Error<types::Error>,
+    > {
         let url = format!("{}/users", self.baseurl,);
         let mut query = Vec::new();
         if let Some(v) = &limit {
@@ -3133,21 +3939,33 @@ impl Client {
 
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 
-    #[doc = "List the built-in system users\n\nreturns a Stream<Item = User> by making successive calls to users_get"]
+    #[doc = "\n\nreturns a Stream<Item = User> by making successive calls to users_get"]
     pub fn users_get_stream<'a>(
         &'a self,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::NameSortMode>,
-    ) -> impl futures::Stream<Item = Result<types::User>> + Unpin + '_ {
+    ) -> impl futures::Stream<Item = Result<types::User, progenitor_client::Error<types::Error>>>
+           + Unpin
+           + '_ {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
         self.users_get(limit, None, sort_by)
             .map_ok(move |page| {
+                let page = page.into_inner();
                 let first = futures::stream::iter(page.items.into_iter().map(Ok));
                 let rest = futures::stream::try_unfold(page.next_page, move |state| async move {
                     if state.is_none() {
@@ -3155,6 +3973,7 @@ impl Client {
                     } else {
                         self.users_get(None, state.as_deref(), None)
                             .map_ok(|page| {
+                                let page = page.into_inner();
                                 Some((
                                     futures::stream::iter(page.items.into_iter().map(Ok)),
                                     page.next_page,
@@ -3170,8 +3989,12 @@ impl Client {
             .boxed()
     }
 
-    #[doc = "Fetch a specific built-in system user\n\nusers_get_user: GET /users/{user_name}"]
-    pub async fn users_get_user<'a>(&'a self, user_name: &'a types::Name) -> Result<types::User> {
+    #[doc = "\n\nusers_get_user: GET /users/{user_name}"]
+    pub async fn users_get_user<'a>(
+        &'a self,
+        user_name: &'a types::Name,
+    ) -> Result<progenitor_client::ResponseValue<types::User>, progenitor_client::Error<types::Error>>
+    {
         let url = format!(
             "{}/users/{}",
             self.baseurl,
@@ -3179,7 +4002,16 @@ impl Client {
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
-        let res = result?.error_for_status()?;
-        Ok(res.json().await?)
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => progenitor_client::ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
+                progenitor_client::ResponseValue::from_response(response).await?,
+            )),
+            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+        }
     }
 }

--- a/progenitor-impl/tests/output/nexus.out
+++ b/progenitor-impl/tests/output/nexus.out
@@ -1,24 +1,4 @@
-pub use progenitor_client::Error;
-pub use progenitor_client::ResponseValue;
-mod progenitor_support {
-    use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
-    #[allow(dead_code)]
-    const PATH_SET: &AsciiSet = &CONTROLS
-        .add(b' ')
-        .add(b'"')
-        .add(b'#')
-        .add(b'<')
-        .add(b'>')
-        .add(b'?')
-        .add(b'`')
-        .add(b'{')
-        .add(b'}');
-    #[allow(dead_code)]
-    pub(crate) fn encode_path(pc: &str) -> String {
-        utf8_percent_encode(pc, PATH_SET).to_string()
-    }
-}
-
+pub use progenitor_client::{Error, ResponseValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[doc = "A count of bytes, typically used either for memory or storage capacity\n\nThe maximum supported byte count is [`i64::MAX`].  This makes it somewhat inconvenient to define constructors: a u32 constructor can be infallible, but an i64 constructor can fail (if the value is negative) and a u64 constructor can fail (if the value is larger than i64::MAX).  We provide all of these for consumers' convenience."]
@@ -1185,10 +1165,7 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::RackResultsPage>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::RackResultsPage>, Error<types::Error>> {
         let url = format!("{}/hardware/racks", self.baseurl,);
         let mut query = Vec::new();
         if let Some(v) = &limit {
@@ -1207,14 +1184,14 @@ impl Client {
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -1223,9 +1200,7 @@ impl Client {
         &'a self,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::IdSortMode>,
-    ) -> impl futures::Stream<Item = Result<types::Rack, progenitor_client::Error<types::Error>>>
-           + Unpin
-           + '_ {
+    ) -> impl futures::Stream<Item = Result<types::Rack, Error<types::Error>>> + Unpin + '_ {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
@@ -1259,25 +1234,24 @@ impl Client {
     pub async fn hardware_racks_get_rack<'a>(
         &'a self,
         rack_id: &'a uuid::Uuid,
-    ) -> Result<progenitor_client::ResponseValue<types::Rack>, progenitor_client::Error<types::Error>>
-    {
+    ) -> Result<ResponseValue<types::Rack>, Error<types::Error>> {
         let url = format!(
             "{}/hardware/racks/{}",
             self.baseurl,
-            progenitor_support::encode_path(&rack_id.to_string()),
+            progenitor_client::encode_path(&rack_id.to_string()),
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -1287,10 +1261,7 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::SledResultsPage>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::SledResultsPage>, Error<types::Error>> {
         let url = format!("{}/hardware/sleds", self.baseurl,);
         let mut query = Vec::new();
         if let Some(v) = &limit {
@@ -1309,14 +1280,14 @@ impl Client {
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -1325,9 +1296,7 @@ impl Client {
         &'a self,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::IdSortMode>,
-    ) -> impl futures::Stream<Item = Result<types::Sled, progenitor_client::Error<types::Error>>>
-           + Unpin
-           + '_ {
+    ) -> impl futures::Stream<Item = Result<types::Sled, Error<types::Error>>> + Unpin + '_ {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
@@ -1361,25 +1330,24 @@ impl Client {
     pub async fn hardware_sleds_get_sled<'a>(
         &'a self,
         sled_id: &'a uuid::Uuid,
-    ) -> Result<progenitor_client::ResponseValue<types::Sled>, progenitor_client::Error<types::Error>>
-    {
+    ) -> Result<ResponseValue<types::Sled>, Error<types::Error>> {
         let url = format!(
             "{}/hardware/sleds/{}",
             self.baseurl,
-            progenitor_support::encode_path(&sled_id.to_string()),
+            progenitor_client::encode_path(&sled_id.to_string()),
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -1387,32 +1355,26 @@ impl Client {
     pub async fn spoof_login<'a>(
         &'a self,
         body: &'a types::LoginParams,
-    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<()>> {
+    ) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/login", self.baseurl,);
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200..=299 => Ok(progenitor_client::ResponseValue::empty(response)),
-            _ => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::empty(response),
-            )),
+            200..=299 => Ok(ResponseValue::empty(response)),
+            _ => Err(Error::ErrorResponse(ResponseValue::empty(response))),
         }
     }
 
     #[doc = "logout: POST /logout"]
-    pub async fn logout<'a>(
-        &'a self,
-    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<()>> {
+    pub async fn logout<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/logout", self.baseurl,);
         let request = self.client.post(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200..=299 => Ok(progenitor_client::ResponseValue::empty(response)),
-            _ => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::empty(response),
-            )),
+            200..=299 => Ok(ResponseValue::empty(response)),
+            _ => Err(Error::ErrorResponse(ResponseValue::empty(response))),
         }
     }
 
@@ -1422,10 +1384,7 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::OrganizationResultsPage>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
         let url = format!("{}/organizations", self.baseurl,);
         let mut query = Vec::new();
         if let Some(v) = &limit {
@@ -1444,14 +1403,14 @@ impl Client {
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -1460,10 +1419,8 @@ impl Client {
         &'a self,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::NameOrIdSortMode>,
-    ) -> impl futures::Stream<
-        Item = Result<types::Organization, progenitor_client::Error<types::Error>>,
-    > + Unpin
-           + '_ {
+    ) -> impl futures::Stream<Item = Result<types::Organization, Error<types::Error>>> + Unpin + '_
+    {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
@@ -1497,23 +1454,20 @@ impl Client {
     pub async fn organizations_post<'a>(
         &'a self,
         body: &'a types::OrganizationCreate,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::Organization>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
         let url = format!("{}/organizations", self.baseurl,);
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            201u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            201u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -1521,27 +1475,24 @@ impl Client {
     pub async fn organizations_get_organization<'a>(
         &'a self,
         organization_name: &'a types::Name,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::Organization>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -1550,27 +1501,24 @@ impl Client {
         &'a self,
         organization_name: &'a types::Name,
         body: &'a types::OrganizationUpdate,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::Organization>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
         );
         let request = self.client.put(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -1578,24 +1526,24 @@ impl Client {
     pub async fn organizations_delete_organization<'a>(
         &'a self,
         organization_name: &'a types::Name,
-    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<types::Error>> {
+    ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
         );
         let request = self.client.delete(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(progenitor_client::ResponseValue::empty(response)),
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            204u16 => Ok(ResponseValue::empty(response)),
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -1606,14 +1554,11 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::ProjectResultsPage>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
         );
         let mut query = Vec::new();
         if let Some(v) = &limit {
@@ -1632,14 +1577,14 @@ impl Client {
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -1649,9 +1594,7 @@ impl Client {
         organization_name: &'a types::Name,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::NameOrIdSortMode>,
-    ) -> impl futures::Stream<Item = Result<types::Project, progenitor_client::Error<types::Error>>>
-           + Unpin
-           + '_ {
+    ) -> impl futures::Stream<Item = Result<types::Project, Error<types::Error>>> + Unpin + '_ {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
@@ -1691,27 +1634,24 @@ impl Client {
         &'a self,
         organization_name: &'a types::Name,
         body: &'a types::ProjectCreate,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::Project>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
         );
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            201u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            201u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -1720,28 +1660,25 @@ impl Client {
         &'a self,
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::Project>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -1751,28 +1688,25 @@ impl Client {
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         body: &'a types::ProjectUpdate,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::Project>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
         );
         let request = self.client.put(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -1781,25 +1715,25 @@ impl Client {
         &'a self,
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
-    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<types::Error>> {
+    ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
         );
         let request = self.client.delete(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(progenitor_client::ResponseValue::empty(response)),
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            204u16 => Ok(ResponseValue::empty(response)),
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -1811,15 +1745,12 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::DiskResultsPage>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/disks",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
         );
         let mut query = Vec::new();
         if let Some(v) = &limit {
@@ -1838,14 +1769,14 @@ impl Client {
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -1856,9 +1787,7 @@ impl Client {
         project_name: &'a types::Name,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::NameSortMode>,
-    ) -> impl futures::Stream<Item = Result<types::Disk, progenitor_client::Error<types::Error>>>
-           + Unpin
-           + '_ {
+    ) -> impl futures::Stream<Item = Result<types::Disk, Error<types::Error>>> + Unpin + '_ {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
@@ -1900,26 +1829,25 @@ impl Client {
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         body: &'a types::DiskCreate,
-    ) -> Result<progenitor_client::ResponseValue<types::Disk>, progenitor_client::Error<types::Error>>
-    {
+    ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/disks",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
         );
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            201u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            201u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -1929,27 +1857,26 @@ impl Client {
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         disk_name: &'a types::Name,
-    ) -> Result<progenitor_client::ResponseValue<types::Disk>, progenitor_client::Error<types::Error>>
-    {
+    ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/disks/{}",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&disk_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&disk_name.to_string()),
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -1959,26 +1886,26 @@ impl Client {
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         disk_name: &'a types::Name,
-    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<types::Error>> {
+    ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/disks/{}",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&disk_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&disk_name.to_string()),
         );
         let request = self.client.delete(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(progenitor_client::ResponseValue::empty(response)),
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            204u16 => Ok(ResponseValue::empty(response)),
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -1990,15 +1917,12 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::InstanceResultsPage>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/instances",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
         );
         let mut query = Vec::new();
         if let Some(v) = &limit {
@@ -2017,14 +1941,14 @@ impl Client {
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -2035,9 +1959,8 @@ impl Client {
         project_name: &'a types::Name,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::NameSortMode>,
-    ) -> impl futures::Stream<Item = Result<types::Instance, progenitor_client::Error<types::Error>>>
-           + Unpin
-           + '_ {
+    ) -> impl futures::Stream<Item = Result<types::Instance, Error<types::Error>>> + Unpin + '_
+    {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
@@ -2079,28 +2002,25 @@ impl Client {
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         body: &'a types::InstanceCreate,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::Instance>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/instances",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
         );
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            201u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            201u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -2110,29 +2030,26 @@ impl Client {
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::Instance>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&instance_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&instance_name.to_string()),
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -2142,26 +2059,26 @@ impl Client {
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
-    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<types::Error>> {
+    ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&instance_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&instance_name.to_string()),
         );
         let request = self.client.delete(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(progenitor_client::ResponseValue::empty(response)),
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            204u16 => Ok(ResponseValue::empty(response)),
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -2174,16 +2091,13 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::DiskResultsPage>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/disks",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&instance_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&instance_name.to_string()),
         );
         let mut query = Vec::new();
         if let Some(v) = &limit {
@@ -2202,14 +2116,14 @@ impl Client {
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -2221,9 +2135,7 @@ impl Client {
         instance_name: &'a types::Name,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::NameSortMode>,
-    ) -> impl futures::Stream<Item = Result<types::Disk, progenitor_client::Error<types::Error>>>
-           + Unpin
-           + '_ {
+    ) -> impl futures::Stream<Item = Result<types::Disk, Error<types::Error>>> + Unpin + '_ {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
@@ -2274,27 +2186,26 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
         body: &'a types::DiskIdentifier,
-    ) -> Result<progenitor_client::ResponseValue<types::Disk>, progenitor_client::Error<types::Error>>
-    {
+    ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/disks/attach",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&instance_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&instance_name.to_string()),
         );
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            202u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            202u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -2305,27 +2216,26 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
         body: &'a types::DiskIdentifier,
-    ) -> Result<progenitor_client::ResponseValue<types::Disk>, progenitor_client::Error<types::Error>>
-    {
+    ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/disks/detach",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&instance_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&instance_name.to_string()),
         );
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            202u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            202u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -2336,29 +2246,26 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
         body: &'a types::InstanceMigrate,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::Instance>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/migrate",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&instance_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&instance_name.to_string()),
         );
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -2368,29 +2275,26 @@ impl Client {
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::Instance>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/reboot",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&instance_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&instance_name.to_string()),
         );
         let request = self.client.post(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            202u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            202u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -2400,29 +2304,26 @@ impl Client {
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::Instance>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/start",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&instance_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&instance_name.to_string()),
         );
         let request = self.client.post(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            202u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            202u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -2432,29 +2333,26 @@ impl Client {
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::Instance>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/stop",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&instance_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&instance_name.to_string()),
         );
         let request = self.client.post(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            202u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            202u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -2466,15 +2364,12 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::VpcResultsPage>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::VpcResultsPage>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
         );
         let mut query = Vec::new();
         if let Some(v) = &limit {
@@ -2493,14 +2388,14 @@ impl Client {
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -2511,9 +2406,7 @@ impl Client {
         project_name: &'a types::Name,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::NameSortMode>,
-    ) -> impl futures::Stream<Item = Result<types::Vpc, progenitor_client::Error<types::Error>>>
-           + Unpin
-           + '_ {
+    ) -> impl futures::Stream<Item = Result<types::Vpc, Error<types::Error>>> + Unpin + '_ {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
@@ -2555,26 +2448,25 @@ impl Client {
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         body: &'a types::VpcCreate,
-    ) -> Result<progenitor_client::ResponseValue<types::Vpc>, progenitor_client::Error<types::Error>>
-    {
+    ) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
         );
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            201u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            201u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -2584,27 +2476,26 @@ impl Client {
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
-    ) -> Result<progenitor_client::ResponseValue<types::Vpc>, progenitor_client::Error<types::Error>>
-    {
+    ) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&vpc_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&vpc_name.to_string()),
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -2615,26 +2506,26 @@ impl Client {
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
         body: &'a types::VpcUpdate,
-    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<types::Error>> {
+    ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&vpc_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&vpc_name.to_string()),
         );
         let request = self.client.put(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(progenitor_client::ResponseValue::empty(response)),
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            204u16 => Ok(ResponseValue::empty(response)),
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -2644,26 +2535,26 @@ impl Client {
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
-    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<types::Error>> {
+    ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&vpc_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&vpc_name.to_string()),
         );
         let request = self.client.delete(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(progenitor_client::ResponseValue::empty(response)),
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            204u16 => Ok(ResponseValue::empty(response)),
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -2676,16 +2567,13 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::VpcFirewallRuleResultsPage>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::VpcFirewallRuleResultsPage>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&vpc_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&vpc_name.to_string()),
         );
         let mut query = Vec::new();
         if let Some(v) = &limit {
@@ -2704,14 +2592,14 @@ impl Client {
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -2723,10 +2611,8 @@ impl Client {
         vpc_name: &'a types::Name,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::NameSortMode>,
-    ) -> impl futures::Stream<
-        Item = Result<types::VpcFirewallRule, progenitor_client::Error<types::Error>>,
-    > + Unpin
-           + '_ {
+    ) -> impl futures::Stream<Item = Result<types::VpcFirewallRule, Error<types::Error>>> + Unpin + '_
+    {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
@@ -2777,29 +2663,26 @@ impl Client {
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
         body: &'a types::VpcFirewallRuleUpdateParams,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::VpcFirewallRuleUpdateResult>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::VpcFirewallRuleUpdateResult>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&vpc_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&vpc_name.to_string()),
         );
         let request = self.client.put(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -2812,16 +2695,13 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::VpcRouterResultsPage>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::VpcRouterResultsPage>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&vpc_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&vpc_name.to_string()),
         );
         let mut query = Vec::new();
         if let Some(v) = &limit {
@@ -2840,14 +2720,14 @@ impl Client {
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -2859,9 +2739,8 @@ impl Client {
         vpc_name: &'a types::Name,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::NameSortMode>,
-    ) -> impl futures::Stream<Item = Result<types::VpcRouter, progenitor_client::Error<types::Error>>>
-           + Unpin
-           + '_ {
+    ) -> impl futures::Stream<Item = Result<types::VpcRouter, Error<types::Error>>> + Unpin + '_
+    {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
@@ -2912,29 +2791,26 @@ impl Client {
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
         body: &'a types::VpcRouterCreate,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::VpcRouter>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&vpc_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&vpc_name.to_string()),
         );
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            201u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            201u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -2945,30 +2821,27 @@ impl Client {
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
         router_name: &'a types::Name,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::VpcRouter>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&vpc_name.to_string()),
-            progenitor_support::encode_path(&router_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&vpc_name.to_string()),
+            progenitor_client::encode_path(&router_name.to_string()),
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -2980,27 +2853,27 @@ impl Client {
         vpc_name: &'a types::Name,
         router_name: &'a types::Name,
         body: &'a types::VpcRouterUpdate,
-    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<types::Error>> {
+    ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&vpc_name.to_string()),
-            progenitor_support::encode_path(&router_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&vpc_name.to_string()),
+            progenitor_client::encode_path(&router_name.to_string()),
         );
         let request = self.client.put(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(progenitor_client::ResponseValue::empty(response)),
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            204u16 => Ok(ResponseValue::empty(response)),
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -3011,27 +2884,27 @@ impl Client {
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
         router_name: &'a types::Name,
-    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<types::Error>> {
+    ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&vpc_name.to_string()),
-            progenitor_support::encode_path(&router_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&vpc_name.to_string()),
+            progenitor_client::encode_path(&router_name.to_string()),
         );
         let request = self.client.delete(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(progenitor_client::ResponseValue::empty(response)),
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            204u16 => Ok(ResponseValue::empty(response)),
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -3045,17 +2918,14 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::RouterRouteResultsPage>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::RouterRouteResultsPage>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&vpc_name.to_string()),
-            progenitor_support::encode_path(&router_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&vpc_name.to_string()),
+            progenitor_client::encode_path(&router_name.to_string()),
         );
         let mut query = Vec::new();
         if let Some(v) = &limit {
@@ -3074,14 +2944,14 @@ impl Client {
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -3094,10 +2964,8 @@ impl Client {
         router_name: &'a types::Name,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::NameSortMode>,
-    ) -> impl futures::Stream<
-        Item = Result<types::RouterRoute, progenitor_client::Error<types::Error>>,
-    > + Unpin
-           + '_ {
+    ) -> impl futures::Stream<Item = Result<types::RouterRoute, Error<types::Error>>> + Unpin + '_
+    {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
@@ -3151,30 +3019,27 @@ impl Client {
         vpc_name: &'a types::Name,
         router_name: &'a types::Name,
         body: &'a types::RouterRouteCreateParams,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::RouterRoute>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&vpc_name.to_string()),
-            progenitor_support::encode_path(&router_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&vpc_name.to_string()),
+            progenitor_client::encode_path(&router_name.to_string()),
         );
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            201u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            201u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -3186,31 +3051,28 @@ impl Client {
         vpc_name: &'a types::Name,
         router_name: &'a types::Name,
         route_name: &'a types::Name,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::RouterRoute>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&vpc_name.to_string()),
-            progenitor_support::encode_path(&router_name.to_string()),
-            progenitor_support::encode_path(&route_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&vpc_name.to_string()),
+            progenitor_client::encode_path(&router_name.to_string()),
+            progenitor_client::encode_path(&route_name.to_string()),
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -3223,28 +3085,28 @@ impl Client {
         router_name: &'a types::Name,
         route_name: &'a types::Name,
         body: &'a types::RouterRouteUpdateParams,
-    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<types::Error>> {
+    ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&vpc_name.to_string()),
-            progenitor_support::encode_path(&router_name.to_string()),
-            progenitor_support::encode_path(&route_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&vpc_name.to_string()),
+            progenitor_client::encode_path(&router_name.to_string()),
+            progenitor_client::encode_path(&route_name.to_string()),
         );
         let request = self.client.put(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(progenitor_client::ResponseValue::empty(response)),
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            204u16 => Ok(ResponseValue::empty(response)),
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -3256,28 +3118,28 @@ impl Client {
         vpc_name: &'a types::Name,
         router_name: &'a types::Name,
         route_name: &'a types::Name,
-    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<types::Error>> {
+    ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&vpc_name.to_string()),
-            progenitor_support::encode_path(&router_name.to_string()),
-            progenitor_support::encode_path(&route_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&vpc_name.to_string()),
+            progenitor_client::encode_path(&router_name.to_string()),
+            progenitor_client::encode_path(&route_name.to_string()),
         );
         let request = self.client.delete(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(progenitor_client::ResponseValue::empty(response)),
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            204u16 => Ok(ResponseValue::empty(response)),
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -3290,16 +3152,13 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::VpcSubnetResultsPage>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::VpcSubnetResultsPage>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&vpc_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&vpc_name.to_string()),
         );
         let mut query = Vec::new();
         if let Some(v) = &limit {
@@ -3318,14 +3177,14 @@ impl Client {
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -3337,9 +3196,8 @@ impl Client {
         vpc_name: &'a types::Name,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::NameSortMode>,
-    ) -> impl futures::Stream<Item = Result<types::VpcSubnet, progenitor_client::Error<types::Error>>>
-           + Unpin
-           + '_ {
+    ) -> impl futures::Stream<Item = Result<types::VpcSubnet, Error<types::Error>>> + Unpin + '_
+    {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
@@ -3390,29 +3248,26 @@ impl Client {
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
         body: &'a types::VpcSubnetCreate,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::VpcSubnet>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&vpc_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&vpc_name.to_string()),
         );
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            201u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            201u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -3423,30 +3278,27 @@ impl Client {
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
         subnet_name: &'a types::Name,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::VpcSubnet>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&vpc_name.to_string()),
-            progenitor_support::encode_path(&subnet_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&vpc_name.to_string()),
+            progenitor_client::encode_path(&subnet_name.to_string()),
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -3458,27 +3310,27 @@ impl Client {
         vpc_name: &'a types::Name,
         subnet_name: &'a types::Name,
         body: &'a types::VpcSubnetUpdate,
-    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<types::Error>> {
+    ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&vpc_name.to_string()),
-            progenitor_support::encode_path(&subnet_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&vpc_name.to_string()),
+            progenitor_client::encode_path(&subnet_name.to_string()),
         );
         let request = self.client.put(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(progenitor_client::ResponseValue::empty(response)),
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            204u16 => Ok(ResponseValue::empty(response)),
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -3489,27 +3341,27 @@ impl Client {
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
         subnet_name: &'a types::Name,
-    ) -> Result<progenitor_client::ResponseValue<()>, progenitor_client::Error<types::Error>> {
+    ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&vpc_name.to_string()),
-            progenitor_support::encode_path(&subnet_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&vpc_name.to_string()),
+            progenitor_client::encode_path(&subnet_name.to_string()),
         );
         let request = self.client.delete(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(progenitor_client::ResponseValue::empty(response)),
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            204u16 => Ok(ResponseValue::empty(response)),
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -3523,17 +3375,14 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::NetworkInterfaceResultsPage>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::NetworkInterfaceResultsPage>, Error<types::Error>> {
         let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}/ips",
             self.baseurl,
-            progenitor_support::encode_path(&organization_name.to_string()),
-            progenitor_support::encode_path(&project_name.to_string()),
-            progenitor_support::encode_path(&vpc_name.to_string()),
-            progenitor_support::encode_path(&subnet_name.to_string()),
+            progenitor_client::encode_path(&organization_name.to_string()),
+            progenitor_client::encode_path(&project_name.to_string()),
+            progenitor_client::encode_path(&vpc_name.to_string()),
+            progenitor_client::encode_path(&subnet_name.to_string()),
         );
         let mut query = Vec::new();
         if let Some(v) = &limit {
@@ -3552,14 +3401,14 @@ impl Client {
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -3572,10 +3421,8 @@ impl Client {
         subnet_name: &'a types::Name,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::NameSortMode>,
-    ) -> impl futures::Stream<
-        Item = Result<types::NetworkInterface, progenitor_client::Error<types::Error>>,
-    > + Unpin
-           + '_ {
+    ) -> impl futures::Stream<Item = Result<types::NetworkInterface, Error<types::Error>>> + Unpin + '_
+    {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
@@ -3626,10 +3473,7 @@ impl Client {
         &'a self,
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::RoleResultsPage>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::RoleResultsPage>, Error<types::Error>> {
         let url = format!("{}/roles", self.baseurl,);
         let mut query = Vec::new();
         if let Some(v) = &limit {
@@ -3644,14 +3488,14 @@ impl Client {
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -3659,9 +3503,7 @@ impl Client {
     pub fn roles_get_stream<'a>(
         &'a self,
         limit: Option<std::num::NonZeroU32>,
-    ) -> impl futures::Stream<Item = Result<types::Role, progenitor_client::Error<types::Error>>>
-           + Unpin
-           + '_ {
+    ) -> impl futures::Stream<Item = Result<types::Role, Error<types::Error>>> + Unpin + '_ {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
@@ -3695,25 +3537,24 @@ impl Client {
     pub async fn roles_get_role<'a>(
         &'a self,
         role_name: &'a str,
-    ) -> Result<progenitor_client::ResponseValue<types::Role>, progenitor_client::Error<types::Error>>
-    {
+    ) -> Result<ResponseValue<types::Role>, Error<types::Error>> {
         let url = format!(
             "{}/roles/{}",
             self.baseurl,
-            progenitor_support::encode_path(&role_name.to_string()),
+            progenitor_client::encode_path(&role_name.to_string()),
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -3723,10 +3564,7 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::SagaResultsPage>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::SagaResultsPage>, Error<types::Error>> {
         let url = format!("{}/sagas", self.baseurl,);
         let mut query = Vec::new();
         if let Some(v) = &limit {
@@ -3745,14 +3583,14 @@ impl Client {
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -3761,9 +3599,7 @@ impl Client {
         &'a self,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::IdSortMode>,
-    ) -> impl futures::Stream<Item = Result<types::Saga, progenitor_client::Error<types::Error>>>
-           + Unpin
-           + '_ {
+    ) -> impl futures::Stream<Item = Result<types::Saga, Error<types::Error>>> + Unpin + '_ {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
@@ -3797,48 +3633,44 @@ impl Client {
     pub async fn sagas_get_saga<'a>(
         &'a self,
         saga_id: &'a uuid::Uuid,
-    ) -> Result<progenitor_client::ResponseValue<types::Saga>, progenitor_client::Error<types::Error>>
-    {
+    ) -> Result<ResponseValue<types::Saga>, Error<types::Error>> {
         let url = format!(
             "{}/sagas/{}",
             self.baseurl,
-            progenitor_support::encode_path(&saga_id.to_string()),
+            progenitor_client::encode_path(&saga_id.to_string()),
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
     #[doc = "session_me: GET /session/me"]
     pub async fn session_me<'a>(
         &'a self,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::SessionUser>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::SessionUser>, Error<types::Error>> {
         let url = format!("{}/session/me", self.baseurl,);
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -3847,10 +3679,7 @@ impl Client {
         &'a self,
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::TimeseriesSchemaResultsPage>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::TimeseriesSchemaResultsPage>, Error<types::Error>> {
         let url = format!("{}/timeseries/schema", self.baseurl,);
         let mut query = Vec::new();
         if let Some(v) = &limit {
@@ -3865,14 +3694,14 @@ impl Client {
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -3880,10 +3709,8 @@ impl Client {
     pub fn timeseries_schema_get_stream<'a>(
         &'a self,
         limit: Option<std::num::NonZeroU32>,
-    ) -> impl futures::Stream<
-        Item = Result<types::TimeseriesSchema, progenitor_client::Error<types::Error>>,
-    > + Unpin
-           + '_ {
+    ) -> impl futures::Stream<Item = Result<types::TimeseriesSchema, Error<types::Error>>> + Unpin + '_
+    {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
@@ -3919,10 +3746,7 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
-    ) -> Result<
-        progenitor_client::ResponseValue<types::UserResultsPage>,
-        progenitor_client::Error<types::Error>,
-    > {
+    ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
         let url = format!("{}/users", self.baseurl,);
         let mut query = Vec::new();
         if let Some(v) = &limit {
@@ -3941,14 +3765,14 @@ impl Client {
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -3957,9 +3781,7 @@ impl Client {
         &'a self,
         limit: Option<std::num::NonZeroU32>,
         sort_by: Option<types::NameSortMode>,
-    ) -> impl futures::Stream<Item = Result<types::User, progenitor_client::Error<types::Error>>>
-           + Unpin
-           + '_ {
+    ) -> impl futures::Stream<Item = Result<types::User, Error<types::Error>>> + Unpin + '_ {
         use futures::StreamExt;
         use futures::TryFutureExt;
         use futures::TryStreamExt;
@@ -3993,25 +3815,24 @@ impl Client {
     pub async fn users_get_user<'a>(
         &'a self,
         user_name: &'a types::Name,
-    ) -> Result<progenitor_client::ResponseValue<types::User>, progenitor_client::Error<types::Error>>
-    {
+    ) -> Result<ResponseValue<types::User>, Error<types::Error>> {
         let url = format!(
             "{}/users/{}",
             self.baseurl,
-            progenitor_support::encode_path(&user_name.to_string()),
+            progenitor_client::encode_path(&user_name.to_string()),
         );
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200u16 => progenitor_client::ResponseValue::from_response(response).await,
-            400u16..=499u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            200u16 => ResponseValue::from_response(response).await,
+            400u16..=499u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            500u16..=599u16 => Err(progenitor_client::Error::ErrorResponse(
-                progenitor_client::ResponseValue::from_response(response).await?,
+            500u16..=599u16 => Err(Error::ErrorResponse(
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(progenitor_client::Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 }

--- a/progenitor-macro/src/lib.rs
+++ b/progenitor-macro/src/lib.rs
@@ -112,6 +112,10 @@ fn do_generate_api(item: TokenStream) -> Result<TokenStream, syn::Error> {
     })?;
 
     let output = quote! {
+        // The progenitor_client is tautologically visible from macro
+        // consumers.
+        use progenitor::progenitor_client;
+
         #code
 
         // Force a rebuild when the given file is modified.

--- a/progenitor/Cargo.toml
+++ b/progenitor/Cargo.toml
@@ -7,8 +7,9 @@ repository = "https://github.com/oxidecomputer/progenitor.git"
 description = "An OpenAPI client generator"
 
 [dependencies]
-progenitor-macro = { path = "../progenitor-macro" }
+progenitor-client = { path = "../progenitor-client" }
 progenitor-impl = { path = "../progenitor-impl" }
+progenitor-macro = { path = "../progenitor-macro" }
 anyhow = "1.0"
 getopts = "0.2"
 openapiv3 = "1.0.0"

--- a/progenitor/src/lib.rs
+++ b/progenitor/src/lib.rs
@@ -1,7 +1,8 @@
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 
 //! TODO This crate does stuff!
 
+pub use progenitor_client;
 pub use progenitor_impl::Error;
 pub use progenitor_impl::Generator;
 pub use progenitor_macro::generate_api;

--- a/progenitor/src/main.rs
+++ b/progenitor/src/main.rs
@@ -161,41 +161,6 @@ where
         bail!("tags not presently supported");
     }
 
-    if let Some(components) = api.components.as_ref() {
-        if !components.security_schemes.is_empty() {
-            bail!("component security schemes not supported");
-        }
-
-        if !components.responses.is_empty() {
-            bail!("component responses not supported");
-        }
-
-        if !components.parameters.is_empty() {
-            bail!("component parameters not supported");
-        }
-
-        if !components.request_bodies.is_empty() {
-            bail!("component request bodies not supported");
-        }
-
-        if !components.headers.is_empty() {
-            bail!("component headers not supported");
-        }
-
-        if !components.links.is_empty() {
-            bail!("component links not supported");
-        }
-
-        if !components.callbacks.is_empty() {
-            bail!("component callbacks not supported");
-        }
-
-        /*
-         * XXX Ignoring "examples" and "extensions" for now.
-         * Explicitly allowing "schemas" through.
-         */
-    }
-
     /*
      * XXX Ignoring "external_docs" and "extensions" for now, as they seem not
      * to immediately affect our code generation.
@@ -217,20 +182,12 @@ where
                             bail!("duplicate operation ID: {}", oid);
                         }
 
-                        if !o.tags.is_empty() {
-                            bail!("op {}: tags, unsupported", oid);
-                        }
-
                         if !o.servers.is_empty() {
                             bail!("op {}: servers, unsupported", oid);
                         }
 
                         if o.security.is_some() {
                             bail!("op {}: security, unsupported", oid);
-                        }
-
-                        if o.responses.default.is_some() {
-                            bail!("op {}: has response default", oid);
                         }
                     } else {
                         bail!("path {} is missing operation ID", p.0);

--- a/sample_openapi/nexus.json
+++ b/sample_openapi/nexus.json
@@ -12,7 +12,11 @@
   "paths": {
     "/hardware/racks": {
       "get": {
-        "description": "List racks in the system.",
+        "tags": [
+          "racks"
+        ],
+        "summary": "List racks in the system.",
+        "description": "",
         "operationId": "hardware_racks_get",
         "parameters": [
           {
@@ -56,6 +60,12 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         },
         "x-dropshot-pagination": true
@@ -63,7 +73,11 @@
     },
     "/hardware/racks/{rack_id}": {
       "get": {
-        "description": "Fetch information about a particular rack.",
+        "tags": [
+          "racks"
+        ],
+        "summary": "Fetch information about a particular rack.",
+        "description": "",
         "operationId": "hardware_racks_get_rack",
         "parameters": [
           {
@@ -88,13 +102,23 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
     },
     "/hardware/sleds": {
       "get": {
-        "description": "List sleds in the system.",
+        "tags": [
+          "sleds"
+        ],
+        "summary": "List sleds in the system.",
+        "description": "",
         "operationId": "hardware_sleds_get",
         "parameters": [
           {
@@ -138,6 +162,12 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         },
         "x-dropshot-pagination": true
@@ -145,7 +175,11 @@
     },
     "/hardware/sleds/{sled_id}": {
       "get": {
-        "description": "Fetch information about a sled in the system.",
+        "tags": [
+          "sleds"
+        ],
+        "summary": "Fetch information about a sled in the system.",
+        "description": "",
         "operationId": "hardware_sleds_get_sled",
         "parameters": [
           {
@@ -170,12 +204,21 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
     },
     "/login": {
       "post": {
+        "tags": [
+          "hidden"
+        ],
         "operationId": "spoof_login",
         "requestBody": {
           "content": {
@@ -196,6 +239,9 @@
     },
     "/logout": {
       "post": {
+        "tags": [
+          "hidden"
+        ],
         "operationId": "logout",
         "responses": {
           "default": {
@@ -206,7 +252,11 @@
     },
     "/organizations": {
       "get": {
-        "description": "List all organizations.",
+        "tags": [
+          "organizations"
+        ],
+        "summary": "List all organizations.",
+        "description": "",
         "operationId": "organizations_get",
         "parameters": [
           {
@@ -250,12 +300,22 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         },
         "x-dropshot-pagination": true
       },
       "post": {
-        "description": "Create a new organization.",
+        "tags": [
+          "organizations"
+        ],
+        "summary": "Create a new organization.",
+        "description": "",
         "operationId": "organizations_post",
         "requestBody": {
           "content": {
@@ -277,13 +337,23 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
     },
     "/organizations/{organization_name}": {
       "get": {
-        "description": "Fetch a specific organization",
+        "tags": [
+          "organizations"
+        ],
+        "summary": "Fetch a specific organization",
+        "description": "",
         "operationId": "organizations_get_organization",
         "parameters": [
           {
@@ -306,11 +376,21 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
       "put": {
-        "description": "Update a specific organization.\n * TODO-correctness: Is it valid for PUT to accept application/json that's a subset of what the resource actually represents?  If not, is that a problem? (HTTP may require that this be idempotent.)  If so, can we get around that having this be a slightly different content-type (e.g., \"application/json-patch\")?  We should see what other APIs do.",
+        "tags": [
+          "organizations"
+        ],
+        "summary": "Update a specific organization.",
+        "description": "",
         "operationId": "organizations_put_organization",
         "parameters": [
           {
@@ -343,11 +423,21 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
       "delete": {
-        "description": "Delete a specific organization.",
+        "tags": [
+          "organizations"
+        ],
+        "summary": "Delete a specific organization.",
+        "description": "",
         "operationId": "organizations_delete_organization",
         "parameters": [
           {
@@ -363,13 +453,23 @@
         "responses": {
           "204": {
             "description": "successful deletion"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
     },
     "/organizations/{organization_name}/projects": {
       "get": {
-        "description": "List all projects.",
+        "tags": [
+          "projects"
+        ],
+        "summary": "List all projects.",
+        "description": "",
         "operationId": "organization_projects_get",
         "parameters": [
           {
@@ -422,12 +522,22 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         },
         "x-dropshot-pagination": true
       },
       "post": {
-        "description": "Create a new project.",
+        "tags": [
+          "projects"
+        ],
+        "summary": "Create a new project.",
+        "description": "",
         "operationId": "organization_projects_post",
         "parameters": [
           {
@@ -460,13 +570,23 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
     },
     "/organizations/{organization_name}/projects/{project_name}": {
       "get": {
-        "description": "Fetch a specific project",
+        "tags": [
+          "projects"
+        ],
+        "summary": "Fetch a specific project",
+        "description": "",
         "operationId": "organization_projects_get_project",
         "parameters": [
           {
@@ -498,11 +618,21 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
       "put": {
-        "description": "Update a specific project.\n * TODO-correctness: Is it valid for PUT to accept application/json that's a subset of what the resource actually represents?  If not, is that a problem? (HTTP may require that this be idempotent.)  If so, can we get around that having this be a slightly different content-type (e.g., \"application/json-patch\")?  We should see what other APIs do.",
+        "tags": [
+          "projects"
+        ],
+        "summary": "Update a specific project.",
+        "description": "",
         "operationId": "organization_projects_put_project",
         "parameters": [
           {
@@ -544,11 +674,21 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
       "delete": {
-        "description": "Delete a specific project.",
+        "tags": [
+          "projects"
+        ],
+        "summary": "Delete a specific project.",
+        "description": "",
         "operationId": "organization_projects_delete_project",
         "parameters": [
           {
@@ -573,13 +713,23 @@
         "responses": {
           "204": {
             "description": "successful deletion"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
     },
     "/organizations/{organization_name}/projects/{project_name}/disks": {
       "get": {
-        "description": "List disks in a project.",
+        "tags": [
+          "disks"
+        ],
+        "summary": "List disks in a project.",
+        "description": "",
         "operationId": "project_disks_get",
         "parameters": [
           {
@@ -641,12 +791,22 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         },
         "x-dropshot-pagination": true
       },
       "post": {
-        "description": "Create a disk in a project.\n * TODO-correctness See note about instance create.  This should be async.",
+        "tags": [
+          "disks"
+        ],
+        "summary": "Create a disk in a project.",
+        "description": "",
         "operationId": "project_disks_post",
         "parameters": [
           {
@@ -688,13 +848,23 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
     },
     "/organizations/{organization_name}/projects/{project_name}/disks/{disk_name}": {
       "get": {
-        "description": "Fetch a single disk in a project.",
+        "tags": [
+          "disks"
+        ],
+        "summary": "Fetch a single disk in a project.",
+        "description": "",
         "operationId": "project_disks_get_disk",
         "parameters": [
           {
@@ -735,11 +905,21 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
       "delete": {
-        "description": "Delete a disk from a project.",
+        "tags": [
+          "disks"
+        ],
+        "summary": "Delete a disk from a project.",
+        "description": "",
         "operationId": "project_disks_delete_disk",
         "parameters": [
           {
@@ -773,13 +953,23 @@
         "responses": {
           "204": {
             "description": "successful deletion"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
     },
     "/organizations/{organization_name}/projects/{project_name}/instances": {
       "get": {
-        "description": "List instances in a project.",
+        "tags": [
+          "instances"
+        ],
+        "summary": "List instances in a project.",
+        "description": "",
         "operationId": "project_instances_get",
         "parameters": [
           {
@@ -841,12 +1031,22 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         },
         "x-dropshot-pagination": true
       },
       "post": {
-        "description": "Create an instance in a project.\n * TODO-correctness This is supposed to be async.  Is that right?  We can create the instance immediately -- it's just not booted yet.  Maybe the boot operation is what's a separate operation_id.  What about the response code (201 Created vs 202 Accepted)?  Is that orthogonal?  Things can return a useful response, including an operation id, with either response code.  Maybe a \"reboot\" operation would return a 202 Accepted because there's no actual resource created?",
+        "tags": [
+          "instances"
+        ],
+        "summary": "Create an instance in a project.",
+        "description": "",
         "operationId": "project_instances_post",
         "parameters": [
           {
@@ -888,13 +1088,23 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
     },
     "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}": {
       "get": {
-        "description": "Get an instance in a project.",
+        "tags": [
+          "instances"
+        ],
+        "summary": "Get an instance in a project.",
+        "description": "",
         "operationId": "project_instances_get_instance",
         "parameters": [
           {
@@ -935,11 +1145,21 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
       "delete": {
-        "description": "Delete an instance from a project.",
+        "tags": [
+          "instances"
+        ],
+        "summary": "Delete an instance from a project.",
+        "description": "",
         "operationId": "project_instances_delete_instance",
         "parameters": [
           {
@@ -973,13 +1193,23 @@
         "responses": {
           "204": {
             "description": "successful deletion"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
     },
     "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks": {
       "get": {
-        "description": "List disks attached to this instance.",
+        "tags": [
+          "instances"
+        ],
+        "summary": "List disks attached to this instance.",
+        "description": "",
         "operationId": "instance_disks_get",
         "parameters": [
           {
@@ -1050,6 +1280,12 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         },
         "x-dropshot-pagination": true
@@ -1057,6 +1293,9 @@
     },
     "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks/attach": {
       "post": {
+        "tags": [
+          "instances"
+        ],
         "operationId": "instance_disks_attach",
         "parameters": [
           {
@@ -1107,12 +1346,21 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
     },
     "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/disks/detach": {
       "post": {
+        "tags": [
+          "instances"
+        ],
         "operationId": "instance_disks_detach",
         "parameters": [
           {
@@ -1163,13 +1411,90 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/migrate": {
+      "post": {
+        "tags": [
+          "instances"
+        ],
+        "summary": "Migrate an instance to a different propolis-server, possibly on a different sled.",
+        "description": "",
+        "operationId": "project_instances_migrate_instance",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "instance_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "organization_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "project_name",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstanceMigrate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Instance"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
     },
     "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/reboot": {
       "post": {
-        "description": "Reboot an instance.",
+        "tags": [
+          "instances"
+        ],
+        "summary": "Reboot an instance.",
+        "description": "",
         "operationId": "project_instances_instance_reboot",
         "parameters": [
           {
@@ -1210,13 +1535,23 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
     },
     "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/start": {
       "post": {
-        "description": "Boot an instance.",
+        "tags": [
+          "instances"
+        ],
+        "summary": "Boot an instance.",
+        "description": "",
         "operationId": "project_instances_instance_start",
         "parameters": [
           {
@@ -1257,13 +1592,23 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
     },
     "/organizations/{organization_name}/projects/{project_name}/instances/{instance_name}/stop": {
       "post": {
-        "description": "Halt an instance.",
+        "tags": [
+          "instances"
+        ],
+        "summary": "Halt an instance.",
+        "description": "",
         "operationId": "project_instances_instance_stop",
         "parameters": [
           {
@@ -1304,13 +1649,23 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
     },
     "/organizations/{organization_name}/projects/{project_name}/vpcs": {
       "get": {
-        "description": "List VPCs in a project.",
+        "tags": [
+          "vpcs"
+        ],
+        "summary": "List VPCs in a project.",
+        "description": "",
         "operationId": "project_vpcs_get",
         "parameters": [
           {
@@ -1372,12 +1727,22 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         },
         "x-dropshot-pagination": true
       },
       "post": {
-        "description": "Create a VPC in a project.",
+        "tags": [
+          "vpcs"
+        ],
+        "summary": "Create a VPC in a project.",
+        "description": "",
         "operationId": "project_vpcs_post",
         "parameters": [
           {
@@ -1419,13 +1784,23 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
     },
     "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}": {
       "get": {
-        "description": "Get a VPC in a project.",
+        "tags": [
+          "vpcs"
+        ],
+        "summary": "Get a VPC in a project.",
+        "description": "",
         "operationId": "project_vpcs_get_vpc",
         "parameters": [
           {
@@ -1466,11 +1841,21 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
       "put": {
-        "description": "Update a VPC.",
+        "tags": [
+          "vpcs"
+        ],
+        "summary": "Update a VPC.",
+        "description": "",
         "operationId": "project_vpcs_put_vpc",
         "parameters": [
           {
@@ -1514,11 +1899,21 @@
         "responses": {
           "204": {
             "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
       "delete": {
-        "description": "Delete a vpc from a project.",
+        "tags": [
+          "vpcs"
+        ],
+        "summary": "Delete a vpc from a project.",
+        "description": "",
         "operationId": "project_vpcs_delete_vpc",
         "parameters": [
           {
@@ -1552,13 +1947,23 @@
         "responses": {
           "204": {
             "description": "successful deletion"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
     },
     "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/firewall/rules": {
       "get": {
-        "description": "List firewall rules for a VPC.",
+        "tags": [
+          "firewall"
+        ],
+        "summary": "List firewall rules for a VPC.",
+        "description": "",
         "operationId": "vpc_firewall_rules_get",
         "parameters": [
           {
@@ -1629,12 +2034,22 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         },
         "x-dropshot-pagination": true
       },
       "put": {
-        "description": "Replace the firewall rules for a VPC",
+        "tags": [
+          "firewall"
+        ],
+        "summary": "Replace the firewall rules for a VPC",
+        "description": "",
         "operationId": "vpc_firewall_rules_put",
         "parameters": [
           {
@@ -1685,13 +2100,23 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
     },
     "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers": {
       "get": {
-        "description": "List VPC Custom and System Routers",
+        "tags": [
+          "routers"
+        ],
+        "summary": "List VPC Custom and System Routers",
+        "description": "",
         "operationId": "vpc_routers_get",
         "parameters": [
           {
@@ -1762,12 +2187,22 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         },
         "x-dropshot-pagination": true
       },
       "post": {
-        "description": "Create a VPC Router",
+        "tags": [
+          "routers"
+        ],
+        "summary": "Create a VPC Router",
+        "description": "",
         "operationId": "vpc_routers_post",
         "parameters": [
           {
@@ -1818,13 +2253,23 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
     },
     "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}": {
       "get": {
-        "description": "Get a VPC Router",
+        "tags": [
+          "routers"
+        ],
+        "summary": "Get a VPC Router",
+        "description": "",
         "operationId": "vpc_routers_get_router",
         "parameters": [
           {
@@ -1874,11 +2319,21 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
       "put": {
-        "description": "Update a VPC Router",
+        "tags": [
+          "routers"
+        ],
+        "summary": "Update a VPC Router",
+        "description": "",
         "operationId": "vpc_routers_put_router",
         "parameters": [
           {
@@ -1931,11 +2386,21 @@
         "responses": {
           "204": {
             "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
       "delete": {
-        "description": "Delete a router from its VPC",
+        "tags": [
+          "routers"
+        ],
+        "summary": "Delete a router from its VPC",
+        "description": "",
         "operationId": "vpc_routers_delete_router",
         "parameters": [
           {
@@ -1978,13 +2443,23 @@
         "responses": {
           "204": {
             "description": "successful deletion"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
     },
     "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes": {
       "get": {
-        "description": "List a Router's routes",
+        "tags": [
+          "routes"
+        ],
+        "summary": "List a Router's routes",
+        "description": "",
         "operationId": "routers_routes_get",
         "parameters": [
           {
@@ -2064,12 +2539,22 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         },
         "x-dropshot-pagination": true
       },
       "post": {
-        "description": "Create a VPC Router",
+        "tags": [
+          "routes"
+        ],
+        "summary": "Create a VPC Router",
+        "description": "",
         "operationId": "routers_routes_post",
         "parameters": [
           {
@@ -2129,13 +2614,23 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
     },
     "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/routers/{router_name}/routes/{route_name}": {
       "get": {
-        "description": "Get a VPC Router route",
+        "tags": [
+          "routes"
+        ],
+        "summary": "Get a VPC Router route",
+        "description": "",
         "operationId": "routers_routes_get_route",
         "parameters": [
           {
@@ -2194,11 +2689,21 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
       "put": {
-        "description": "Update a Router route",
+        "tags": [
+          "routes"
+        ],
+        "summary": "Update a Router route",
+        "description": "",
         "operationId": "routers_routes_put_route",
         "parameters": [
           {
@@ -2260,11 +2765,21 @@
         "responses": {
           "204": {
             "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
       "delete": {
-        "description": "Delete a route from its router",
+        "tags": [
+          "routes"
+        ],
+        "summary": "Delete a route from its router",
+        "description": "",
         "operationId": "routers_routes_delete_route",
         "parameters": [
           {
@@ -2316,13 +2831,23 @@
         "responses": {
           "204": {
             "description": "successful deletion"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
     },
     "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets": {
       "get": {
-        "description": "List subnets in a VPC.",
+        "tags": [
+          "subnets"
+        ],
+        "summary": "List subnets in a VPC.",
+        "description": "",
         "operationId": "vpc_subnets_get",
         "parameters": [
           {
@@ -2393,12 +2918,22 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         },
         "x-dropshot-pagination": true
       },
       "post": {
-        "description": "Create a subnet in a VPC.",
+        "tags": [
+          "subnets"
+        ],
+        "summary": "Create a subnet in a VPC.",
+        "description": "",
         "operationId": "vpc_subnets_post",
         "parameters": [
           {
@@ -2449,13 +2984,23 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
     },
     "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}": {
       "get": {
-        "description": "Get subnet in a VPC.",
+        "tags": [
+          "subnets"
+        ],
+        "summary": "Get subnet in a VPC.",
+        "description": "",
         "operationId": "vpc_subnets_get_subnet",
         "parameters": [
           {
@@ -2505,11 +3050,21 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
       "put": {
-        "description": "Update a VPC Subnet.",
+        "tags": [
+          "subnets"
+        ],
+        "summary": "Update a VPC Subnet.",
+        "description": "",
         "operationId": "vpc_subnets_put_subnet",
         "parameters": [
           {
@@ -2562,11 +3117,21 @@
         "responses": {
           "204": {
             "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
       "delete": {
-        "description": "Delete a subnet from a VPC.",
+        "tags": [
+          "subnets"
+        ],
+        "summary": "Delete a subnet from a VPC.",
+        "description": "",
         "operationId": "vpc_subnets_delete_subnet",
         "parameters": [
           {
@@ -2609,13 +3174,23 @@
         "responses": {
           "204": {
             "description": "successful deletion"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
     },
     "/organizations/{organization_name}/projects/{project_name}/vpcs/{vpc_name}/subnets/{subnet_name}/ips": {
       "get": {
-        "description": "List IP addresses on a VPC subnet.",
+        "tags": [
+          "subnets"
+        ],
+        "summary": "List IP addresses on a VPC subnet.",
+        "description": "",
         "operationId": "subnets_ips_get",
         "parameters": [
           {
@@ -2695,6 +3270,12 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         },
         "x-dropshot-pagination": true
@@ -2702,7 +3283,11 @@
     },
     "/roles": {
       "get": {
-        "description": "List the built-in roles",
+        "tags": [
+          "roles"
+        ],
+        "summary": "List the built-in roles",
+        "description": "",
         "operationId": "roles_get",
         "parameters": [
           {
@@ -2738,6 +3323,12 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         },
         "x-dropshot-pagination": true
@@ -2745,7 +3336,11 @@
     },
     "/roles/{role_name}": {
       "get": {
-        "description": "Fetch a specific built-in role",
+        "tags": [
+          "roles"
+        ],
+        "summary": "Fetch a specific built-in role",
+        "description": "",
         "operationId": "roles_get_role",
         "parameters": [
           {
@@ -2769,13 +3364,23 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
     },
     "/sagas": {
       "get": {
-        "description": "List all sagas (for debugging)",
+        "tags": [
+          "sagas"
+        ],
+        "summary": "List all sagas (for debugging)",
+        "description": "",
         "operationId": "sagas_get",
         "parameters": [
           {
@@ -2819,6 +3424,12 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         },
         "x-dropshot-pagination": true
@@ -2826,7 +3437,11 @@
     },
     "/sagas/{saga_id}": {
       "get": {
-        "description": "Fetch information about a single saga (for debugging)",
+        "tags": [
+          "sagas"
+        ],
+        "summary": "Fetch information about a single saga (for debugging)",
+        "description": "",
         "operationId": "sagas_get_saga",
         "parameters": [
           {
@@ -2850,13 +3465,50 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/session/me": {
+      "get": {
+        "tags": [
+          "hidden"
+        ],
+        "summary": "Fetch the user associated with the current session",
+        "operationId": "session_me",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionUser"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
     },
     "/timeseries/schema": {
       "get": {
-        "description": "List all timeseries schema",
+        "tags": [
+          "metrics"
+        ],
+        "summary": "List all timeseries schema",
+        "description": "",
         "operationId": "timeseries_schema_get",
         "parameters": [
           {
@@ -2892,6 +3544,12 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         },
         "x-dropshot-pagination": true
@@ -2899,7 +3557,11 @@
     },
     "/users": {
       "get": {
-        "description": "List the built-in system users",
+        "tags": [
+          "users"
+        ],
+        "summary": "List the built-in system users",
+        "description": "",
         "operationId": "users_get",
         "parameters": [
           {
@@ -2943,6 +3605,12 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         },
         "x-dropshot-pagination": true
@@ -2950,7 +3618,11 @@
     },
     "/users/{user_name}": {
       "get": {
-        "description": "Fetch a specific built-in system user",
+        "tags": [
+          "users"
+        ],
+        "summary": "Fetch a specific built-in system user",
+        "description": "",
         "operationId": "users_get_user",
         "parameters": [
           {
@@ -2973,12 +3645,30 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
     }
   },
   "components": {
+    "responses": {
+      "Error": {
+        "description": "Error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    },
     "schemas": {
       "ByteCount": {
         "description": "A count of bytes, typically used either for memory or storage capacity\n\nThe maximum supported byte count is [`i64::MAX`].  This makes it somewhat inconvenient to define constructors: a u32 constructor can be infallible, but an i64 constructor can fail (if the value is negative) and a u64 constructor can fail (if the value is larger than i64::MAX).  We provide all of these for consumers' convenience.",
@@ -3009,7 +3699,7 @@
             "description": "human-readable free-form text about a resource",
             "type": "string"
           },
-          "devicePath": {
+          "device_path": {
             "type": "string"
           },
           "id": {
@@ -3025,14 +3715,14 @@
               }
             ]
           },
-          "projectId": {
+          "project_id": {
             "type": "string",
             "format": "uuid"
           },
           "size": {
             "$ref": "#/components/schemas/ByteCount"
           },
-          "snapshotId": {
+          "snapshot_id": {
             "nullable": true,
             "type": "string",
             "format": "uuid"
@@ -3040,12 +3730,12 @@
           "state": {
             "$ref": "#/components/schemas/DiskState"
           },
-          "timeCreated": {
+          "time_created": {
             "description": "timestamp when this resource was created",
             "type": "string",
             "format": "date-time"
           },
-          "timeModified": {
+          "time_modified": {
             "description": "timestamp when this resource was last modified",
             "type": "string",
             "format": "date-time"
@@ -3053,14 +3743,14 @@
         },
         "required": [
           "description",
-          "devicePath",
+          "device_path",
           "id",
           "name",
-          "projectId",
+          "project_id",
           "size",
           "state",
-          "timeCreated",
-          "timeModified"
+          "time_created",
+          "time_modified"
         ]
       },
       "DiskCreate": {
@@ -3081,7 +3771,7 @@
               }
             ]
           },
-          "snapshotId": {
+          "snapshot_id": {
             "nullable": true,
             "description": "id for snapshot from which the Disk should be created, if any",
             "type": "string",
@@ -3252,6 +3942,25 @@
           }
         ]
       },
+      "Error": {
+        "description": "Body of an HTTP response for an `HttpError`.  This type can be used to deserialize an HTTP response corresponding to an error in order to access the error code, message, etc.",
+        "type": "object",
+        "properties": {
+          "error_code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "request_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message",
+          "request_id"
+        ]
+      },
       "FieldSchema": {
         "description": "The name and type information for a field of a timeseries schema.",
         "type": "object",
@@ -3289,46 +3998,6 @@
           "IpAddr",
           "Uuid",
           "Bool"
-        ]
-      },
-      "IdentityMetadata": {
-        "description": "Identity-related metadata that's included in nearly all public API objects",
-        "type": "object",
-        "properties": {
-          "description": {
-            "description": "human-readable free-form text about a resource",
-            "type": "string"
-          },
-          "id": {
-            "description": "unique, immutable, system-controlled identifier for each resource",
-            "type": "string",
-            "format": "uuid"
-          },
-          "name": {
-            "description": "unique, mutable, user-controlled identifier for each resource",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Name"
-              }
-            ]
-          },
-          "timeCreated": {
-            "description": "timestamp when this resource was created",
-            "type": "string",
-            "format": "date-time"
-          },
-          "timeModified": {
-            "description": "timestamp when this resource was last modified",
-            "type": "string",
-            "format": "date-time"
-          }
-        },
-        "required": [
-          "description",
-          "id",
-          "name",
-          "timeCreated",
-          "timeModified"
         ]
       },
       "Instance": {
@@ -3372,25 +4041,25 @@
               }
             ]
           },
-          "projectId": {
+          "project_id": {
             "description": "id for the project containing this Instance",
             "type": "string",
             "format": "uuid"
           },
-          "runState": {
+          "run_state": {
             "$ref": "#/components/schemas/InstanceState"
           },
-          "timeCreated": {
+          "time_created": {
             "description": "timestamp when this resource was created",
             "type": "string",
             "format": "date-time"
           },
-          "timeModified": {
+          "time_modified": {
             "description": "timestamp when this resource was last modified",
             "type": "string",
             "format": "date-time"
           },
-          "timeRunStateUpdated": {
+          "time_run_state_updated": {
             "type": "string",
             "format": "date-time"
           }
@@ -3402,11 +4071,11 @@
           "memory",
           "name",
           "ncpus",
-          "projectId",
-          "runState",
-          "timeCreated",
-          "timeModified",
-          "timeRunStateUpdated"
+          "project_id",
+          "run_state",
+          "time_created",
+          "time_modified",
+          "time_run_state_updated"
         ]
       },
       "InstanceCpuCount": {
@@ -3443,6 +4112,19 @@
           "ncpus"
         ]
       },
+      "InstanceMigrate": {
+        "description": "Migration parameters for an [`Instance`]",
+        "type": "object",
+        "properties": {
+          "dst_sled_uuid": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "dst_sled_uuid"
+        ]
+      },
       "InstanceResultsPage": {
         "description": "A single page of results",
         "type": "object",
@@ -3474,6 +4156,7 @@
           "stopping",
           "stopped",
           "rebooting",
+          "migrating",
           "repairing",
           "failed",
           "destroyed"
@@ -3531,13 +4214,14 @@
         "description": "A `NetworkInterface` represents a virtual network interface device.",
         "type": "object",
         "properties": {
-          "identity": {
-            "description": "common identifying metadata",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/IdentityMetadata"
-              }
-            ]
+          "description": {
+            "description": "human-readable free-form text about a resource",
+            "type": "string"
+          },
+          "id": {
+            "description": "unique, immutable, system-controlled identifier for each resource",
+            "type": "string",
+            "format": "uuid"
           },
           "instance_id": {
             "description": "The Instance to which the interface belongs.",
@@ -3557,10 +4241,28 @@
               }
             ]
           },
+          "name": {
+            "description": "unique, mutable, user-controlled identifier for each resource",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          },
           "subnet_id": {
             "description": "The subnet to which the interface belongs.",
             "type": "string",
             "format": "uuid"
+          },
+          "time_created": {
+            "description": "timestamp when this resource was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "time_modified": {
+            "description": "timestamp when this resource was last modified",
+            "type": "string",
+            "format": "date-time"
           },
           "vpc_id": {
             "description": "The VPC to which the interface belongs.",
@@ -3569,11 +4271,15 @@
           }
         },
         "required": [
-          "identity",
+          "description",
+          "id",
           "instance_id",
           "ip",
           "mac",
+          "name",
           "subnet_id",
+          "time_created",
+          "time_modified",
           "vpc_id"
         ]
       },
@@ -3619,12 +4325,12 @@
               }
             ]
           },
-          "timeCreated": {
+          "time_created": {
             "description": "timestamp when this resource was created",
             "type": "string",
             "format": "date-time"
           },
-          "timeModified": {
+          "time_modified": {
             "description": "timestamp when this resource was last modified",
             "type": "string",
             "format": "date-time"
@@ -3634,8 +4340,8 @@
           "description",
           "id",
           "name",
-          "timeCreated",
-          "timeModified"
+          "time_created",
+          "time_modified"
         ]
       },
       "OrganizationCreate": {
@@ -3714,16 +4420,16 @@
               }
             ]
           },
-          "organizationId": {
+          "organization_id": {
             "type": "string",
             "format": "uuid"
           },
-          "timeCreated": {
+          "time_created": {
             "description": "timestamp when this resource was created",
             "type": "string",
             "format": "date-time"
           },
-          "timeModified": {
+          "time_modified": {
             "description": "timestamp when this resource was last modified",
             "type": "string",
             "format": "date-time"
@@ -3733,9 +4439,9 @@
           "description",
           "id",
           "name",
-          "organizationId",
-          "timeCreated",
-          "timeModified"
+          "organization_id",
+          "time_created",
+          "time_modified"
         ]
       },
       "ProjectCreate": {
@@ -3797,12 +4503,40 @@
         "description": "Client view of an [`Rack`]",
         "type": "object",
         "properties": {
-          "identity": {
-            "$ref": "#/components/schemas/IdentityMetadata"
+          "description": {
+            "description": "human-readable free-form text about a resource",
+            "type": "string"
+          },
+          "id": {
+            "description": "unique, immutable, system-controlled identifier for each resource",
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "description": "unique, mutable, user-controlled identifier for each resource",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          },
+          "time_created": {
+            "description": "timestamp when this resource was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "time_modified": {
+            "description": "timestamp when this resource was last modified",
+            "type": "string",
+            "format": "date-time"
           }
         },
         "required": [
-          "identity"
+          "description",
+          "id",
+          "name",
+          "time_created",
+          "time_modified"
         ]
       },
       "RackResultsPage": {
@@ -4012,7 +4746,7 @@
               "type": {
                 "type": "string",
                 "enum": [
-                  "internetGateway"
+                  "internet_gateway"
                 ]
               },
               "value": {
@@ -4030,22 +4764,31 @@
         "description": "A route defines a rule that governs where traffic should be sent based on its destination.",
         "type": "object",
         "properties": {
+          "description": {
+            "description": "human-readable free-form text about a resource",
+            "type": "string"
+          },
           "destination": {
             "$ref": "#/components/schemas/RouteDestination"
           },
-          "identity": {
-            "description": "common identifying metadata",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/IdentityMetadata"
-              }
-            ]
+          "id": {
+            "description": "unique, immutable, system-controlled identifier for each resource",
+            "type": "string",
+            "format": "uuid"
           },
           "kind": {
             "description": "Describes the kind of router. Set at creation. `read-only`",
             "allOf": [
               {
                 "$ref": "#/components/schemas/RouterRouteKind"
+              }
+            ]
+          },
+          "name": {
+            "description": "unique, mutable, user-controlled identifier for each resource",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
               }
             ]
           },
@@ -4056,14 +4799,28 @@
           },
           "target": {
             "$ref": "#/components/schemas/RouteTarget"
+          },
+          "time_created": {
+            "description": "timestamp when this resource was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "time_modified": {
+            "description": "timestamp when this resource was last modified",
+            "type": "string",
+            "format": "date-time"
           }
         },
         "required": [
+          "description",
           "destination",
-          "identity",
+          "id",
           "kind",
+          "name",
           "router_id",
-          "target"
+          "target",
+          "time_created",
+          "time_modified"
         ]
       },
       "RouterRouteCreateParams": {
@@ -4094,10 +4851,10 @@
         "description": "The classification of a [`RouterRoute`] as defined by the system. The kind determines certain attributes such as if the route is modifiable and describes how or where the route was created.\n\nSee [RFD-21](https://rfd.shared.oxide.computer/rfd/0021#concept-router) for more context",
         "type": "string",
         "enum": [
-          "Default",
-          "VpcSubnet",
-          "VpcPeering",
-          "Custom"
+          "default",
+          "vpc_subnet",
+          "vpc_peering",
+          "custom"
         ]
       },
       "RouterRouteResultsPage": {
@@ -4173,7 +4930,7 @@
               "error": {
                 "type": "string",
                 "enum": [
-                  "actionFailed"
+                  "action_failed"
                 ]
               },
               "source_error": {}
@@ -4189,7 +4946,7 @@
               "error": {
                 "type": "string",
                 "enum": [
-                  "deserializeFailed"
+                  "deserialize_failed"
                 ]
               },
               "message": {
@@ -4207,7 +4964,7 @@
               "error": {
                 "type": "string",
                 "enum": [
-                  "injectedError"
+                  "injected_error"
                 ]
               }
             },
@@ -4221,7 +4978,7 @@
               "error": {
                 "type": "string",
                 "enum": [
-                  "serializeFailed"
+                  "serialize_failed"
                 ]
               },
               "message": {
@@ -4239,7 +4996,7 @@
               "error": {
                 "type": "string",
                 "enum": [
-                  "subsagaCreateFailed"
+                  "subsaga_create_failed"
                 ]
               },
               "message": {
@@ -4328,6 +5085,19 @@
           }
         ]
       },
+      "SessionUser": {
+        "description": "Client view of currently authed user.",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
       "Sled": {
         "description": "Client view of an [`Sled`]",
         "type": "object",
@@ -4349,15 +5119,15 @@
               }
             ]
           },
-          "serviceAddress": {
+          "service_address": {
             "type": "string"
           },
-          "timeCreated": {
+          "time_created": {
             "description": "timestamp when this resource was created",
             "type": "string",
             "format": "date-time"
           },
-          "timeModified": {
+          "time_modified": {
             "description": "timestamp when this resource was last modified",
             "type": "string",
             "format": "date-time"
@@ -4367,9 +5137,9 @@
           "description",
           "id",
           "name",
-          "serviceAddress",
-          "timeCreated",
-          "timeModified"
+          "service_address",
+          "time_created",
+          "time_modified"
         ]
       },
       "SledResultsPage": {
@@ -4469,12 +5239,12 @@
               }
             ]
           },
-          "timeCreated": {
+          "time_created": {
             "description": "timestamp when this resource was created",
             "type": "string",
             "format": "date-time"
           },
-          "timeModified": {
+          "time_modified": {
             "description": "timestamp when this resource was last modified",
             "type": "string",
             "format": "date-time"
@@ -4484,8 +5254,8 @@
           "description",
           "id",
           "name",
-          "timeCreated",
-          "timeModified"
+          "time_created",
+          "time_modified"
         ]
       },
       "UserResultsPage": {
@@ -4517,7 +5287,7 @@
             "description": "human-readable free-form text about a resource",
             "type": "string"
           },
-          "dnsName": {
+          "dns_name": {
             "description": "The name used for the VPC in DNS.",
             "allOf": [
               {
@@ -4538,22 +5308,22 @@
               }
             ]
           },
-          "projectId": {
+          "project_id": {
             "description": "id for the project containing this VPC",
             "type": "string",
             "format": "uuid"
           },
-          "systemRouterId": {
+          "system_router_id": {
             "description": "id for the system router where subnet default routes are registered",
             "type": "string",
             "format": "uuid"
           },
-          "timeCreated": {
+          "time_created": {
             "description": "timestamp when this resource was created",
             "type": "string",
             "format": "date-time"
           },
-          "timeModified": {
+          "time_modified": {
             "description": "timestamp when this resource was last modified",
             "type": "string",
             "format": "date-time"
@@ -4561,13 +5331,13 @@
         },
         "required": [
           "description",
-          "dnsName",
+          "dns_name",
           "id",
           "name",
-          "projectId",
-          "systemRouterId",
-          "timeCreated",
-          "timeModified"
+          "project_id",
+          "system_router_id",
+          "time_created",
+          "time_modified"
         ]
       },
       "VpcCreate": {
@@ -4577,7 +5347,7 @@
           "description": {
             "type": "string"
           },
-          "dnsName": {
+          "dns_name": {
             "$ref": "#/components/schemas/Name"
           },
           "name": {
@@ -4586,7 +5356,7 @@
         },
         "required": [
           "description",
-          "dnsName",
+          "dns_name",
           "name"
         ]
       },
@@ -4601,6 +5371,10 @@
                 "$ref": "#/components/schemas/VpcFirewallRuleAction"
               }
             ]
+          },
+          "description": {
+            "description": "human-readable free-form text about a resource",
+            "type": "string"
           },
           "direction": {
             "description": "whether this rule is for incoming or outgoing traffic",
@@ -4618,11 +5392,16 @@
               }
             ]
           },
-          "identity": {
-            "description": "common identifying metadata",
+          "id": {
+            "description": "unique, immutable, system-controlled identifier for each resource",
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "description": "unique, mutable, user-controlled identifier for each resource",
             "allOf": [
               {
-                "$ref": "#/components/schemas/IdentityMetadata"
+                "$ref": "#/components/schemas/Name"
               }
             ]
           },
@@ -4646,16 +5425,30 @@
             "items": {
               "$ref": "#/components/schemas/VpcFirewallRuleTarget"
             }
+          },
+          "time_created": {
+            "description": "timestamp when this resource was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "time_modified": {
+            "description": "timestamp when this resource was last modified",
+            "type": "string",
+            "format": "date-time"
           }
         },
         "required": [
           "action",
+          "description",
           "direction",
           "filters",
-          "identity",
+          "id",
+          "name",
           "priority",
           "status",
-          "targets"
+          "targets",
+          "time_created",
+          "time_modified"
         ]
       },
       "VpcFirewallRuleAction": {
@@ -4784,7 +5577,7 @@
               "type": {
                 "type": "string",
                 "enum": [
-                  "internetGateway"
+                  "internet_gateway"
                 ]
               },
               "value": {
@@ -4997,16 +5790,35 @@
         "description": "A VPC router defines a series of rules that indicate where traffic should be sent depending on its destination.",
         "type": "object",
         "properties": {
-          "identity": {
-            "description": "common identifying metadata",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/IdentityMetadata"
-              }
-            ]
+          "description": {
+            "description": "human-readable free-form text about a resource",
+            "type": "string"
+          },
+          "id": {
+            "description": "unique, immutable, system-controlled identifier for each resource",
+            "type": "string",
+            "format": "uuid"
           },
           "kind": {
             "$ref": "#/components/schemas/VpcRouterKind"
+          },
+          "name": {
+            "description": "unique, mutable, user-controlled identifier for each resource",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          },
+          "time_created": {
+            "description": "timestamp when this resource was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "time_modified": {
+            "description": "timestamp when this resource was last modified",
+            "type": "string",
+            "format": "date-time"
           },
           "vpc_id": {
             "description": "The VPC to which the router belongs.",
@@ -5015,8 +5827,12 @@
           }
         },
         "required": [
-          "identity",
+          "description",
+          "id",
           "kind",
+          "name",
+          "time_created",
+          "time_modified",
           "vpc_id"
         ]
       },
@@ -5086,13 +5902,14 @@
         "description": "A VPC subnet represents a logical grouping for instances that allows network traffic between them, within a IPv4 subnetwork or optionall an IPv6 subnetwork.",
         "type": "object",
         "properties": {
-          "identity": {
-            "description": "common identifying metadata",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/IdentityMetadata"
-              }
-            ]
+          "description": {
+            "description": "human-readable free-form text about a resource",
+            "type": "string"
+          },
+          "id": {
+            "description": "unique, immutable, system-controlled identifier for each resource",
+            "type": "string",
+            "format": "uuid"
           },
           "ipv4_block": {
             "nullable": true,
@@ -5112,6 +5929,24 @@
               }
             ]
           },
+          "name": {
+            "description": "unique, mutable, user-controlled identifier for each resource",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ]
+          },
+          "time_created": {
+            "description": "timestamp when this resource was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "time_modified": {
+            "description": "timestamp when this resource was last modified",
+            "type": "string",
+            "format": "date-time"
+          },
           "vpc_id": {
             "description": "The VPC to which the subnet belongs.",
             "type": "string",
@@ -5119,7 +5954,11 @@
           }
         },
         "required": [
-          "identity",
+          "description",
+          "id",
+          "name",
+          "time_created",
+          "time_modified",
           "vpc_id"
         ]
       },
@@ -5130,7 +5969,7 @@
           "description": {
             "type": "string"
           },
-          "ipv4Block": {
+          "ipv4_block": {
             "nullable": true,
             "allOf": [
               {
@@ -5138,7 +5977,7 @@
               }
             ]
           },
-          "ipv6Block": {
+          "ipv6_block": {
             "nullable": true,
             "allOf": [
               {
@@ -5184,7 +6023,7 @@
             "nullable": true,
             "type": "string"
           },
-          "ipv4Block": {
+          "ipv4_block": {
             "nullable": true,
             "allOf": [
               {
@@ -5192,7 +6031,7 @@
               }
             ]
           },
-          "ipv6Block": {
+          "ipv6_block": {
             "nullable": true,
             "allOf": [
               {
@@ -5218,7 +6057,7 @@
             "nullable": true,
             "type": "string"
           },
-          "dnsName": {
+          "dns_name": {
             "nullable": true,
             "allOf": [
               {


### PR DESCRIPTION
The best description of these new types can be found here as part of the documentation added in the review:

https://github.com/oxidecomputer/progenitor/compare/rich-types?expand=1#diff-77d7c2273b1288d66668e4d113eb3e3e79f9743b6b2971a2ea63720bd007a1d4

Methods previous returned `Result<types::SuccessResponseType, anyhow::Error>`. This has a few shortcomings:

- A successful response can include additional information beyond the specified type including headers and the status code.
- An OpenAPI document may include structured error types
- `anyhow::Error` doesn't provide a lot of opportunity to understand the nature of the error programmatically

With this change methods will return...
```rust
Result<
    ResponseValue<types::SuccessResponseType>,
    Error<types::ErrorResponseType>,
>
```

@jclulow I'd particularly appreciate if you could kick the tyres [sic] here to see if this works for you.