### PR TITLE
Handle byte streams for both success and error responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ dependencies = [
 [[package]]
 name = "dropshot"
 version = "0.6.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot#eadf3bb7169a5744eab633f159093d7f7017b9d6"
+source = "git+https://github.com/oxidecomputer/dropshot#18078c4909d6260dddb924915f830de12840871d"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -278,7 +278,7 @@ dependencies = [
 [[package]]
 name = "dropshot_endpoint"
 version = "0.6.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot#eadf3bb7169a5744eab633f159093d7f7017b9d6"
+source = "git+https://github.com/oxidecomputer/dropshot#18078c4909d6260dddb924915f830de12840871d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -574,7 +574,7 @@ checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.1",
+ "itoa",
 ]
 
 [[package]]
@@ -590,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
 
 [[package]]
 name = "httpdate"
@@ -602,9 +602,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.16"
+version = "0.14.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ec3e62bdc98a2f0393a5048e4c30ef659440ea6e0e572965103e72bd836f55"
+checksum = "043f0e083e9901b6cc658a77d1eb86f4fc650bbb977a4337dd63192826aa85dd"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -615,7 +615,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 0.4.8",
+ "itoa",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -673,12 +673,6 @@ name = "ipnet"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
-
-[[package]]
-name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
@@ -1033,6 +1027,8 @@ dependencies = [
 name = "progenitor-client"
 version = "0.0.0"
 dependencies = [
+ "bytes",
+ "futures-core",
  "percent-encoding",
  "reqwest",
  "serde",
@@ -1047,6 +1043,8 @@ dependencies = [
  "dropshot",
  "expectorate",
  "getopts",
+ "http",
+ "hyper",
  "indexmap",
  "openapiv3",
  "proc-macro2",
@@ -1365,7 +1363,7 @@ version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
- "itoa 1.0.1",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -1388,7 +1386,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.1",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -1607,7 +1605,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
 dependencies = [
- "itoa 1.0.1",
+ "itoa",
  "libc",
  "num_threads",
  "time-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,5 @@ default-members = [
 
 #[patch."https://github.com/oxidecomputer/typify"]
 #typify = { path = "../typify/typify" }
+#[patch."https://github.com/oxidecomputer/dropshot"]
+#dropshot = { path = "../dropshot/dropshot" }

--- a/progenitor-client/Cargo.toml
+++ b/progenitor-client/Cargo.toml
@@ -7,6 +7,8 @@ repository = "https://github.com/oxidecomputer/progenitor.git"
 description = "An OpenAPI client generator - client support"
 
 [dependencies]
+bytes = "1.1.0"
+futures-core = "0.3.21"
 percent-encoding = "2.1"
 reqwest = { version = "0.11", features = ["json"] }
 serde = "1.0"

--- a/progenitor-client/src/lib.rs
+++ b/progenitor-client/src/lib.rs
@@ -131,8 +131,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for ResponseValue<T> {
 /// The type parameter may be a struct if there's a single expected error type
 /// or an enum if there are multiple valid error types. It can be the unit type
 /// if there are no structured returns expected.
-#[derive(Debug)]
-pub enum Error<E: std::fmt::Debug = ()> {
+pub enum Error<E = ()> {
     /// A server error either with the data, or with the connection.
     CommunicationError(reqwest::Error),
 
@@ -148,7 +147,7 @@ pub enum Error<E: std::fmt::Debug = ()> {
     UnexpectedResponse(reqwest::Response),
 }
 
-impl<E: std::fmt::Debug> Error<E> {
+impl<E> Error<E> {
     /// Returns the status code, if the error was generated from a response.
     pub fn status(&self) -> Option<reqwest::StatusCode> {
         match self {
@@ -181,20 +180,20 @@ impl<E: std::fmt::Debug> Error<E> {
     }
 }
 
-impl<E: std::fmt::Debug> From<reqwest::Error> for Error<E> {
+impl<E> From<reqwest::Error> for Error<E> {
     fn from(e: reqwest::Error) -> Self {
         Self::CommunicationError(e)
     }
 }
 
-impl<E: std::fmt::Debug> std::fmt::Display for Error<E> {
+impl<E> std::fmt::Display for Error<E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Error::CommunicationError(e) => {
                 write!(f, "Communication Error {}", e)
             }
-            Error::ErrorResponse(rv) => {
-                write!(f, "Error Response {:?}", rv)
+            Error::ErrorResponse(_) => {
+                write!(f, "Error Response")
             }
             Error::InvalidResponsePayload(e) => {
                 write!(f, "Invalid Response Payload {}", e)
@@ -205,7 +204,12 @@ impl<E: std::fmt::Debug> std::fmt::Display for Error<E> {
         }
     }
 }
-impl<E: std::fmt::Debug> std::error::Error for Error<E> {
+impl<E> std::fmt::Debug for Error<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self, f)
+    }
+}
+impl<E> std::error::Error for Error<E> {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Error::CommunicationError(e) => Some(e),

--- a/progenitor-impl/Cargo.toml
+++ b/progenitor-impl/Cargo.toml
@@ -24,5 +24,7 @@ typify = { git = "https://github.com/oxidecomputer/typify" }
 unicode-xid = "0.2"
 
 [dev-dependencies]
-expectorate = "1.0"
 dropshot = { git = "https://github.com/oxidecomputer/dropshot" }
+expectorate = "1.0"
+http = "0.2.6"
+hyper = "0.14.17"

--- a/progenitor-impl/tests/output/buildomat.out
+++ b/progenitor-impl/tests/output/buildomat.out
@@ -1,4 +1,4 @@
-pub use progenitor_client::{Error, ResponseValue};
+pub use progenitor_client::{ByteStream, Error, ResponseValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -281,7 +281,7 @@ impl Client {
         &'a self,
         task: &'a str,
         output: &'a str,
-    ) -> Result<reqwest::Response, Error<()>> {
+    ) -> Result<ResponseValue<ByteStream>, Error<()>> {
         let url = format!(
             "{}/v1/tasks/{}/outputs/{}",
             self.baseurl,
@@ -292,7 +292,7 @@ impl Client {
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200..=299 => Ok(response),
+            200..=299 => Ok(ResponseValue::stream(response)),
             _ => Err(Error::UnexpectedResponse(response)),
         }
     }

--- a/progenitor-impl/tests/output/keeper.out
+++ b/progenitor-impl/tests/output/keeper.out
@@ -1,4 +1,4 @@
-pub use progenitor_client::{Error, ResponseValue};
+pub use progenitor_client::{ByteStream, Error, ResponseValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/progenitor-impl/tests/output/nexus.out
+++ b/progenitor-impl/tests/output/nexus.out
@@ -1,4 +1,4 @@
-pub use progenitor_client::{Error, ResponseValue};
+pub use progenitor_client::{ByteStream, Error, ResponseValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[doc = "A count of bytes, typically used either for memory or storage capacity\n\nThe maximum supported byte count is [`i64::MAX`].  This makes it somewhat inconvenient to define constructors: a u32 constructor can be infallible, but an i64 constructor can fail (if the value is negative) and a u64 constructor can fail (if the value is larger than i64::MAX).  We provide all of these for consumers' convenience."]

--- a/progenitor-impl/tests/output/nexus.out
+++ b/progenitor-impl/tests/output/nexus.out
@@ -1355,14 +1355,14 @@ impl Client {
     pub async fn spoof_login<'a>(
         &'a self,
         body: &'a types::LoginParams,
-    ) -> Result<ResponseValue<()>, Error<()>> {
+    ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
         let url = format!("{}/login", self.baseurl,);
         let request = self.client.post(url).json(body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200..=299 => Ok(ResponseValue::empty(response)),
-            _ => Err(Error::ErrorResponse(ResponseValue::empty(response))),
+            200..=299 => Ok(ResponseValue::stream(response)),
+            _ => Err(Error::ErrorResponse(ResponseValue::stream(response))),
         }
     }
 

--- a/progenitor-impl/tests/output/test_freeform_response.out
+++ b/progenitor-impl/tests/output/test_freeform_response.out
@@ -43,39 +43,17 @@ impl Client {
         &self.client
     }
 
-    #[doc = "renamed_parameters: GET /{ref}/{type}/{trait}"]
-    pub async fn renamed_parameters<'a>(
+    #[doc = "freeform_response: GET "]
+    pub async fn freeform_response<'a>(
         &'a self,
-        ref_: &'a str,
-        type_: &'a str,
-        trait_: &'a str,
-        if_: &'a str,
-        in_: &'a str,
-        use_: &'a str,
-    ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
-            "{}/{}/{}/{}",
-            self.baseurl,
-            progenitor_client::encode_path(&ref_.to_string()),
-            progenitor_client::encode_path(&type_.to_string()),
-            progenitor_client::encode_path(&trait_.to_string()),
-        );
-        let mut query = Vec::new();
-        query.push(("if", if_.to_string()));
-        query.push(("in", in_.to_string()));
-        query.push(("use", use_.to_string()));
-        let request = self.client.get(url).query(&query).build()?;
+    ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
+        let url = format!("{}", self.baseurl,);
+        let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
-            400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
-            )),
-            500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
-            )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            200..=299 => Ok(ResponseValue::stream(response)),
+            _ => Err(Error::ErrorResponse(ResponseValue::stream(response))),
         }
     }
 }

--- a/sample_openapi/nexus.json
+++ b/sample_openapi/nexus.json
@@ -232,7 +232,12 @@
         },
         "responses": {
           "default": {
-            "description": ""
+            "description": "",
+            "content": {
+              "*/*": {
+                "schema": {}
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
When an OpenAPI spec reports that errors may be unstructured, generated clients need a way to express this. Currently they just use `()` which is obviously imprecise.

There were three options I considered:

1. Add another `Error` variant alongside `ErrorResponse(ResponseValue<E>)`--something like `UnstructuredErrorResponse(Response)`--which would have the raw response
2. Change `Error<T>` which currently takes any type `T` to take either a `ResponseValue<T>` or a `Response`
3. Add a new type `ByteStream` to represent the unstructured response body; this could be used within a `ResponseValue<ByteStream>`

Each of these has its drawbacks. 1 requires clients to consider two--essentially identical--error variants, only one of which would only be relevant for a given API call. 2 imposes the knowledge of the structure of `Error` types more onerously on mock clients; it requires exposing a trait to treat `ResponseValue<T>` and `Response` generically which can also lead to confusing error messages. 3 doesn't give access to rest of the `Response` structure, extracting only the streaming body via `Response::bytes_stream()`.

After prototyping all three and trying them out with omicron, I chose 3. 1 felt pretty janky with the two nominally conflicting Error variants; 2 felt easy to get wrong and seemed to expose more implementation detail than was desirable; 3 actually had some nice properties of unifying type and status code handling of success and error responses. With 3, we figure out the type of the response `T`--either a generated type, a `ByteStream`, or `()`--and then the success case is a `ResponseValue<T>` and the error case is an `Error<T>`. This has a pleasant symmetry to it.

In Dropshot, the OpenAPI description for an endpoint whose response is completely free-form uses the `default` response type and the `*/*` content type: there's nothing specific Dropshot can say about the response codes, content type, schema, etc. In those cases, the return value for the corresponding generated client method will be `Response<ResponseValue<ByteStream>, Error<ByteStream>>` where the only thing distinguishing the success and error cases is the response code that the endpoint applied to its custom response.

For https://github.com/oxidecomputer/dropshot/issues/297, with this PR a method with a streaming response but error types would have a return type that looks like this: `Response<ResponseValue<ByteStream>, Error<types::Error>>`.

Note that both @leftwo and @iliana have hit conditions applicable to this PR.