### PR TITLE
Add support for rust_decimal

### DIFF
--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -216,6 +216,9 @@ impl Generator {
         if self.type_space.uses_chrono() {
             deps.push("chrono = { version = \"0.4\", features = [\"serde\"] }")
         }
+        if self.type_space.uses_rust_decimal() {
+            deps.push("rust_decimal = \"1.23\"")
+        }
         if self.uses_futures {
             deps.push("futures = \"0.3\"")
         }


### PR DESCRIPTION
This adds support for the corresponding `typify` pr https://github.com/oxidecomputer/typify/pull/47

This will need to be updated to point at the latest version of `typify`.