### PR TITLE
Add application/x-www-form-urlencoded to extract json media type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/target
+target/

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -1876,9 +1876,13 @@ impl ExtractJsonMediaType for openapiv3::RequestBody {
 
         if let Some(mt) = self.content.get("application/json") {
             Ok(mt.clone())
+        } else if let Some(mt) =
+            self.content.get("application/x-www-form-urlencoded")
+        {
+            Ok(mt.clone())
         } else {
             todo!(
-                "could not find application/json, only found {}",
+                "could not find application/json or application/x-www-form-urlencoded, only found {}",
                 self.content.keys().next().unwrap()
             );
         }


### PR DESCRIPTION
Does what it says on the tin :)

On the [line](https://github.com/oxidecomputer/progenitor/blob/main/progenitor-impl/src/method.rs#L1865) above the ExtractJsonMediaType trait, it says "// TODO do I want/need this?" I'm guessing this might all be deleted in the future?