### PR TITLE
improved template parsing

### DIFF
--- a/progenitor-impl/tests/output/test_default_params.out
+++ b/progenitor-impl/tests/output/test_default_params.out
@@ -66,12 +66,12 @@ impl Client {
 }
 
 impl Client {
-    ///Sends a `POST` request to ``
+    ///Sends a `POST` request to `/`
     pub async fn default_params<'a>(
         &'a self,
         body: &'a types::BodyWithDefaults,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-        let url = format!("{}", self.baseurl,);
+        let url = format!("{}/", self.baseurl,);
         let request = self.client.post(url).json(&body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;

--- a/progenitor-impl/tests/output/test_freeform_response.out
+++ b/progenitor-impl/tests/output/test_freeform_response.out
@@ -47,11 +47,11 @@ impl Client {
 }
 
 impl Client {
-    ///Sends a `GET` request to ``
+    ///Sends a `GET` request to `/`
     pub async fn freeform_response<'a>(
         &'a self,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-        let url = format!("{}", self.baseurl,);
+        let url = format!("{}/", self.baseurl,);
         let request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;


### PR DESCRIPTION
As mentioned in [a comment on #76](https://github.com/oxidecomputer/progenitor/issues/76#issuecomment-1178645832), our template handling is presently too strict: it requires that each parameter in the path spans an entire path component, with no additional strings.  We should be a bit more relaxed about this.