### PR TITLE
ResponseValue could expose Content-Length

### DIFF
--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -118,6 +118,16 @@ impl<T> ResponseValue<T> {
         &self.headers
     }
 
+    /// Get the parsed value of the Content-Length header, if present and valid.
+    pub fn content_length(&self) -> Option<u64> {
+        self.headers
+            .get(reqwest::header::CONTENT_LENGTH)?
+            .to_str()
+            .ok()?
+            .parse::<u64>()
+            .ok()
+    }
+
     #[doc(hidden)]
     pub fn map<U: std::fmt::Debug, F, E>(
         self,


### PR DESCRIPTION
Add a `content_length()` method to `ResponseValue` which would return a numeric value iff `Content-Length` is present in the response and is a valid positive integer.