### PR TITLE
code generation fixes after 03e2cfad3c4d63

### DIFF
--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -335,7 +335,7 @@ impl<E> RequestBuilderExt<E> for RequestBuilder {
                     "application/x-www-form-urlencoded",
                 ),
             )
-            .body(serde_json::to_vec(&body).map_err(|_| {
+            .body(serde_urlencoded::to_string(&body).map_err(|_| {
                 Error::InvalidRequest("failed to serialize body".to_string())
             })?))
     }

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -400,7 +400,7 @@ impl Generator {
             "percent-encoding = \"2.1\"",
             "reqwest = { version = \"0.11\", features = [\"json\", \"stream\"] }",
             "serde = { version = \"1.0\", features = [\"derive\"] }",
-            "serde_urlencoded = 0.7",
+            "serde_urlencoded = \"0.7\"",
         ];
         if self.type_space.uses_regress() {
             deps.push("regress = 0.4")


### PR DESCRIPTION
It looks like 03e2cfad3c4d637918b9e4a267f6a0ef426b0186 introduced a couple of small issues into the generated `Cargo.toml` when using the `progenitor` CLI:

* `serde_urlencoded` uses an unquoted version string, which the TOML parser really wants to believe is a float; this upsets `cargo`.
* `serde_json` is no longer optional based on the use of JSON types in the type space, as it is used unconditionally in the `form_urlencoded()` member of `RequestBuilderExt` for `RequestBuilder`.