### PR TITLE
Change builder methods to accept `TryInto<T>`

### DIFF
--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -208,8 +208,13 @@ impl Generator {
             #[allow(unused_imports)]
             use progenitor_client::{encode_path, RequestBuilderExt};
 
+
             pub mod types {
                 use serde::{Deserialize, Serialize};
+
+                // This may be used by some impl Deserialize, but not all.
+                #[allow(unused_imports)]
+                use std::convert::TryFrom;
                 #shared
                 #(#types)*
             }
@@ -307,6 +312,8 @@ impl Generator {
                     RequestBuilderExt,
                     ResponseValue,
                 };
+                #[allow(unused_imports)]
+                use std::convert::TryInto;
 
                 #(#builder_struct)*
             }

--- a/progenitor-impl/tests/output/buildomat-builder-tagged.out
+++ b/progenitor-impl/tests/output/buildomat-builder-tagged.out
@@ -3,6 +3,8 @@ use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
+    #[allow(unused_imports)]
+    use std::convert::TryFrom;
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct Task {
         pub id: String,
@@ -428,35 +430,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct TaskGet<'a> {
         client: &'a super::Client,
-        task: Option<String>,
+        task: Result<String, String>,
     }
 
     impl<'a> TaskGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, task: None }
+            Self {
+                client,
+                task: Err("task was not initialized".to_string()),
+            }
         }
 
-        pub fn task<S: ToString>(mut self, value: S) -> Self {
-            self.task = Some(value.to_string());
+        pub fn task<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.task = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for task failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/v1/task/{task}`
         pub async fn send(self) -> Result<ResponseValue<types::Task>, Error<()>> {
             let Self { client, task } = self;
-            let (task,) = match (task,) {
-                (Some(task),) => (task,),
-                (task,) => {
-                    let mut missing = Vec::new();
-                    if task.is_none() {
-                        missing.push(stringify!(task));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let task = task.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/v1/task/{}",
                 client.baseurl,
@@ -505,35 +503,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct TaskSubmit<'a> {
         client: &'a super::Client,
-        body: Option<types::TaskSubmit>,
+        body: Result<types::TaskSubmit, String>,
     }
 
     impl<'a> TaskSubmit<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::TaskSubmit) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::TaskSubmit>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `TaskSubmit` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/v1/tasks`
         pub async fn send(self) -> Result<ResponseValue<types::TaskSubmitResult>, Error<()>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/tasks", client.baseurl,);
             let request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
@@ -551,26 +545,37 @@ pub mod builder {
     #[derive(Clone)]
     pub struct TaskEventsGet<'a> {
         client: &'a super::Client,
-        task: Option<String>,
-        minseq: Option<u32>,
+        task: Result<String, String>,
+        minseq: Result<Option<u32>, String>,
     }
 
     impl<'a> TaskEventsGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                task: None,
-                minseq: None,
+                task: Err("task was not initialized".to_string()),
+                minseq: Ok(None),
             }
         }
 
-        pub fn task<S: ToString>(mut self, value: S) -> Self {
-            self.task = Some(value.to_string());
+        pub fn task<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.task = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for task failed".to_string());
             self
         }
 
-        pub fn minseq(mut self, value: u32) -> Self {
-            self.minseq = Some(value);
+        pub fn minseq<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<u32>,
+        {
+            self.minseq = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < u32 >` for minseq failed".to_string());
             self
         }
 
@@ -581,19 +586,8 @@ pub mod builder {
                 task,
                 minseq,
             } = self;
-            let (task,) = match (task,) {
-                (Some(task),) => (task,),
-                (task,) => {
-                    let mut missing = Vec::new();
-                    if task.is_none() {
-                        missing.push(stringify!(task));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let task = task.map_err(Error::InvalidRequest)?;
+            let minseq = minseq.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/v1/tasks/{}/events",
                 client.baseurl,
@@ -619,35 +613,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct TaskOutputsGet<'a> {
         client: &'a super::Client,
-        task: Option<String>,
+        task: Result<String, String>,
     }
 
     impl<'a> TaskOutputsGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, task: None }
+            Self {
+                client,
+                task: Err("task was not initialized".to_string()),
+            }
         }
 
-        pub fn task<S: ToString>(mut self, value: S) -> Self {
-            self.task = Some(value.to_string());
+        pub fn task<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.task = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for task failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/v1/tasks/{task}/outputs`
         pub async fn send(self) -> Result<ResponseValue<Vec<types::TaskOutput>>, Error<()>> {
             let Self { client, task } = self;
-            let (task,) = match (task,) {
-                (Some(task),) => (task,),
-                (task,) => {
-                    let mut missing = Vec::new();
-                    if task.is_none() {
-                        missing.push(stringify!(task));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let task = task.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/v1/tasks/{}/outputs",
                 client.baseurl,
@@ -669,26 +659,36 @@ pub mod builder {
     #[derive(Clone)]
     pub struct TaskOutputDownload<'a> {
         client: &'a super::Client,
-        task: Option<String>,
-        output: Option<String>,
+        task: Result<String, String>,
+        output: Result<String, String>,
     }
 
     impl<'a> TaskOutputDownload<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                task: None,
-                output: None,
+                task: Err("task was not initialized".to_string()),
+                output: Err("output was not initialized".to_string()),
             }
         }
 
-        pub fn task<S: ToString>(mut self, value: S) -> Self {
-            self.task = Some(value.to_string());
+        pub fn task<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.task = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for task failed".to_string());
             self
         }
 
-        pub fn output<S: ToString>(mut self, value: S) -> Self {
-            self.output = Some(value.to_string());
+        pub fn output<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.output = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for output failed".to_string());
             self
         }
 
@@ -699,22 +699,8 @@ pub mod builder {
                 task,
                 output,
             } = self;
-            let (task, output) = match (task, output) {
-                (Some(task), Some(output)) => (task, output),
-                (task, output) => {
-                    let mut missing = Vec::new();
-                    if task.is_none() {
-                        missing.push(stringify!(task));
-                    }
-                    if output.is_none() {
-                        missing.push(stringify!(output));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let task = task.map_err(Error::InvalidRequest)?;
+            let output = output.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/v1/tasks/{}/outputs/{}",
                 client.baseurl,
@@ -737,35 +723,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct UserCreate<'a> {
         client: &'a super::Client,
-        body: Option<types::UserCreate>,
+        body: Result<types::UserCreate, String>,
     }
 
     impl<'a> UserCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::UserCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::UserCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `UserCreate` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/v1/users`
         pub async fn send(self) -> Result<ResponseValue<types::UserCreateResult>, Error<()>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/users", client.baseurl,);
             let request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
@@ -810,35 +792,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct WorkerBootstrap<'a> {
         client: &'a super::Client,
-        body: Option<types::WorkerBootstrap>,
+        body: Result<types::WorkerBootstrap, String>,
     }
 
     impl<'a> WorkerBootstrap<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::WorkerBootstrap) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::WorkerBootstrap>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `WorkerBootstrap` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/v1/worker/bootstrap`
         pub async fn send(self) -> Result<ResponseValue<types::WorkerBootstrapResult>, Error<()>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/worker/bootstrap", client.baseurl,);
             let request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
@@ -883,48 +861,44 @@ pub mod builder {
     #[derive(Clone)]
     pub struct WorkerTaskAppend<'a> {
         client: &'a super::Client,
-        task: Option<String>,
-        body: Option<types::WorkerAppendTask>,
+        task: Result<String, String>,
+        body: Result<types::WorkerAppendTask, String>,
     }
 
     impl<'a> WorkerTaskAppend<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                task: None,
-                body: None,
+                task: Err("task was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn task<S: ToString>(mut self, value: S) -> Self {
-            self.task = Some(value.to_string());
+        pub fn task<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.task = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for task failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::WorkerAppendTask) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::WorkerAppendTask>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `WorkerAppendTask` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/append`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client, task, body } = self;
-            let (task, body) = match (task, body) {
-                (Some(task), Some(body)) => (task, body),
-                (task, body) => {
-                    let mut missing = Vec::new();
-                    if task.is_none() {
-                        missing.push(stringify!(task));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let task = task.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/v1/worker/task/{}/append",
                 client.baseurl,
@@ -945,48 +919,44 @@ pub mod builder {
     ///[`Client::worker_task_upload_chunk`]: super::Client::worker_task_upload_chunk
     pub struct WorkerTaskUploadChunk<'a> {
         client: &'a super::Client,
-        task: Option<String>,
-        body: Option<reqwest::Body>,
+        task: Result<String, String>,
+        body: Result<reqwest::Body, String>,
     }
 
     impl<'a> WorkerTaskUploadChunk<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                task: None,
-                body: None,
+                task: Err("task was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn task<S: ToString>(mut self, value: S) -> Self {
-            self.task = Some(value.to_string());
+        pub fn task<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.task = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for task failed".to_string());
             self
         }
 
-        pub fn body<B: Into<reqwest::Body>>(mut self, value: B) -> Self {
-            self.body = Some(value.into());
+        pub fn body<B>(mut self, value: B) -> Self
+        where
+            B: TryInto<reqwest::Body>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `reqwest::Body` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/chunk`
         pub async fn send(self) -> Result<ResponseValue<types::UploadedChunk>, Error<()>> {
             let Self { client, task, body } = self;
-            let (task, body) = match (task, body) {
-                (Some(task), Some(body)) => (task, body),
-                (task, body) => {
-                    let mut missing = Vec::new();
-                    if task.is_none() {
-                        missing.push(stringify!(task));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let task = task.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/v1/worker/task/{}/chunk",
                 client.baseurl,
@@ -1016,48 +986,44 @@ pub mod builder {
     #[derive(Clone)]
     pub struct WorkerTaskComplete<'a> {
         client: &'a super::Client,
-        task: Option<String>,
-        body: Option<types::WorkerCompleteTask>,
+        task: Result<String, String>,
+        body: Result<types::WorkerCompleteTask, String>,
     }
 
     impl<'a> WorkerTaskComplete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                task: None,
-                body: None,
+                task: Err("task was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn task<S: ToString>(mut self, value: S) -> Self {
-            self.task = Some(value.to_string());
+        pub fn task<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.task = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for task failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::WorkerCompleteTask) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::WorkerCompleteTask>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `WorkerCompleteTask` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/complete`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client, task, body } = self;
-            let (task, body) = match (task, body) {
-                (Some(task), Some(body)) => (task, body),
-                (task, body) => {
-                    let mut missing = Vec::new();
-                    if task.is_none() {
-                        missing.push(stringify!(task));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let task = task.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/v1/worker/task/{}/complete",
                 client.baseurl,
@@ -1079,48 +1045,44 @@ pub mod builder {
     #[derive(Clone)]
     pub struct WorkerTaskAddOutput<'a> {
         client: &'a super::Client,
-        task: Option<String>,
-        body: Option<types::WorkerAddOutput>,
+        task: Result<String, String>,
+        body: Result<types::WorkerAddOutput, String>,
     }
 
     impl<'a> WorkerTaskAddOutput<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                task: None,
-                body: None,
+                task: Err("task was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn task<S: ToString>(mut self, value: S) -> Self {
-            self.task = Some(value.to_string());
+        pub fn task<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.task = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for task failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::WorkerAddOutput) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::WorkerAddOutput>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `WorkerAddOutput` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/output`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client, task, body } = self;
-            let (task, body) = match (task, body) {
-                (Some(task), Some(body)) => (task, body),
-                (task, body) => {
-                    let mut missing = Vec::new();
-                    if task.is_none() {
-                        missing.push(stringify!(task));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let task = task.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/v1/worker/task/{}/output",
                 client.baseurl,

--- a/progenitor-impl/tests/output/buildomat-builder.out
+++ b/progenitor-impl/tests/output/buildomat-builder.out
@@ -3,6 +3,8 @@ use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
+    #[allow(unused_imports)]
+    use std::convert::TryFrom;
     #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
     pub struct Task {
         pub id: String,
@@ -368,6 +370,8 @@ pub mod builder {
     use super::types;
     #[allow(unused_imports)]
     use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    #[allow(unused_imports)]
+    use std::convert::TryInto;
     ///Builder for [`Client::control_hold`]
     ///
     ///[`Client::control_hold`]: super::Client::control_hold
@@ -428,35 +432,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct TaskGet<'a> {
         client: &'a super::Client,
-        task: Option<String>,
+        task: Result<String, String>,
     }
 
     impl<'a> TaskGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, task: None }
+            Self {
+                client,
+                task: Err("task was not initialized".to_string()),
+            }
         }
 
-        pub fn task<S: ToString>(mut self, value: S) -> Self {
-            self.task = Some(value.to_string());
+        pub fn task<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.task = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for task failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/v1/task/{task}`
         pub async fn send(self) -> Result<ResponseValue<types::Task>, Error<()>> {
             let Self { client, task } = self;
-            let (task,) = match (task,) {
-                (Some(task),) => (task,),
-                (task,) => {
-                    let mut missing = Vec::new();
-                    if task.is_none() {
-                        missing.push(stringify!(task));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let task = task.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/v1/task/{}",
                 client.baseurl,
@@ -505,35 +505,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct TaskSubmit<'a> {
         client: &'a super::Client,
-        body: Option<types::TaskSubmit>,
+        body: Result<types::TaskSubmit, String>,
     }
 
     impl<'a> TaskSubmit<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::TaskSubmit) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::TaskSubmit>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `TaskSubmit` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/v1/tasks`
         pub async fn send(self) -> Result<ResponseValue<types::TaskSubmitResult>, Error<()>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/tasks", client.baseurl,);
             let request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
@@ -551,26 +547,37 @@ pub mod builder {
     #[derive(Clone)]
     pub struct TaskEventsGet<'a> {
         client: &'a super::Client,
-        task: Option<String>,
-        minseq: Option<u32>,
+        task: Result<String, String>,
+        minseq: Result<Option<u32>, String>,
     }
 
     impl<'a> TaskEventsGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                task: None,
-                minseq: None,
+                task: Err("task was not initialized".to_string()),
+                minseq: Ok(None),
             }
         }
 
-        pub fn task<S: ToString>(mut self, value: S) -> Self {
-            self.task = Some(value.to_string());
+        pub fn task<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.task = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for task failed".to_string());
             self
         }
 
-        pub fn minseq(mut self, value: u32) -> Self {
-            self.minseq = Some(value);
+        pub fn minseq<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<u32>,
+        {
+            self.minseq = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < u32 >` for minseq failed".to_string());
             self
         }
 
@@ -581,19 +588,8 @@ pub mod builder {
                 task,
                 minseq,
             } = self;
-            let (task,) = match (task,) {
-                (Some(task),) => (task,),
-                (task,) => {
-                    let mut missing = Vec::new();
-                    if task.is_none() {
-                        missing.push(stringify!(task));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let task = task.map_err(Error::InvalidRequest)?;
+            let minseq = minseq.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/v1/tasks/{}/events",
                 client.baseurl,
@@ -619,35 +615,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct TaskOutputsGet<'a> {
         client: &'a super::Client,
-        task: Option<String>,
+        task: Result<String, String>,
     }
 
     impl<'a> TaskOutputsGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, task: None }
+            Self {
+                client,
+                task: Err("task was not initialized".to_string()),
+            }
         }
 
-        pub fn task<S: ToString>(mut self, value: S) -> Self {
-            self.task = Some(value.to_string());
+        pub fn task<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.task = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for task failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/v1/tasks/{task}/outputs`
         pub async fn send(self) -> Result<ResponseValue<Vec<types::TaskOutput>>, Error<()>> {
             let Self { client, task } = self;
-            let (task,) = match (task,) {
-                (Some(task),) => (task,),
-                (task,) => {
-                    let mut missing = Vec::new();
-                    if task.is_none() {
-                        missing.push(stringify!(task));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let task = task.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/v1/tasks/{}/outputs",
                 client.baseurl,
@@ -669,26 +661,36 @@ pub mod builder {
     #[derive(Clone)]
     pub struct TaskOutputDownload<'a> {
         client: &'a super::Client,
-        task: Option<String>,
-        output: Option<String>,
+        task: Result<String, String>,
+        output: Result<String, String>,
     }
 
     impl<'a> TaskOutputDownload<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                task: None,
-                output: None,
+                task: Err("task was not initialized".to_string()),
+                output: Err("output was not initialized".to_string()),
             }
         }
 
-        pub fn task<S: ToString>(mut self, value: S) -> Self {
-            self.task = Some(value.to_string());
+        pub fn task<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.task = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for task failed".to_string());
             self
         }
 
-        pub fn output<S: ToString>(mut self, value: S) -> Self {
-            self.output = Some(value.to_string());
+        pub fn output<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.output = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for output failed".to_string());
             self
         }
 
@@ -699,22 +701,8 @@ pub mod builder {
                 task,
                 output,
             } = self;
-            let (task, output) = match (task, output) {
-                (Some(task), Some(output)) => (task, output),
-                (task, output) => {
-                    let mut missing = Vec::new();
-                    if task.is_none() {
-                        missing.push(stringify!(task));
-                    }
-                    if output.is_none() {
-                        missing.push(stringify!(output));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let task = task.map_err(Error::InvalidRequest)?;
+            let output = output.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/v1/tasks/{}/outputs/{}",
                 client.baseurl,
@@ -737,35 +725,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct UserCreate<'a> {
         client: &'a super::Client,
-        body: Option<types::UserCreate>,
+        body: Result<types::UserCreate, String>,
     }
 
     impl<'a> UserCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::UserCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::UserCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `UserCreate` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/v1/users`
         pub async fn send(self) -> Result<ResponseValue<types::UserCreateResult>, Error<()>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/users", client.baseurl,);
             let request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
@@ -810,35 +794,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct WorkerBootstrap<'a> {
         client: &'a super::Client,
-        body: Option<types::WorkerBootstrap>,
+        body: Result<types::WorkerBootstrap, String>,
     }
 
     impl<'a> WorkerBootstrap<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::WorkerBootstrap) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::WorkerBootstrap>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `WorkerBootstrap` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/v1/worker/bootstrap`
         pub async fn send(self) -> Result<ResponseValue<types::WorkerBootstrapResult>, Error<()>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/worker/bootstrap", client.baseurl,);
             let request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
@@ -883,48 +863,44 @@ pub mod builder {
     #[derive(Clone)]
     pub struct WorkerTaskAppend<'a> {
         client: &'a super::Client,
-        task: Option<String>,
-        body: Option<types::WorkerAppendTask>,
+        task: Result<String, String>,
+        body: Result<types::WorkerAppendTask, String>,
     }
 
     impl<'a> WorkerTaskAppend<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                task: None,
-                body: None,
+                task: Err("task was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn task<S: ToString>(mut self, value: S) -> Self {
-            self.task = Some(value.to_string());
+        pub fn task<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.task = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for task failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::WorkerAppendTask) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::WorkerAppendTask>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `WorkerAppendTask` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/append`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client, task, body } = self;
-            let (task, body) = match (task, body) {
-                (Some(task), Some(body)) => (task, body),
-                (task, body) => {
-                    let mut missing = Vec::new();
-                    if task.is_none() {
-                        missing.push(stringify!(task));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let task = task.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/v1/worker/task/{}/append",
                 client.baseurl,
@@ -945,48 +921,44 @@ pub mod builder {
     ///[`Client::worker_task_upload_chunk`]: super::Client::worker_task_upload_chunk
     pub struct WorkerTaskUploadChunk<'a> {
         client: &'a super::Client,
-        task: Option<String>,
-        body: Option<reqwest::Body>,
+        task: Result<String, String>,
+        body: Result<reqwest::Body, String>,
     }
 
     impl<'a> WorkerTaskUploadChunk<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                task: None,
-                body: None,
+                task: Err("task was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn task<S: ToString>(mut self, value: S) -> Self {
-            self.task = Some(value.to_string());
+        pub fn task<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.task = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for task failed".to_string());
             self
         }
 
-        pub fn body<B: Into<reqwest::Body>>(mut self, value: B) -> Self {
-            self.body = Some(value.into());
+        pub fn body<B>(mut self, value: B) -> Self
+        where
+            B: TryInto<reqwest::Body>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `reqwest::Body` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/chunk`
         pub async fn send(self) -> Result<ResponseValue<types::UploadedChunk>, Error<()>> {
             let Self { client, task, body } = self;
-            let (task, body) = match (task, body) {
-                (Some(task), Some(body)) => (task, body),
-                (task, body) => {
-                    let mut missing = Vec::new();
-                    if task.is_none() {
-                        missing.push(stringify!(task));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let task = task.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/v1/worker/task/{}/chunk",
                 client.baseurl,
@@ -1016,48 +988,44 @@ pub mod builder {
     #[derive(Clone)]
     pub struct WorkerTaskComplete<'a> {
         client: &'a super::Client,
-        task: Option<String>,
-        body: Option<types::WorkerCompleteTask>,
+        task: Result<String, String>,
+        body: Result<types::WorkerCompleteTask, String>,
     }
 
     impl<'a> WorkerTaskComplete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                task: None,
-                body: None,
+                task: Err("task was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn task<S: ToString>(mut self, value: S) -> Self {
-            self.task = Some(value.to_string());
+        pub fn task<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.task = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for task failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::WorkerCompleteTask) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::WorkerCompleteTask>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `WorkerCompleteTask` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/complete`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client, task, body } = self;
-            let (task, body) = match (task, body) {
-                (Some(task), Some(body)) => (task, body),
-                (task, body) => {
-                    let mut missing = Vec::new();
-                    if task.is_none() {
-                        missing.push(stringify!(task));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let task = task.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/v1/worker/task/{}/complete",
                 client.baseurl,
@@ -1079,48 +1047,44 @@ pub mod builder {
     #[derive(Clone)]
     pub struct WorkerTaskAddOutput<'a> {
         client: &'a super::Client,
-        task: Option<String>,
-        body: Option<types::WorkerAddOutput>,
+        task: Result<String, String>,
+        body: Result<types::WorkerAddOutput, String>,
     }
 
     impl<'a> WorkerTaskAddOutput<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                task: None,
-                body: None,
+                task: Err("task was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn task<S: ToString>(mut self, value: S) -> Self {
-            self.task = Some(value.to_string());
+        pub fn task<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.task = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for task failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::WorkerAddOutput) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::WorkerAddOutput>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `WorkerAddOutput` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/output`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client, task, body } = self;
-            let (task, body) = match (task, body) {
-                (Some(task), Some(body)) => (task, body),
-                (task, body) => {
-                    let mut missing = Vec::new();
-                    if task.is_none() {
-                        missing.push(stringify!(task));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let task = task.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/v1/worker/task/{}/output",
                 client.baseurl,

--- a/progenitor-impl/tests/output/buildomat-positional.out
+++ b/progenitor-impl/tests/output/buildomat-positional.out
@@ -3,6 +3,8 @@ use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
+    #[allow(unused_imports)]
+    use std::convert::TryFrom;
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct Task {
         pub id: String,

--- a/progenitor-impl/tests/output/keeper-builder-tagged.out
+++ b/progenitor-impl/tests/output/keeper-builder-tagged.out
@@ -3,6 +3,8 @@ use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
+    #[allow(unused_imports)]
+    use std::convert::TryFrom;
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct EnrolBody {
         pub host: String,
@@ -182,35 +184,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct Enrol<'a> {
         client: &'a super::Client,
-        body: Option<types::EnrolBody>,
+        body: Result<types::EnrolBody, String>,
     }
 
     impl<'a> Enrol<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::EnrolBody) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::EnrolBody>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `EnrolBody` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/enrol`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/enrol", client.baseurl,);
             let request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
@@ -282,35 +280,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ReportFinish<'a> {
         client: &'a super::Client,
-        body: Option<types::ReportFinishBody>,
+        body: Result<types::ReportFinishBody, String>,
     }
 
     impl<'a> ReportFinish<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::ReportFinishBody) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::ReportFinishBody>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `ReportFinishBody` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/report/finish`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/report/finish", client.baseurl,);
             let request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
@@ -328,35 +322,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ReportOutput<'a> {
         client: &'a super::Client,
-        body: Option<types::ReportOutputBody>,
+        body: Result<types::ReportOutputBody, String>,
     }
 
     impl<'a> ReportOutput<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::ReportOutputBody) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::ReportOutputBody>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `ReportOutputBody` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/report/output`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/report/output", client.baseurl,);
             let request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
@@ -374,35 +364,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ReportStart<'a> {
         client: &'a super::Client,
-        body: Option<types::ReportStartBody>,
+        body: Result<types::ReportStartBody, String>,
     }
 
     impl<'a> ReportStart<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::ReportStartBody) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::ReportStartBody>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `ReportStartBody` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/report/start`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/report/start", client.baseurl,);
             let request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;

--- a/progenitor-impl/tests/output/keeper-builder.out
+++ b/progenitor-impl/tests/output/keeper-builder.out
@@ -3,6 +3,8 @@ use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
+    #[allow(unused_imports)]
+    use std::convert::TryFrom;
     #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
     pub struct EnrolBody {
         pub host: String,
@@ -176,41 +178,39 @@ pub mod builder {
     use super::types;
     #[allow(unused_imports)]
     use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    #[allow(unused_imports)]
+    use std::convert::TryInto;
     ///Builder for [`Client::enrol`]
     ///
     ///[`Client::enrol`]: super::Client::enrol
     #[derive(Clone)]
     pub struct Enrol<'a> {
         client: &'a super::Client,
-        body: Option<types::EnrolBody>,
+        body: Result<types::EnrolBody, String>,
     }
 
     impl<'a> Enrol<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::EnrolBody) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::EnrolBody>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `EnrolBody` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/enrol`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/enrol", client.baseurl,);
             let request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
@@ -282,35 +282,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ReportFinish<'a> {
         client: &'a super::Client,
-        body: Option<types::ReportFinishBody>,
+        body: Result<types::ReportFinishBody, String>,
     }
 
     impl<'a> ReportFinish<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::ReportFinishBody) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::ReportFinishBody>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `ReportFinishBody` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/report/finish`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/report/finish", client.baseurl,);
             let request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
@@ -328,35 +324,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ReportOutput<'a> {
         client: &'a super::Client,
-        body: Option<types::ReportOutputBody>,
+        body: Result<types::ReportOutputBody, String>,
     }
 
     impl<'a> ReportOutput<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::ReportOutputBody) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::ReportOutputBody>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `ReportOutputBody` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/report/output`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/report/output", client.baseurl,);
             let request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
@@ -374,35 +366,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ReportStart<'a> {
         client: &'a super::Client,
-        body: Option<types::ReportStartBody>,
+        body: Result<types::ReportStartBody, String>,
     }
 
     impl<'a> ReportStart<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::ReportStartBody) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::ReportStartBody>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `ReportStartBody` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/report/start`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/report/start", client.baseurl,);
             let request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;

--- a/progenitor-impl/tests/output/keeper-positional.out
+++ b/progenitor-impl/tests/output/keeper-positional.out
@@ -3,6 +3,8 @@ use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
+    #[allow(unused_imports)]
+    use std::convert::TryFrom;
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct EnrolBody {
         pub host: String,

--- a/progenitor-impl/tests/output/nexus-builder-tagged.out
+++ b/progenitor-impl/tests/output/nexus-builder-tagged.out
@@ -3,6 +3,8 @@ use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
+    #[allow(unused_imports)]
+    use std::convert::TryFrom;
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct BlockSize(i64);
     impl std::ops::Deref for BlockSize {
@@ -5164,35 +5166,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct DiskViewById<'a> {
         client: &'a super::Client,
-        id: Option<uuid::Uuid>,
+        id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> DiskViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, id: None }
+            Self {
+                client,
+                id: Err("id was not initialized".to_string()),
+            }
         }
 
-        pub fn id(mut self, value: uuid::Uuid) -> Self {
-            self.id = Some(value);
+        pub fn id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for id failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/by-id/disks/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self { client, id } = self;
-            let (id,) = match (id,) {
-                (Some(id),) => (id,),
-                (id,) => {
-                    let mut missing = Vec::new();
-                    if id.is_none() {
-                        missing.push(stringify!(id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let id = id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/by-id/disks/{}",
                 client.baseurl,
@@ -5220,35 +5218,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ImageGlobalViewById<'a> {
         client: &'a super::Client,
-        id: Option<uuid::Uuid>,
+        id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> ImageGlobalViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, id: None }
+            Self {
+                client,
+                id: Err("id was not initialized".to_string()),
+            }
         }
 
-        pub fn id(mut self, value: uuid::Uuid) -> Self {
-            self.id = Some(value);
+        pub fn id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for id failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/by-id/global-images/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
             let Self { client, id } = self;
-            let (id,) = match (id,) {
-                (Some(id),) => (id,),
-                (id,) => {
-                    let mut missing = Vec::new();
-                    if id.is_none() {
-                        missing.push(stringify!(id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let id = id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/by-id/global-images/{}",
                 client.baseurl,
@@ -5276,35 +5270,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ImageViewById<'a> {
         client: &'a super::Client,
-        id: Option<uuid::Uuid>,
+        id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> ImageViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, id: None }
+            Self {
+                client,
+                id: Err("id was not initialized".to_string()),
+            }
         }
 
-        pub fn id(mut self, value: uuid::Uuid) -> Self {
-            self.id = Some(value);
+        pub fn id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for id failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/by-id/images/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
             let Self { client, id } = self;
-            let (id,) = match (id,) {
-                (Some(id),) => (id,),
-                (id,) => {
-                    let mut missing = Vec::new();
-                    if id.is_none() {
-                        missing.push(stringify!(id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let id = id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/by-id/images/{}",
                 client.baseurl,
@@ -5332,35 +5322,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceViewById<'a> {
         client: &'a super::Client,
-        id: Option<uuid::Uuid>,
+        id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> InstanceViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, id: None }
+            Self {
+                client,
+                id: Err("id was not initialized".to_string()),
+            }
         }
 
-        pub fn id(mut self, value: uuid::Uuid) -> Self {
-            self.id = Some(value);
+        pub fn id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for id failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/by-id/instances/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self { client, id } = self;
-            let (id,) = match (id,) {
-                (Some(id),) => (id,),
-                (id,) => {
-                    let mut missing = Vec::new();
-                    if id.is_none() {
-                        missing.push(stringify!(id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let id = id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/by-id/instances/{}",
                 client.baseurl,
@@ -5389,16 +5375,24 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceNetworkInterfaceViewById<'a> {
         client: &'a super::Client,
-        id: Option<uuid::Uuid>,
+        id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> InstanceNetworkInterfaceViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, id: None }
+            Self {
+                client,
+                id: Err("id was not initialized".to_string()),
+            }
         }
 
-        pub fn id(mut self, value: uuid::Uuid) -> Self {
-            self.id = Some(value);
+        pub fn id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for id failed".to_string());
             self
         }
 
@@ -5407,19 +5401,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
             let Self { client, id } = self;
-            let (id,) = match (id,) {
-                (Some(id),) => (id,),
-                (id,) => {
-                    let mut missing = Vec::new();
-                    if id.is_none() {
-                        missing.push(stringify!(id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let id = id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/by-id/network-interfaces/{}",
                 client.baseurl,
@@ -5447,35 +5429,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct OrganizationViewById<'a> {
         client: &'a super::Client,
-        id: Option<uuid::Uuid>,
+        id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> OrganizationViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, id: None }
+            Self {
+                client,
+                id: Err("id was not initialized".to_string()),
+            }
         }
 
-        pub fn id(mut self, value: uuid::Uuid) -> Self {
-            self.id = Some(value);
+        pub fn id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for id failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/by-id/organizations/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self { client, id } = self;
-            let (id,) = match (id,) {
-                (Some(id),) => (id,),
-                (id,) => {
-                    let mut missing = Vec::new();
-                    if id.is_none() {
-                        missing.push(stringify!(id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let id = id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/by-id/organizations/{}",
                 client.baseurl,
@@ -5503,35 +5481,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ProjectViewById<'a> {
         client: &'a super::Client,
-        id: Option<uuid::Uuid>,
+        id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> ProjectViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, id: None }
+            Self {
+                client,
+                id: Err("id was not initialized".to_string()),
+            }
         }
 
-        pub fn id(mut self, value: uuid::Uuid) -> Self {
-            self.id = Some(value);
+        pub fn id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for id failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/by-id/projects/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self { client, id } = self;
-            let (id,) = match (id,) {
-                (Some(id),) => (id,),
-                (id,) => {
-                    let mut missing = Vec::new();
-                    if id.is_none() {
-                        missing.push(stringify!(id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let id = id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/by-id/projects/{}",
                 client.baseurl,
@@ -5559,35 +5533,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SnapshotViewById<'a> {
         client: &'a super::Client,
-        id: Option<uuid::Uuid>,
+        id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SnapshotViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, id: None }
+            Self {
+                client,
+                id: Err("id was not initialized".to_string()),
+            }
         }
 
-        pub fn id(mut self, value: uuid::Uuid) -> Self {
-            self.id = Some(value);
+        pub fn id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for id failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/by-id/snapshots/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
             let Self { client, id } = self;
-            let (id,) = match (id,) {
-                (Some(id),) => (id,),
-                (id,) => {
-                    let mut missing = Vec::new();
-                    if id.is_none() {
-                        missing.push(stringify!(id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let id = id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/by-id/snapshots/{}",
                 client.baseurl,
@@ -5615,35 +5585,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcRouterRouteViewById<'a> {
         client: &'a super::Client,
-        id: Option<uuid::Uuid>,
+        id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcRouterRouteViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, id: None }
+            Self {
+                client,
+                id: Err("id was not initialized".to_string()),
+            }
         }
 
-        pub fn id(mut self, value: uuid::Uuid) -> Self {
-            self.id = Some(value);
+        pub fn id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for id failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/by-id/vpc-router-routes/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self { client, id } = self;
-            let (id,) = match (id,) {
-                (Some(id),) => (id,),
-                (id,) => {
-                    let mut missing = Vec::new();
-                    if id.is_none() {
-                        missing.push(stringify!(id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let id = id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/by-id/vpc-router-routes/{}",
                 client.baseurl,
@@ -5671,35 +5637,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcRouterViewById<'a> {
         client: &'a super::Client,
-        id: Option<uuid::Uuid>,
+        id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcRouterViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, id: None }
+            Self {
+                client,
+                id: Err("id was not initialized".to_string()),
+            }
         }
 
-        pub fn id(mut self, value: uuid::Uuid) -> Self {
-            self.id = Some(value);
+        pub fn id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for id failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/by-id/vpc-routers/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self { client, id } = self;
-            let (id,) = match (id,) {
-                (Some(id),) => (id,),
-                (id,) => {
-                    let mut missing = Vec::new();
-                    if id.is_none() {
-                        missing.push(stringify!(id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let id = id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/by-id/vpc-routers/{}",
                 client.baseurl,
@@ -5727,35 +5689,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcSubnetViewById<'a> {
         client: &'a super::Client,
-        id: Option<uuid::Uuid>,
+        id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcSubnetViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, id: None }
+            Self {
+                client,
+                id: Err("id was not initialized".to_string()),
+            }
         }
 
-        pub fn id(mut self, value: uuid::Uuid) -> Self {
-            self.id = Some(value);
+        pub fn id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for id failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/by-id/vpc-subnets/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self { client, id } = self;
-            let (id,) = match (id,) {
-                (Some(id),) => (id,),
-                (id,) => {
-                    let mut missing = Vec::new();
-                    if id.is_none() {
-                        missing.push(stringify!(id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let id = id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/by-id/vpc-subnets/{}",
                 client.baseurl,
@@ -5783,35 +5741,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcViewById<'a> {
         client: &'a super::Client,
-        id: Option<uuid::Uuid>,
+        id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, id: None }
+            Self {
+                client,
+                id: Err("id was not initialized".to_string()),
+            }
         }
 
-        pub fn id(mut self, value: uuid::Uuid) -> Self {
-            self.id = Some(value);
+        pub fn id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for id failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/by-id/vpcs/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self { client, id } = self;
-            let (id,) = match (id,) {
-                (Some(id),) => (id,),
-                (id,) => {
-                    let mut missing = Vec::new();
-                    if id.is_none() {
-                        missing.push(stringify!(id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let id = id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/by-id/vpcs/{}",
                 client.baseurl,
@@ -5839,35 +5793,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct DeviceAuthRequest<'a> {
         client: &'a super::Client,
-        body: Option<types::DeviceAuthRequest>,
+        body: Result<types::DeviceAuthRequest, String>,
     }
 
     impl<'a> DeviceAuthRequest<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::DeviceAuthRequest) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::DeviceAuthRequest>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `DeviceAuthRequest` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/device/auth`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/device/auth", client.baseurl,);
             let request = client.client.post(url).form_urlencoded(&body)?.build()?;
             let result = client.client.execute(request).await;
@@ -5885,35 +5835,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct DeviceAuthConfirm<'a> {
         client: &'a super::Client,
-        body: Option<types::DeviceAuthVerify>,
+        body: Result<types::DeviceAuthVerify, String>,
     }
 
     impl<'a> DeviceAuthConfirm<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::DeviceAuthVerify) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::DeviceAuthVerify>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `DeviceAuthVerify` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/device/confirm`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/device/confirm", client.baseurl,);
             let request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
@@ -5937,35 +5883,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct DeviceAccessToken<'a> {
         client: &'a super::Client,
-        body: Option<types::DeviceAccessTokenRequest>,
+        body: Result<types::DeviceAccessTokenRequest, String>,
     }
 
     impl<'a> DeviceAccessToken<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::DeviceAccessTokenRequest) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::DeviceAccessTokenRequest>,
+        {
+            self.body = value.try_into().map_err(|_| {
+                "conversion to `DeviceAccessTokenRequest` for body failed".to_string()
+            });
             self
         }
 
         ///Sends a `POST` request to `/device/token`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/device/token", client.baseurl,);
             let request = client.client.post(url).form_urlencoded(&body)?.build()?;
             let result = client.client.execute(request).await;
@@ -5983,33 +5925,49 @@ pub mod builder {
     #[derive(Clone)]
     pub struct RackList<'a> {
         client: &'a super::Client,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::IdSortMode>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::IdSortMode>, String>,
     }
 
     impl<'a> RackList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::IdSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::IdSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < IdSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -6023,6 +5981,9 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/hardware/racks", client.baseurl,);
             let mut query = Vec::new();
             if let Some(v) = &limit {
@@ -6058,9 +6019,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -6074,7 +6035,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -6103,38 +6064,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct RackView<'a> {
         client: &'a super::Client,
-        rack_id: Option<uuid::Uuid>,
+        rack_id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> RackView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                rack_id: None,
+                rack_id: Err("rack_id was not initialized".to_string()),
             }
         }
 
-        pub fn rack_id(mut self, value: uuid::Uuid) -> Self {
-            self.rack_id = Some(value);
+        pub fn rack_id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.rack_id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for rack_id failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/hardware/racks/{rack_id}`
         pub async fn send(self) -> Result<ResponseValue<types::Rack>, Error<types::Error>> {
             let Self { client, rack_id } = self;
-            let (rack_id,) = match (rack_id,) {
-                (Some(rack_id),) => (rack_id,),
-                (rack_id,) => {
-                    let mut missing = Vec::new();
-                    if rack_id.is_none() {
-                        missing.push(stringify!(rack_id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let rack_id = rack_id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/hardware/racks/{}",
                 client.baseurl,
@@ -6162,33 +6116,49 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SledList<'a> {
         client: &'a super::Client,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::IdSortMode>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::IdSortMode>, String>,
     }
 
     impl<'a> SledList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::IdSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::IdSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < IdSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -6202,6 +6172,9 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/hardware/sleds", client.baseurl,);
             let mut query = Vec::new();
             if let Some(v) = &limit {
@@ -6237,9 +6210,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -6253,7 +6226,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -6282,38 +6255,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SledView<'a> {
         client: &'a super::Client,
-        sled_id: Option<uuid::Uuid>,
+        sled_id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SledView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                sled_id: None,
+                sled_id: Err("sled_id was not initialized".to_string()),
             }
         }
 
-        pub fn sled_id(mut self, value: uuid::Uuid) -> Self {
-            self.sled_id = Some(value);
+        pub fn sled_id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.sled_id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for sled_id failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/hardware/sleds/{sled_id}`
         pub async fn send(self) -> Result<ResponseValue<types::Sled>, Error<types::Error>> {
             let Self { client, sled_id } = self;
-            let (sled_id,) = match (sled_id,) {
-                (Some(sled_id),) => (sled_id,),
-                (sled_id,) => {
-                    let mut missing = Vec::new();
-                    if sled_id.is_none() {
-                        missing.push(stringify!(sled_id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let sled_id = sled_id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/hardware/sleds/{}",
                 client.baseurl,
@@ -6341,33 +6307,49 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ImageGlobalList<'a> {
         client: &'a super::Client,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> ImageGlobalList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -6381,6 +6363,9 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/images", client.baseurl,);
             let mut query = Vec::new();
             if let Some(v) = &limit {
@@ -6416,9 +6401,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -6432,7 +6417,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -6461,35 +6446,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ImageGlobalCreate<'a> {
         client: &'a super::Client,
-        body: Option<types::GlobalImageCreate>,
+        body: Result<types::GlobalImageCreate, String>,
     }
 
     impl<'a> ImageGlobalCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::GlobalImageCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::GlobalImageCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `GlobalImageCreate` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/images`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/images", client.baseurl,);
             let request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
@@ -6513,38 +6494,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ImageGlobalView<'a> {
         client: &'a super::Client,
-        image_name: Option<types::Name>,
+        image_name: Result<types::Name, String>,
     }
 
     impl<'a> ImageGlobalView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                image_name: None,
+                image_name: Err("image_name was not initialized".to_string()),
             }
         }
 
-        pub fn image_name(mut self, value: types::Name) -> Self {
-            self.image_name = Some(value);
+        pub fn image_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.image_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for image_name failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/images/{image_name}`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
             let Self { client, image_name } = self;
-            let (image_name,) = match (image_name,) {
-                (Some(image_name),) => (image_name,),
-                (image_name,) => {
-                    let mut missing = Vec::new();
-                    if image_name.is_none() {
-                        missing.push(stringify!(image_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let image_name = image_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/images/{}",
                 client.baseurl,
@@ -6572,38 +6546,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ImageGlobalDelete<'a> {
         client: &'a super::Client,
-        image_name: Option<types::Name>,
+        image_name: Result<types::Name, String>,
     }
 
     impl<'a> ImageGlobalDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                image_name: None,
+                image_name: Err("image_name was not initialized".to_string()),
             }
         }
 
-        pub fn image_name(mut self, value: types::Name) -> Self {
-            self.image_name = Some(value);
+        pub fn image_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.image_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for image_name failed".to_string());
             self
         }
 
         ///Sends a `DELETE` request to `/images/{image_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, image_name } = self;
-            let (image_name,) = match (image_name,) {
-                (Some(image_name),) => (image_name,),
-                (image_name,) => {
-                    let mut missing = Vec::new();
-                    if image_name.is_none() {
-                        missing.push(stringify!(image_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let image_name = image_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/images/{}",
                 client.baseurl,
@@ -6631,33 +6598,49 @@ pub mod builder {
     #[derive(Clone)]
     pub struct IpPoolList<'a> {
         client: &'a super::Client,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameOrIdSortMode>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameOrIdSortMode>, String>,
     }
 
     impl<'a> IpPoolList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameOrIdSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameOrIdSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameOrIdSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -6671,6 +6654,9 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/ip-pools", client.baseurl,);
             let mut query = Vec::new();
             if let Some(v) = &limit {
@@ -6706,9 +6692,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -6722,7 +6708,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -6751,35 +6737,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct IpPoolCreate<'a> {
         client: &'a super::Client,
-        body: Option<types::IpPoolCreate>,
+        body: Result<types::IpPoolCreate, String>,
     }
 
     impl<'a> IpPoolCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::IpPoolCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::IpPoolCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `IpPoolCreate` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/ip-pools`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/ip-pools", client.baseurl,);
             let request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
@@ -6803,38 +6785,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct IpPoolView<'a> {
         client: &'a super::Client,
-        pool_name: Option<types::Name>,
+        pool_name: Result<types::Name, String>,
     }
 
     impl<'a> IpPoolView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                pool_name: None,
+                pool_name: Err("pool_name was not initialized".to_string()),
             }
         }
 
-        pub fn pool_name(mut self, value: types::Name) -> Self {
-            self.pool_name = Some(value);
+        pub fn pool_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.pool_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for pool_name failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/ip-pools/{pool_name}`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client, pool_name } = self;
-            let (pool_name,) = match (pool_name,) {
-                (Some(pool_name),) => (pool_name,),
-                (pool_name,) => {
-                    let mut missing = Vec::new();
-                    if pool_name.is_none() {
-                        missing.push(stringify!(pool_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/ip-pools/{}",
                 client.baseurl,
@@ -6862,26 +6837,36 @@ pub mod builder {
     #[derive(Clone)]
     pub struct IpPoolUpdate<'a> {
         client: &'a super::Client,
-        pool_name: Option<types::Name>,
-        body: Option<types::IpPoolUpdate>,
+        pool_name: Result<types::Name, String>,
+        body: Result<types::IpPoolUpdate, String>,
     }
 
     impl<'a> IpPoolUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                pool_name: None,
-                body: None,
+                pool_name: Err("pool_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn pool_name(mut self, value: types::Name) -> Self {
-            self.pool_name = Some(value);
+        pub fn pool_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.pool_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for pool_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::IpPoolUpdate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::IpPoolUpdate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `IpPoolUpdate` for body failed".to_string());
             self
         }
 
@@ -6892,22 +6877,8 @@ pub mod builder {
                 pool_name,
                 body,
             } = self;
-            let (pool_name, body) = match (pool_name, body) {
-                (Some(pool_name), Some(body)) => (pool_name, body),
-                (pool_name, body) => {
-                    let mut missing = Vec::new();
-                    if pool_name.is_none() {
-                        missing.push(stringify!(pool_name));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let pool_name = pool_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/ip-pools/{}",
                 client.baseurl,
@@ -6935,38 +6906,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct IpPoolDelete<'a> {
         client: &'a super::Client,
-        pool_name: Option<types::Name>,
+        pool_name: Result<types::Name, String>,
     }
 
     impl<'a> IpPoolDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                pool_name: None,
+                pool_name: Err("pool_name was not initialized".to_string()),
             }
         }
 
-        pub fn pool_name(mut self, value: types::Name) -> Self {
-            self.pool_name = Some(value);
+        pub fn pool_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.pool_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for pool_name failed".to_string());
             self
         }
 
         ///Sends a `DELETE` request to `/ip-pools/{pool_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, pool_name } = self;
-            let (pool_name,) = match (pool_name,) {
-                (Some(pool_name),) => (pool_name,),
-                (pool_name,) => {
-                    let mut missing = Vec::new();
-                    if pool_name.is_none() {
-                        missing.push(stringify!(pool_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/ip-pools/{}",
                 client.baseurl,
@@ -6994,33 +6958,49 @@ pub mod builder {
     #[derive(Clone)]
     pub struct IpPoolRangeList<'a> {
         client: &'a super::Client,
-        pool_name: Option<types::Name>,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
+        pool_name: Result<types::Name, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
     }
 
     impl<'a> IpPoolRangeList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                pool_name: None,
-                limit: None,
-                page_token: None,
+                pool_name: Err("pool_name was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
             }
         }
 
-        pub fn pool_name(mut self, value: types::Name) -> Self {
-            self.pool_name = Some(value);
+        pub fn pool_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.pool_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for pool_name failed".to_string());
             self
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
@@ -7034,19 +7014,9 @@ pub mod builder {
                 limit,
                 page_token,
             } = self;
-            let (pool_name,) = match (pool_name,) {
-                (Some(pool_name),) => (pool_name,),
-                (pool_name,) => {
-                    let mut missing = Vec::new();
-                    if pool_name.is_none() {
-                        missing.push(stringify!(pool_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let pool_name = pool_name.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/ip-pools/{}/ranges",
                 client.baseurl,
@@ -7083,8 +7053,8 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
+                limit: Ok(None),
+                page_token: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -7098,7 +7068,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -7127,26 +7097,36 @@ pub mod builder {
     #[derive(Clone)]
     pub struct IpPoolRangeAdd<'a> {
         client: &'a super::Client,
-        pool_name: Option<types::Name>,
-        body: Option<types::IpRange>,
+        pool_name: Result<types::Name, String>,
+        body: Result<types::IpRange, String>,
     }
 
     impl<'a> IpPoolRangeAdd<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                pool_name: None,
-                body: None,
+                pool_name: Err("pool_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn pool_name(mut self, value: types::Name) -> Self {
-            self.pool_name = Some(value);
+        pub fn pool_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.pool_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for pool_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::IpRange) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::IpRange>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `IpRange` for body failed".to_string());
             self
         }
 
@@ -7157,22 +7137,8 @@ pub mod builder {
                 pool_name,
                 body,
             } = self;
-            let (pool_name, body) = match (pool_name, body) {
-                (Some(pool_name), Some(body)) => (pool_name, body),
-                (pool_name, body) => {
-                    let mut missing = Vec::new();
-                    if pool_name.is_none() {
-                        missing.push(stringify!(pool_name));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let pool_name = pool_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/ip-pools/{}/ranges/add",
                 client.baseurl,
@@ -7200,26 +7166,36 @@ pub mod builder {
     #[derive(Clone)]
     pub struct IpPoolRangeRemove<'a> {
         client: &'a super::Client,
-        pool_name: Option<types::Name>,
-        body: Option<types::IpRange>,
+        pool_name: Result<types::Name, String>,
+        body: Result<types::IpRange, String>,
     }
 
     impl<'a> IpPoolRangeRemove<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                pool_name: None,
-                body: None,
+                pool_name: Err("pool_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn pool_name(mut self, value: types::Name) -> Self {
-            self.pool_name = Some(value);
+        pub fn pool_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.pool_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for pool_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::IpRange) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::IpRange>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `IpRange` for body failed".to_string());
             self
         }
 
@@ -7230,22 +7206,8 @@ pub mod builder {
                 pool_name,
                 body,
             } = self;
-            let (pool_name, body) = match (pool_name, body) {
-                (Some(pool_name), Some(body)) => (pool_name, body),
-                (pool_name, body) => {
-                    let mut missing = Vec::new();
-                    if pool_name.is_none() {
-                        missing.push(stringify!(pool_name));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let pool_name = pool_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/ip-pools/{}/ranges/remove",
                 client.baseurl,
@@ -7273,35 +7235,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SpoofLogin<'a> {
         client: &'a super::Client,
-        body: Option<types::SpoofLoginBody>,
+        body: Result<types::SpoofLoginBody, String>,
     }
 
     impl<'a> SpoofLogin<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::SpoofLoginBody) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::SpoofLoginBody>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `SpoofLoginBody` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/login`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/login", client.baseurl,);
             let request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
@@ -7319,26 +7277,36 @@ pub mod builder {
     #[derive(Clone)]
     pub struct Login<'a> {
         client: &'a super::Client,
-        silo_name: Option<types::Name>,
-        provider_name: Option<types::Name>,
+        silo_name: Result<types::Name, String>,
+        provider_name: Result<types::Name, String>,
     }
 
     impl<'a> Login<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                silo_name: None,
-                provider_name: None,
+                silo_name: Err("silo_name was not initialized".to_string()),
+                provider_name: Err("provider_name was not initialized".to_string()),
             }
         }
 
-        pub fn silo_name(mut self, value: types::Name) -> Self {
-            self.silo_name = Some(value);
+        pub fn silo_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.silo_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for silo_name failed".to_string());
             self
         }
 
-        pub fn provider_name(mut self, value: types::Name) -> Self {
-            self.provider_name = Some(value);
+        pub fn provider_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.provider_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for provider_name failed".to_string());
             self
         }
 
@@ -7349,22 +7317,8 @@ pub mod builder {
                 silo_name,
                 provider_name,
             } = self;
-            let (silo_name, provider_name) = match (silo_name, provider_name) {
-                (Some(silo_name), Some(provider_name)) => (silo_name, provider_name),
-                (silo_name, provider_name) => {
-                    let mut missing = Vec::new();
-                    if silo_name.is_none() {
-                        missing.push(stringify!(silo_name));
-                    }
-                    if provider_name.is_none() {
-                        missing.push(stringify!(provider_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let silo_name = silo_name.map_err(Error::InvalidRequest)?;
+            let provider_name = provider_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/login/{}/{}",
                 client.baseurl,
@@ -7386,33 +7340,48 @@ pub mod builder {
     ///[`ClientLoginExt::consume_credentials`]: super::ClientLoginExt::consume_credentials
     pub struct ConsumeCredentials<'a> {
         client: &'a super::Client,
-        silo_name: Option<types::Name>,
-        provider_name: Option<types::Name>,
-        body: Option<reqwest::Body>,
+        silo_name: Result<types::Name, String>,
+        provider_name: Result<types::Name, String>,
+        body: Result<reqwest::Body, String>,
     }
 
     impl<'a> ConsumeCredentials<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                silo_name: None,
-                provider_name: None,
-                body: None,
+                silo_name: Err("silo_name was not initialized".to_string()),
+                provider_name: Err("provider_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn silo_name(mut self, value: types::Name) -> Self {
-            self.silo_name = Some(value);
+        pub fn silo_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.silo_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for silo_name failed".to_string());
             self
         }
 
-        pub fn provider_name(mut self, value: types::Name) -> Self {
-            self.provider_name = Some(value);
+        pub fn provider_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.provider_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for provider_name failed".to_string());
             self
         }
 
-        pub fn body<B: Into<reqwest::Body>>(mut self, value: B) -> Self {
-            self.body = Some(value.into());
+        pub fn body<B>(mut self, value: B) -> Self
+        where
+            B: TryInto<reqwest::Body>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `reqwest::Body` for body failed".to_string());
             self
         }
 
@@ -7424,27 +7393,9 @@ pub mod builder {
                 provider_name,
                 body,
             } = self;
-            let (silo_name, provider_name, body) = match (silo_name, provider_name, body) {
-                (Some(silo_name), Some(provider_name), Some(body)) => {
-                    (silo_name, provider_name, body)
-                }
-                (silo_name, provider_name, body) => {
-                    let mut missing = Vec::new();
-                    if silo_name.is_none() {
-                        missing.push(stringify!(silo_name));
-                    }
-                    if provider_name.is_none() {
-                        missing.push(stringify!(provider_name));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let silo_name = silo_name.map_err(Error::InvalidRequest)?;
+            let provider_name = provider_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/login/{}/{}",
                 client.baseurl,
@@ -7502,33 +7453,49 @@ pub mod builder {
     #[derive(Clone)]
     pub struct OrganizationList<'a> {
         client: &'a super::Client,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameOrIdSortMode>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameOrIdSortMode>, String>,
     }
 
     impl<'a> OrganizationList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameOrIdSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameOrIdSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameOrIdSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -7542,6 +7509,9 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/organizations", client.baseurl,);
             let mut query = Vec::new();
             if let Some(v) = &limit {
@@ -7577,9 +7547,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -7593,7 +7563,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -7622,35 +7592,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct OrganizationCreate<'a> {
         client: &'a super::Client,
-        body: Option<types::OrganizationCreate>,
+        body: Result<types::OrganizationCreate, String>,
     }
 
     impl<'a> OrganizationCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::OrganizationCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::OrganizationCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `OrganizationCreate` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/organizations`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/organizations", client.baseurl,);
             let request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
@@ -7674,19 +7640,24 @@ pub mod builder {
     #[derive(Clone)]
     pub struct OrganizationView<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
     }
 
     impl<'a> OrganizationView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
@@ -7696,19 +7667,7 @@ pub mod builder {
                 client,
                 organization_name,
             } = self;
-            let (organization_name,) = match (organization_name,) {
-                (Some(organization_name),) => (organization_name,),
-                (organization_name,) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}",
                 client.baseurl,
@@ -7736,26 +7695,36 @@ pub mod builder {
     #[derive(Clone)]
     pub struct OrganizationUpdate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        body: Option<types::OrganizationUpdate>,
+        organization_name: Result<types::Name, String>,
+        body: Result<types::OrganizationUpdate, String>,
     }
 
     impl<'a> OrganizationUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::OrganizationUpdate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::OrganizationUpdate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `OrganizationUpdate` for body failed".to_string());
             self
         }
 
@@ -7766,22 +7735,8 @@ pub mod builder {
                 organization_name,
                 body,
             } = self;
-            let (organization_name, body) = match (organization_name, body) {
-                (Some(organization_name), Some(body)) => (organization_name, body),
-                (organization_name, body) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}",
                 client.baseurl,
@@ -7809,19 +7764,24 @@ pub mod builder {
     #[derive(Clone)]
     pub struct OrganizationDelete<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
     }
 
     impl<'a> OrganizationDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
@@ -7831,19 +7791,7 @@ pub mod builder {
                 client,
                 organization_name,
             } = self;
-            let (organization_name,) = match (organization_name,) {
-                (Some(organization_name),) => (organization_name,),
-                (organization_name,) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}",
                 client.baseurl,
@@ -7871,19 +7819,24 @@ pub mod builder {
     #[derive(Clone)]
     pub struct OrganizationPolicyView<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
     }
 
     impl<'a> OrganizationPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
@@ -7895,19 +7848,7 @@ pub mod builder {
                 client,
                 organization_name,
             } = self;
-            let (organization_name,) = match (organization_name,) {
-                (Some(organization_name),) => (organization_name,),
-                (organization_name,) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/policy",
                 client.baseurl,
@@ -7935,26 +7876,36 @@ pub mod builder {
     #[derive(Clone)]
     pub struct OrganizationPolicyUpdate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        body: Option<types::OrganizationRolePolicy>,
+        organization_name: Result<types::Name, String>,
+        body: Result<types::OrganizationRolePolicy, String>,
     }
 
     impl<'a> OrganizationPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::OrganizationRolePolicy) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::OrganizationRolePolicy>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `OrganizationRolePolicy` for body failed".to_string());
             self
         }
 
@@ -7967,22 +7918,8 @@ pub mod builder {
                 organization_name,
                 body,
             } = self;
-            let (organization_name, body) = match (organization_name, body) {
-                (Some(organization_name), Some(body)) => (organization_name, body),
-                (organization_name, body) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/policy",
                 client.baseurl,
@@ -8010,40 +7947,61 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ProjectList<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameOrIdSortMode>,
+        organization_name: Result<types::Name, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameOrIdSortMode>, String>,
     }
 
     impl<'a> ProjectList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameOrIdSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameOrIdSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameOrIdSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -8059,19 +8017,10 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
-            let (organization_name,) = match (organization_name,) {
-                (Some(organization_name),) => (organization_name,),
-                (organization_name,) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects",
                 client.baseurl,
@@ -8112,9 +8061,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -8128,7 +8077,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -8157,26 +8106,36 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ProjectCreate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        body: Option<types::ProjectCreate>,
+        organization_name: Result<types::Name, String>,
+        body: Result<types::ProjectCreate, String>,
     }
 
     impl<'a> ProjectCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::ProjectCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::ProjectCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `ProjectCreate` for body failed".to_string());
             self
         }
 
@@ -8188,22 +8147,8 @@ pub mod builder {
                 organization_name,
                 body,
             } = self;
-            let (organization_name, body) = match (organization_name, body) {
-                (Some(organization_name), Some(body)) => (organization_name, body),
-                (organization_name, body) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects",
                 client.baseurl,
@@ -8231,26 +8176,36 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ProjectView<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
     }
 
     impl<'a> ProjectView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
@@ -8262,22 +8217,8 @@ pub mod builder {
                 organization_name,
                 project_name,
             } = self;
-            let (organization_name, project_name) = match (organization_name, project_name) {
-                (Some(organization_name), Some(project_name)) => (organization_name, project_name),
-                (organization_name, project_name) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if project_name.is_none() {
-                        missing.push(stringify!(project_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}",
                 client.baseurl,
@@ -8306,33 +8247,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ProjectUpdate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        body: Option<types::ProjectUpdate>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        body: Result<types::ProjectUpdate, String>,
     }
 
     impl<'a> ProjectUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::ProjectUpdate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::ProjectUpdate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `ProjectUpdate` for body failed".to_string());
             self
         }
 
@@ -8345,28 +8301,9 @@ pub mod builder {
                 project_name,
                 body,
             } = self;
-            let (organization_name, project_name, body) =
-                match (organization_name, project_name, body) {
-                    (Some(organization_name), Some(project_name), Some(body)) => {
-                        (organization_name, project_name, body)
-                    }
-                    (organization_name, project_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}",
                 client.baseurl,
@@ -8395,26 +8332,36 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ProjectDelete<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
     }
 
     impl<'a> ProjectDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
@@ -8426,22 +8373,8 @@ pub mod builder {
                 organization_name,
                 project_name,
             } = self;
-            let (organization_name, project_name) = match (organization_name, project_name) {
-                (Some(organization_name), Some(project_name)) => (organization_name, project_name),
-                (organization_name, project_name) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if project_name.is_none() {
-                        missing.push(stringify!(project_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}",
                 client.baseurl,
@@ -8470,47 +8403,73 @@ pub mod builder {
     #[derive(Clone)]
     pub struct DiskList<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> DiskList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -8527,22 +8486,11 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
-            let (organization_name, project_name) = match (organization_name, project_name) {
-                (Some(organization_name), Some(project_name)) => (organization_name, project_name),
-                (organization_name, project_name) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if project_name.is_none() {
-                        missing.push(stringify!(project_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/disks",
                 client.baseurl,
@@ -8584,9 +8532,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -8600,7 +8548,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -8629,33 +8577,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct DiskCreate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        body: Option<types::DiskCreate>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        body: Result<types::DiskCreate, String>,
     }
 
     impl<'a> DiskCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::DiskCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::DiskCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `DiskCreate` for body failed".to_string());
             self
         }
 
@@ -8668,28 +8631,9 @@ pub mod builder {
                 project_name,
                 body,
             } = self;
-            let (organization_name, project_name, body) =
-                match (organization_name, project_name, body) {
-                    (Some(organization_name), Some(project_name), Some(body)) => {
-                        (organization_name, project_name, body)
-                    }
-                    (organization_name, project_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/disks",
                 client.baseurl,
@@ -8718,33 +8662,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct DiskView<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        disk_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        disk_name: Result<types::Name, String>,
     }
 
     impl<'a> DiskView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                disk_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                disk_name: Err("disk_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn disk_name(mut self, value: types::Name) -> Self {
-            self.disk_name = Some(value);
+        pub fn disk_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.disk_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for disk_name failed".to_string());
             self
         }
 
@@ -8758,28 +8717,9 @@ pub mod builder {
                 project_name,
                 disk_name,
             } = self;
-            let (organization_name, project_name, disk_name) =
-                match (organization_name, project_name, disk_name) {
-                    (Some(organization_name), Some(project_name), Some(disk_name)) => {
-                        (organization_name, project_name, disk_name)
-                    }
-                    (organization_name, project_name, disk_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if disk_name.is_none() {
-                            missing.push(stringify!(disk_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let disk_name = disk_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/disks/{}",
                 client.baseurl,
@@ -8809,33 +8749,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct DiskDelete<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        disk_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        disk_name: Result<types::Name, String>,
     }
 
     impl<'a> DiskDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                disk_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                disk_name: Err("disk_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn disk_name(mut self, value: types::Name) -> Self {
-            self.disk_name = Some(value);
+        pub fn disk_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.disk_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for disk_name failed".to_string());
             self
         }
 
@@ -8849,28 +8804,9 @@ pub mod builder {
                 project_name,
                 disk_name,
             } = self;
-            let (organization_name, project_name, disk_name) =
-                match (organization_name, project_name, disk_name) {
-                    (Some(organization_name), Some(project_name), Some(disk_name)) => {
-                        (organization_name, project_name, disk_name)
-                    }
-                    (organization_name, project_name, disk_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if disk_name.is_none() {
-                            missing.push(stringify!(disk_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let disk_name = disk_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/disks/{}",
                 client.baseurl,
@@ -8900,47 +8836,73 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ImageList<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> ImageList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -8957,22 +8919,11 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
-            let (organization_name, project_name) = match (organization_name, project_name) {
-                (Some(organization_name), Some(project_name)) => (organization_name, project_name),
-                (organization_name, project_name) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if project_name.is_none() {
-                        missing.push(stringify!(project_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/images",
                 client.baseurl,
@@ -9014,9 +8965,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -9030,7 +8981,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -9059,33 +9010,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ImageCreate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        body: Option<types::ImageCreate>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        body: Result<types::ImageCreate, String>,
     }
 
     impl<'a> ImageCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::ImageCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::ImageCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `ImageCreate` for body failed".to_string());
             self
         }
 
@@ -9098,28 +9064,9 @@ pub mod builder {
                 project_name,
                 body,
             } = self;
-            let (organization_name, project_name, body) =
-                match (organization_name, project_name, body) {
-                    (Some(organization_name), Some(project_name), Some(body)) => {
-                        (organization_name, project_name, body)
-                    }
-                    (organization_name, project_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/images",
                 client.baseurl,
@@ -9148,33 +9095,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ImageView<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        image_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        image_name: Result<types::Name, String>,
     }
 
     impl<'a> ImageView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                image_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                image_name: Err("image_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn image_name(mut self, value: types::Name) -> Self {
-            self.image_name = Some(value);
+        pub fn image_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.image_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for image_name failed".to_string());
             self
         }
 
@@ -9188,28 +9150,9 @@ pub mod builder {
                 project_name,
                 image_name,
             } = self;
-            let (organization_name, project_name, image_name) =
-                match (organization_name, project_name, image_name) {
-                    (Some(organization_name), Some(project_name), Some(image_name)) => {
-                        (organization_name, project_name, image_name)
-                    }
-                    (organization_name, project_name, image_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if image_name.is_none() {
-                            missing.push(stringify!(image_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let image_name = image_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/images/{}",
                 client.baseurl,
@@ -9239,33 +9182,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ImageDelete<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        image_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        image_name: Result<types::Name, String>,
     }
 
     impl<'a> ImageDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                image_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                image_name: Err("image_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn image_name(mut self, value: types::Name) -> Self {
-            self.image_name = Some(value);
+        pub fn image_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.image_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for image_name failed".to_string());
             self
         }
 
@@ -9279,28 +9237,9 @@ pub mod builder {
                 project_name,
                 image_name,
             } = self;
-            let (organization_name, project_name, image_name) =
-                match (organization_name, project_name, image_name) {
-                    (Some(organization_name), Some(project_name), Some(image_name)) => {
-                        (organization_name, project_name, image_name)
-                    }
-                    (organization_name, project_name, image_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if image_name.is_none() {
-                            missing.push(stringify!(image_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let image_name = image_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/images/{}",
                 client.baseurl,
@@ -9330,47 +9269,73 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceList<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> InstanceList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -9388,22 +9353,11 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
-            let (organization_name, project_name) = match (organization_name, project_name) {
-                (Some(organization_name), Some(project_name)) => (organization_name, project_name),
-                (organization_name, project_name) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if project_name.is_none() {
-                        missing.push(stringify!(project_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances",
                 client.baseurl,
@@ -9446,9 +9400,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -9462,7 +9416,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -9491,33 +9445,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceCreate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        body: Option<types::InstanceCreate>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        body: Result<types::InstanceCreate, String>,
     }
 
     impl<'a> InstanceCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::InstanceCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::InstanceCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `InstanceCreate` for body failed".to_string());
             self
         }
 
@@ -9531,28 +9500,9 @@ pub mod builder {
                 project_name,
                 body,
             } = self;
-            let (organization_name, project_name, body) =
-                match (organization_name, project_name, body) {
-                    (Some(organization_name), Some(project_name), Some(body)) => {
-                        (organization_name, project_name, body)
-                    }
-                    (organization_name, project_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances",
                 client.baseurl,
@@ -9581,33 +9531,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceView<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
     }
 
     impl<'a> InstanceView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
@@ -9621,28 +9586,9 @@ pub mod builder {
                 project_name,
                 instance_name,
             } = self;
-            let (organization_name, project_name, instance_name) =
-                match (organization_name, project_name, instance_name) {
-                    (Some(organization_name), Some(project_name), Some(instance_name)) => {
-                        (organization_name, project_name, instance_name)
-                    }
-                    (organization_name, project_name, instance_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if instance_name.is_none() {
-                            missing.push(stringify!(instance_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}",
                 client.baseurl,
@@ -9672,33 +9618,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceDelete<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
     }
 
     impl<'a> InstanceDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
@@ -9712,28 +9673,9 @@ pub mod builder {
                 project_name,
                 instance_name,
             } = self;
-            let (organization_name, project_name, instance_name) =
-                match (organization_name, project_name, instance_name) {
-                    (Some(organization_name), Some(project_name), Some(instance_name)) => {
-                        (organization_name, project_name, instance_name)
-                    }
-                    (organization_name, project_name, instance_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if instance_name.is_none() {
-                            missing.push(stringify!(instance_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}",
                 client.baseurl,
@@ -9763,54 +9705,85 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceDiskList<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> InstanceDiskList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -9829,28 +9802,12 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
-            let (organization_name, project_name, instance_name) =
-                match (organization_name, project_name, instance_name) {
-                    (Some(organization_name), Some(project_name), Some(instance_name)) => {
-                        (organization_name, project_name, instance_name)
-                    }
-                    (organization_name, project_name, instance_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if instance_name.is_none() {
-                            missing.push(stringify!(instance_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks",
                 client.baseurl,
@@ -9894,9 +9851,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -9910,7 +9867,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -9939,40 +9896,60 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceDiskAttach<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
-        body: Option<types::DiskIdentifier>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
+        body: Result<types::DiskIdentifier, String>,
     }
 
     impl<'a> InstanceDiskAttach<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::DiskIdentifier) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::DiskIdentifier>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `DiskIdentifier` for body failed".to_string());
             self
         }
 
@@ -9987,34 +9964,10 @@ pub mod builder {
                 instance_name,
                 body,
             } = self;
-            let (organization_name, project_name, instance_name, body) =
-                match (organization_name, project_name, instance_name, body) {
-                    (
-                        Some(organization_name),
-                        Some(project_name),
-                        Some(instance_name),
-                        Some(body),
-                    ) => (organization_name, project_name, instance_name, body),
-                    (organization_name, project_name, instance_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if instance_name.is_none() {
-                            missing.push(stringify!(instance_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks/attach",
                 client.baseurl,
@@ -10044,40 +9997,60 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceDiskDetach<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
-        body: Option<types::DiskIdentifier>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
+        body: Result<types::DiskIdentifier, String>,
     }
 
     impl<'a> InstanceDiskDetach<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::DiskIdentifier) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::DiskIdentifier>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `DiskIdentifier` for body failed".to_string());
             self
         }
 
@@ -10092,34 +10065,10 @@ pub mod builder {
                 instance_name,
                 body,
             } = self;
-            let (organization_name, project_name, instance_name, body) =
-                match (organization_name, project_name, instance_name, body) {
-                    (
-                        Some(organization_name),
-                        Some(project_name),
-                        Some(instance_name),
-                        Some(body),
-                    ) => (organization_name, project_name, instance_name, body),
-                    (organization_name, project_name, instance_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if instance_name.is_none() {
-                            missing.push(stringify!(instance_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks/detach",
                 client.baseurl,
@@ -10149,40 +10098,60 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceMigrate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
-        body: Option<types::InstanceMigrate>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
+        body: Result<types::InstanceMigrate, String>,
     }
 
     impl<'a> InstanceMigrate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::InstanceMigrate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::InstanceMigrate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `InstanceMigrate` for body failed".to_string());
             self
         }
 
@@ -10197,34 +10166,10 @@ pub mod builder {
                 instance_name,
                 body,
             } = self;
-            let (organization_name, project_name, instance_name, body) =
-                match (organization_name, project_name, instance_name, body) {
-                    (
-                        Some(organization_name),
-                        Some(project_name),
-                        Some(instance_name),
-                        Some(body),
-                    ) => (organization_name, project_name, instance_name, body),
-                    (organization_name, project_name, instance_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if instance_name.is_none() {
-                            missing.push(stringify!(instance_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/migrate",
                 client.baseurl,
@@ -10254,54 +10199,85 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceNetworkInterfaceList<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> InstanceNetworkInterfaceList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -10321,28 +10297,12 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
-            let (organization_name, project_name, instance_name) =
-                match (organization_name, project_name, instance_name) {
-                    (Some(organization_name), Some(project_name), Some(instance_name)) => {
-                        (organization_name, project_name, instance_name)
-                    }
-                    (organization_name, project_name, instance_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if instance_name.is_none() {
-                            missing.push(stringify!(instance_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
                 client.baseurl,
@@ -10386,9 +10346,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -10402,7 +10362,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -10431,40 +10391,60 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceNetworkInterfaceCreate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
-        body: Option<types::NetworkInterfaceCreate>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
+        body: Result<types::NetworkInterfaceCreate, String>,
     }
 
     impl<'a> InstanceNetworkInterfaceCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::NetworkInterfaceCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NetworkInterfaceCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `NetworkInterfaceCreate` for body failed".to_string());
             self
         }
 
@@ -10481,34 +10461,10 @@ pub mod builder {
                 instance_name,
                 body,
             } = self;
-            let (organization_name, project_name, instance_name, body) =
-                match (organization_name, project_name, instance_name, body) {
-                    (
-                        Some(organization_name),
-                        Some(project_name),
-                        Some(instance_name),
-                        Some(body),
-                    ) => (organization_name, project_name, instance_name, body),
-                    (organization_name, project_name, instance_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if instance_name.is_none() {
-                            missing.push(stringify!(instance_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
                 client.baseurl,
@@ -10538,40 +10494,60 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceNetworkInterfaceView<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
-        interface_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
+        interface_name: Result<types::Name, String>,
     }
 
     impl<'a> InstanceNetworkInterfaceView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
-                interface_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
+                interface_name: Err("interface_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
-        pub fn interface_name(mut self, value: types::Name) -> Self {
-            self.interface_name = Some(value);
+        pub fn interface_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.interface_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for interface_name failed".to_string());
             self
         }
 
@@ -10588,43 +10564,10 @@ pub mod builder {
                 instance_name,
                 interface_name,
             } = self;
-            let (organization_name, project_name, instance_name, interface_name) = match (
-                organization_name,
-                project_name,
-                instance_name,
-                interface_name,
-            ) {
-                (
-                    Some(organization_name),
-                    Some(project_name),
-                    Some(instance_name),
-                    Some(interface_name),
-                ) => (
-                    organization_name,
-                    project_name,
-                    instance_name,
-                    interface_name,
-                ),
-                (organization_name, project_name, instance_name, interface_name) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if project_name.is_none() {
-                        missing.push(stringify!(project_name));
-                    }
-                    if instance_name.is_none() {
-                        missing.push(stringify!(instance_name));
-                    }
-                    if interface_name.is_none() {
-                        missing.push(stringify!(interface_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
+            let interface_name = interface_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
                 client.baseurl,
@@ -10655,47 +10598,72 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceNetworkInterfaceUpdate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
-        interface_name: Option<types::Name>,
-        body: Option<types::NetworkInterfaceUpdate>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
+        interface_name: Result<types::Name, String>,
+        body: Result<types::NetworkInterfaceUpdate, String>,
     }
 
     impl<'a> InstanceNetworkInterfaceUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
-                interface_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
+                interface_name: Err("interface_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
-        pub fn interface_name(mut self, value: types::Name) -> Self {
-            self.interface_name = Some(value);
+        pub fn interface_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.interface_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for interface_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::NetworkInterfaceUpdate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NetworkInterfaceUpdate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `NetworkInterfaceUpdate` for body failed".to_string());
             self
         }
 
@@ -10713,49 +10681,11 @@ pub mod builder {
                 interface_name,
                 body,
             } = self;
-            let (organization_name, project_name, instance_name, interface_name, body) = match (
-                organization_name,
-                project_name,
-                instance_name,
-                interface_name,
-                body,
-            ) {
-                (
-                    Some(organization_name),
-                    Some(project_name),
-                    Some(instance_name),
-                    Some(interface_name),
-                    Some(body),
-                ) => (
-                    organization_name,
-                    project_name,
-                    instance_name,
-                    interface_name,
-                    body,
-                ),
-                (organization_name, project_name, instance_name, interface_name, body) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if project_name.is_none() {
-                        missing.push(stringify!(project_name));
-                    }
-                    if instance_name.is_none() {
-                        missing.push(stringify!(instance_name));
-                    }
-                    if interface_name.is_none() {
-                        missing.push(stringify!(interface_name));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
+            let interface_name = interface_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
                 client.baseurl,
@@ -10786,40 +10716,60 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceNetworkInterfaceDelete<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
-        interface_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
+        interface_name: Result<types::Name, String>,
     }
 
     impl<'a> InstanceNetworkInterfaceDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
-                interface_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
+                interface_name: Err("interface_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
-        pub fn interface_name(mut self, value: types::Name) -> Self {
-            self.interface_name = Some(value);
+        pub fn interface_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.interface_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for interface_name failed".to_string());
             self
         }
 
@@ -10834,43 +10784,10 @@ pub mod builder {
                 instance_name,
                 interface_name,
             } = self;
-            let (organization_name, project_name, instance_name, interface_name) = match (
-                organization_name,
-                project_name,
-                instance_name,
-                interface_name,
-            ) {
-                (
-                    Some(organization_name),
-                    Some(project_name),
-                    Some(instance_name),
-                    Some(interface_name),
-                ) => (
-                    organization_name,
-                    project_name,
-                    instance_name,
-                    interface_name,
-                ),
-                (organization_name, project_name, instance_name, interface_name) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if project_name.is_none() {
-                        missing.push(stringify!(project_name));
-                    }
-                    if instance_name.is_none() {
-                        missing.push(stringify!(instance_name));
-                    }
-                    if interface_name.is_none() {
-                        missing.push(stringify!(interface_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
+            let interface_name = interface_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
                 client.baseurl,
@@ -10901,33 +10818,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceReboot<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
     }
 
     impl<'a> InstanceReboot<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
@@ -10941,28 +10873,9 @@ pub mod builder {
                 project_name,
                 instance_name,
             } = self;
-            let (organization_name, project_name, instance_name) =
-                match (organization_name, project_name, instance_name) {
-                    (Some(organization_name), Some(project_name), Some(instance_name)) => {
-                        (organization_name, project_name, instance_name)
-                    }
-                    (organization_name, project_name, instance_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if instance_name.is_none() {
-                            missing.push(stringify!(instance_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/reboot",
                 client.baseurl,
@@ -10992,54 +10905,87 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceSerialConsole<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
-        from_start: Option<u64>,
-        max_bytes: Option<u64>,
-        most_recent: Option<u64>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
+        from_start: Result<Option<u64>, String>,
+        max_bytes: Result<Option<u64>, String>,
+        most_recent: Result<Option<u64>, String>,
     }
 
     impl<'a> InstanceSerialConsole<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
-                from_start: None,
-                max_bytes: None,
-                most_recent: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
+                from_start: Ok(None),
+                max_bytes: Ok(None),
+                most_recent: Ok(None),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
-        pub fn from_start(mut self, value: u64) -> Self {
-            self.from_start = Some(value);
+        pub fn from_start<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<u64>,
+        {
+            self.from_start = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < u64 >` for from_start failed".to_string());
             self
         }
 
-        pub fn max_bytes(mut self, value: u64) -> Self {
-            self.max_bytes = Some(value);
+        pub fn max_bytes<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<u64>,
+        {
+            self.max_bytes = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < u64 >` for max_bytes failed".to_string());
             self
         }
 
-        pub fn most_recent(mut self, value: u64) -> Self {
-            self.most_recent = Some(value);
+        pub fn most_recent<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<u64>,
+        {
+            self.most_recent = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < u64 >` for most_recent failed".to_string());
             self
         }
 
@@ -11058,28 +11004,12 @@ pub mod builder {
                 max_bytes,
                 most_recent,
             } = self;
-            let (organization_name, project_name, instance_name) =
-                match (organization_name, project_name, instance_name) {
-                    (Some(organization_name), Some(project_name), Some(instance_name)) => {
-                        (organization_name, project_name, instance_name)
-                    }
-                    (organization_name, project_name, instance_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if instance_name.is_none() {
-                            missing.push(stringify!(instance_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
+            let from_start = from_start.map_err(Error::InvalidRequest)?;
+            let max_bytes = max_bytes.map_err(Error::InvalidRequest)?;
+            let most_recent = most_recent.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/serial-console",
                 client.baseurl,
@@ -11119,33 +11049,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceStart<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
     }
 
     impl<'a> InstanceStart<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
@@ -11159,28 +11104,9 @@ pub mod builder {
                 project_name,
                 instance_name,
             } = self;
-            let (organization_name, project_name, instance_name) =
-                match (organization_name, project_name, instance_name) {
-                    (Some(organization_name), Some(project_name), Some(instance_name)) => {
-                        (organization_name, project_name, instance_name)
-                    }
-                    (organization_name, project_name, instance_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if instance_name.is_none() {
-                            missing.push(stringify!(instance_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/start",
                 client.baseurl,
@@ -11210,33 +11136,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceStop<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
     }
 
     impl<'a> InstanceStop<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
@@ -11250,28 +11191,9 @@ pub mod builder {
                 project_name,
                 instance_name,
             } = self;
-            let (organization_name, project_name, instance_name) =
-                match (organization_name, project_name, instance_name) {
-                    (Some(organization_name), Some(project_name), Some(instance_name)) => {
-                        (organization_name, project_name, instance_name)
-                    }
-                    (organization_name, project_name, instance_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if instance_name.is_none() {
-                            missing.push(stringify!(instance_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/stop",
                 client.baseurl,
@@ -11301,26 +11223,36 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ProjectPolicyView<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
     }
 
     impl<'a> ProjectPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
@@ -11334,22 +11266,8 @@ pub mod builder {
                 organization_name,
                 project_name,
             } = self;
-            let (organization_name, project_name) = match (organization_name, project_name) {
-                (Some(organization_name), Some(project_name)) => (organization_name, project_name),
-                (organization_name, project_name) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if project_name.is_none() {
-                        missing.push(stringify!(project_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/policy",
                 client.baseurl,
@@ -11378,33 +11296,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ProjectPolicyUpdate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        body: Option<types::ProjectRolePolicy>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        body: Result<types::ProjectRolePolicy, String>,
     }
 
     impl<'a> ProjectPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::ProjectRolePolicy) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::ProjectRolePolicy>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `ProjectRolePolicy` for body failed".to_string());
             self
         }
 
@@ -11419,28 +11352,9 @@ pub mod builder {
                 project_name,
                 body,
             } = self;
-            let (organization_name, project_name, body) =
-                match (organization_name, project_name, body) {
-                    (Some(organization_name), Some(project_name), Some(body)) => {
-                        (organization_name, project_name, body)
-                    }
-                    (organization_name, project_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/policy",
                 client.baseurl,
@@ -11469,47 +11383,73 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SnapshotList<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> SnapshotList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -11527,22 +11467,11 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
-            let (organization_name, project_name) = match (organization_name, project_name) {
-                (Some(organization_name), Some(project_name)) => (organization_name, project_name),
-                (organization_name, project_name) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if project_name.is_none() {
-                        missing.push(stringify!(project_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/snapshots",
                 client.baseurl,
@@ -11585,9 +11514,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -11601,7 +11530,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -11630,33 +11559,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SnapshotCreate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        body: Option<types::SnapshotCreate>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        body: Result<types::SnapshotCreate, String>,
     }
 
     impl<'a> SnapshotCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::SnapshotCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::SnapshotCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `SnapshotCreate` for body failed".to_string());
             self
         }
 
@@ -11670,28 +11614,9 @@ pub mod builder {
                 project_name,
                 body,
             } = self;
-            let (organization_name, project_name, body) =
-                match (organization_name, project_name, body) {
-                    (Some(organization_name), Some(project_name), Some(body)) => {
-                        (organization_name, project_name, body)
-                    }
-                    (organization_name, project_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/snapshots",
                 client.baseurl,
@@ -11720,33 +11645,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SnapshotView<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        snapshot_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        snapshot_name: Result<types::Name, String>,
     }
 
     impl<'a> SnapshotView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                snapshot_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                snapshot_name: Err("snapshot_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn snapshot_name(mut self, value: types::Name) -> Self {
-            self.snapshot_name = Some(value);
+        pub fn snapshot_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.snapshot_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for snapshot_name failed".to_string());
             self
         }
 
@@ -11760,28 +11700,9 @@ pub mod builder {
                 project_name,
                 snapshot_name,
             } = self;
-            let (organization_name, project_name, snapshot_name) =
-                match (organization_name, project_name, snapshot_name) {
-                    (Some(organization_name), Some(project_name), Some(snapshot_name)) => {
-                        (organization_name, project_name, snapshot_name)
-                    }
-                    (organization_name, project_name, snapshot_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if snapshot_name.is_none() {
-                            missing.push(stringify!(snapshot_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let snapshot_name = snapshot_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/snapshots/{}",
                 client.baseurl,
@@ -11811,33 +11732,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SnapshotDelete<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        snapshot_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        snapshot_name: Result<types::Name, String>,
     }
 
     impl<'a> SnapshotDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                snapshot_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                snapshot_name: Err("snapshot_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn snapshot_name(mut self, value: types::Name) -> Self {
-            self.snapshot_name = Some(value);
+        pub fn snapshot_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.snapshot_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for snapshot_name failed".to_string());
             self
         }
 
@@ -11851,28 +11787,9 @@ pub mod builder {
                 project_name,
                 snapshot_name,
             } = self;
-            let (organization_name, project_name, snapshot_name) =
-                match (organization_name, project_name, snapshot_name) {
-                    (Some(organization_name), Some(project_name), Some(snapshot_name)) => {
-                        (organization_name, project_name, snapshot_name)
-                    }
-                    (organization_name, project_name, snapshot_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if snapshot_name.is_none() {
-                            missing.push(stringify!(snapshot_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let snapshot_name = snapshot_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/snapshots/{}",
                 client.baseurl,
@@ -11902,47 +11819,73 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcList<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> VpcList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -11959,22 +11902,11 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
-            let (organization_name, project_name) = match (organization_name, project_name) {
-                (Some(organization_name), Some(project_name)) => (organization_name, project_name),
-                (organization_name, project_name) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if project_name.is_none() {
-                        missing.push(stringify!(project_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs",
                 client.baseurl,
@@ -12016,9 +11948,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -12032,7 +11964,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -12061,33 +11993,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcCreate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        body: Option<types::VpcCreate>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        body: Result<types::VpcCreate, String>,
     }
 
     impl<'a> VpcCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::VpcCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::VpcCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `VpcCreate` for body failed".to_string());
             self
         }
 
@@ -12100,28 +12047,9 @@ pub mod builder {
                 project_name,
                 body,
             } = self;
-            let (organization_name, project_name, body) =
-                match (organization_name, project_name, body) {
-                    (Some(organization_name), Some(project_name), Some(body)) => {
-                        (organization_name, project_name, body)
-                    }
-                    (organization_name, project_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs",
                 client.baseurl,
@@ -12150,33 +12078,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcView<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
     }
 
     impl<'a> VpcView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
@@ -12190,28 +12133,9 @@ pub mod builder {
                 project_name,
                 vpc_name,
             } = self;
-            let (organization_name, project_name, vpc_name) =
-                match (organization_name, project_name, vpc_name) {
-                    (Some(organization_name), Some(project_name), Some(vpc_name)) => {
-                        (organization_name, project_name, vpc_name)
-                    }
-                    (organization_name, project_name, vpc_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
                 client.baseurl,
@@ -12241,40 +12165,60 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcUpdate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        body: Option<types::VpcUpdate>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        body: Result<types::VpcUpdate, String>,
     }
 
     impl<'a> VpcUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::VpcUpdate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::VpcUpdate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `VpcUpdate` for body failed".to_string());
             self
         }
 
@@ -12289,31 +12233,10 @@ pub mod builder {
                 vpc_name,
                 body,
             } = self;
-            let (organization_name, project_name, vpc_name, body) =
-                match (organization_name, project_name, vpc_name, body) {
-                    (Some(organization_name), Some(project_name), Some(vpc_name), Some(body)) => {
-                        (organization_name, project_name, vpc_name, body)
-                    }
-                    (organization_name, project_name, vpc_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
                 client.baseurl,
@@ -12343,33 +12266,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcDelete<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
     }
 
     impl<'a> VpcDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
@@ -12383,28 +12321,9 @@ pub mod builder {
                 project_name,
                 vpc_name,
             } = self;
-            let (organization_name, project_name, vpc_name) =
-                match (organization_name, project_name, vpc_name) {
-                    (Some(organization_name), Some(project_name), Some(vpc_name)) => {
-                        (organization_name, project_name, vpc_name)
-                    }
-                    (organization_name, project_name, vpc_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
                 client.baseurl,
@@ -12434,33 +12353,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcFirewallRulesView<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
     }
 
     impl<'a> VpcFirewallRulesView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
@@ -12476,28 +12410,9 @@ pub mod builder {
                 project_name,
                 vpc_name,
             } = self;
-            let (organization_name, project_name, vpc_name) =
-                match (organization_name, project_name, vpc_name) {
-                    (Some(organization_name), Some(project_name), Some(vpc_name)) => {
-                        (organization_name, project_name, vpc_name)
-                    }
-                    (organization_name, project_name, vpc_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
                 client.baseurl,
@@ -12527,40 +12442,60 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcFirewallRulesUpdate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        body: Option<types::VpcFirewallRuleUpdateParams>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        body: Result<types::VpcFirewallRuleUpdateParams, String>,
     }
 
     impl<'a> VpcFirewallRulesUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::VpcFirewallRuleUpdateParams) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::VpcFirewallRuleUpdateParams>,
+        {
+            self.body = value.try_into().map_err(|_| {
+                "conversion to `VpcFirewallRuleUpdateParams` for body failed".to_string()
+            });
             self
         }
 
@@ -12577,31 +12512,10 @@ pub mod builder {
                 vpc_name,
                 body,
             } = self;
-            let (organization_name, project_name, vpc_name, body) =
-                match (organization_name, project_name, vpc_name, body) {
-                    (Some(organization_name), Some(project_name), Some(vpc_name), Some(body)) => {
-                        (organization_name, project_name, vpc_name, body)
-                    }
-                    (organization_name, project_name, vpc_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
                 client.baseurl,
@@ -12631,54 +12545,85 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcRouterList<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> VpcRouterList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -12697,28 +12642,12 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
-            let (organization_name, project_name, vpc_name) =
-                match (organization_name, project_name, vpc_name) {
-                    (Some(organization_name), Some(project_name), Some(vpc_name)) => {
-                        (organization_name, project_name, vpc_name)
-                    }
-                    (organization_name, project_name, vpc_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers",
                 client.baseurl,
@@ -12762,9 +12691,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -12778,7 +12707,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -12807,40 +12736,60 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcRouterCreate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        body: Option<types::VpcRouterCreate>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        body: Result<types::VpcRouterCreate, String>,
     }
 
     impl<'a> VpcRouterCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::VpcRouterCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::VpcRouterCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `VpcRouterCreate` for body failed".to_string());
             self
         }
 
@@ -12855,31 +12804,10 @@ pub mod builder {
                 vpc_name,
                 body,
             } = self;
-            let (organization_name, project_name, vpc_name, body) =
-                match (organization_name, project_name, vpc_name, body) {
-                    (Some(organization_name), Some(project_name), Some(vpc_name), Some(body)) => {
-                        (organization_name, project_name, vpc_name, body)
-                    }
-                    (organization_name, project_name, vpc_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers",
                 client.baseurl,
@@ -12909,40 +12837,60 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcRouterView<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        router_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        router_name: Result<types::Name, String>,
     }
 
     impl<'a> VpcRouterView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                router_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                router_name: Err("router_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn router_name(mut self, value: types::Name) -> Self {
-            self.router_name = Some(value);
+        pub fn router_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.router_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for router_name failed".to_string());
             self
         }
 
@@ -12957,34 +12905,10 @@ pub mod builder {
                 vpc_name,
                 router_name,
             } = self;
-            let (organization_name, project_name, vpc_name, router_name) =
-                match (organization_name, project_name, vpc_name, router_name) {
-                    (
-                        Some(organization_name),
-                        Some(project_name),
-                        Some(vpc_name),
-                        Some(router_name),
-                    ) => (organization_name, project_name, vpc_name, router_name),
-                    (organization_name, project_name, vpc_name, router_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        if router_name.is_none() {
-                            missing.push(stringify!(router_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let router_name = router_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
                 client.baseurl,
@@ -13015,47 +12939,72 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcRouterUpdate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        router_name: Option<types::Name>,
-        body: Option<types::VpcRouterUpdate>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        router_name: Result<types::Name, String>,
+        body: Result<types::VpcRouterUpdate, String>,
     }
 
     impl<'a> VpcRouterUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                router_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                router_name: Err("router_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn router_name(mut self, value: types::Name) -> Self {
-            self.router_name = Some(value);
+        pub fn router_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.router_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for router_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::VpcRouterUpdate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::VpcRouterUpdate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `VpcRouterUpdate` for body failed".to_string());
             self
         }
 
@@ -13071,38 +13020,11 @@ pub mod builder {
                 router_name,
                 body,
             } = self;
-            let (organization_name, project_name, vpc_name, router_name, body) =
-                match (organization_name, project_name, vpc_name, router_name, body) {
-                    (
-                        Some(organization_name),
-                        Some(project_name),
-                        Some(vpc_name),
-                        Some(router_name),
-                        Some(body),
-                    ) => (organization_name, project_name, vpc_name, router_name, body),
-                    (organization_name, project_name, vpc_name, router_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        if router_name.is_none() {
-                            missing.push(stringify!(router_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let router_name = router_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
                 client.baseurl,
@@ -13133,40 +13055,60 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcRouterDelete<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        router_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        router_name: Result<types::Name, String>,
     }
 
     impl<'a> VpcRouterDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                router_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                router_name: Err("router_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn router_name(mut self, value: types::Name) -> Self {
-            self.router_name = Some(value);
+        pub fn router_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.router_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for router_name failed".to_string());
             self
         }
 
@@ -13181,34 +13123,10 @@ pub mod builder {
                 vpc_name,
                 router_name,
             } = self;
-            let (organization_name, project_name, vpc_name, router_name) =
-                match (organization_name, project_name, vpc_name, router_name) {
-                    (
-                        Some(organization_name),
-                        Some(project_name),
-                        Some(vpc_name),
-                        Some(router_name),
-                    ) => (organization_name, project_name, vpc_name, router_name),
-                    (organization_name, project_name, vpc_name, router_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        if router_name.is_none() {
-                            missing.push(stringify!(router_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let router_name = router_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
                 client.baseurl,
@@ -13239,61 +13157,97 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcRouterRouteList<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        router_name: Option<types::Name>,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        router_name: Result<types::Name, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> VpcRouterRouteList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                router_name: None,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                router_name: Err("router_name was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn router_name(mut self, value: types::Name) -> Self {
-            self.router_name = Some(value);
+        pub fn router_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.router_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for router_name failed".to_string());
             self
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -13313,34 +13267,13 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
-            let (organization_name, project_name, vpc_name, router_name) =
-                match (organization_name, project_name, vpc_name, router_name) {
-                    (
-                        Some(organization_name),
-                        Some(project_name),
-                        Some(vpc_name),
-                        Some(router_name),
-                    ) => (organization_name, project_name, vpc_name, router_name),
-                    (organization_name, project_name, vpc_name, router_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        if router_name.is_none() {
-                            missing.push(stringify!(router_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let router_name = router_name.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
                 client.baseurl,
@@ -13385,9 +13318,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -13401,7 +13334,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -13430,47 +13363,72 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcRouterRouteCreate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        router_name: Option<types::Name>,
-        body: Option<types::RouterRouteCreateParams>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        router_name: Result<types::Name, String>,
+        body: Result<types::RouterRouteCreateParams, String>,
     }
 
     impl<'a> VpcRouterRouteCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                router_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                router_name: Err("router_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn router_name(mut self, value: types::Name) -> Self {
-            self.router_name = Some(value);
+        pub fn router_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.router_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for router_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::RouterRouteCreateParams) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::RouterRouteCreateParams>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `RouterRouteCreateParams` for body failed".to_string());
             self
         }
 
@@ -13486,38 +13444,11 @@ pub mod builder {
                 router_name,
                 body,
             } = self;
-            let (organization_name, project_name, vpc_name, router_name, body) =
-                match (organization_name, project_name, vpc_name, router_name, body) {
-                    (
-                        Some(organization_name),
-                        Some(project_name),
-                        Some(vpc_name),
-                        Some(router_name),
-                        Some(body),
-                    ) => (organization_name, project_name, vpc_name, router_name, body),
-                    (organization_name, project_name, vpc_name, router_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        if router_name.is_none() {
-                            missing.push(stringify!(router_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let router_name = router_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
                 client.baseurl,
@@ -13548,47 +13479,72 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcRouterRouteView<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        router_name: Option<types::Name>,
-        route_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        router_name: Result<types::Name, String>,
+        route_name: Result<types::Name, String>,
     }
 
     impl<'a> VpcRouterRouteView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                router_name: None,
-                route_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                router_name: Err("router_name was not initialized".to_string()),
+                route_name: Err("route_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn router_name(mut self, value: types::Name) -> Self {
-            self.router_name = Some(value);
+        pub fn router_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.router_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for router_name failed".to_string());
             self
         }
 
-        pub fn route_name(mut self, value: types::Name) -> Self {
-            self.route_name = Some(value);
+        pub fn route_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.route_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for route_name failed".to_string());
             self
         }
 
@@ -13604,49 +13560,11 @@ pub mod builder {
                 router_name,
                 route_name,
             } = self;
-            let (organization_name, project_name, vpc_name, router_name, route_name) = match (
-                organization_name,
-                project_name,
-                vpc_name,
-                router_name,
-                route_name,
-            ) {
-                (
-                    Some(organization_name),
-                    Some(project_name),
-                    Some(vpc_name),
-                    Some(router_name),
-                    Some(route_name),
-                ) => (
-                    organization_name,
-                    project_name,
-                    vpc_name,
-                    router_name,
-                    route_name,
-                ),
-                (organization_name, project_name, vpc_name, router_name, route_name) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if project_name.is_none() {
-                        missing.push(stringify!(project_name));
-                    }
-                    if vpc_name.is_none() {
-                        missing.push(stringify!(vpc_name));
-                    }
-                    if router_name.is_none() {
-                        missing.push(stringify!(router_name));
-                    }
-                    if route_name.is_none() {
-                        missing.push(stringify!(route_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let router_name = router_name.map_err(Error::InvalidRequest)?;
+            let route_name = route_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
                 client.baseurl,
@@ -13678,54 +13596,84 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcRouterRouteUpdate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        router_name: Option<types::Name>,
-        route_name: Option<types::Name>,
-        body: Option<types::RouterRouteUpdateParams>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        router_name: Result<types::Name, String>,
+        route_name: Result<types::Name, String>,
+        body: Result<types::RouterRouteUpdateParams, String>,
     }
 
     impl<'a> VpcRouterRouteUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                router_name: None,
-                route_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                router_name: Err("router_name was not initialized".to_string()),
+                route_name: Err("route_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn router_name(mut self, value: types::Name) -> Self {
-            self.router_name = Some(value);
+        pub fn router_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.router_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for router_name failed".to_string());
             self
         }
 
-        pub fn route_name(mut self, value: types::Name) -> Self {
-            self.route_name = Some(value);
+        pub fn route_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.route_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for route_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::RouterRouteUpdateParams) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::RouterRouteUpdateParams>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `RouterRouteUpdateParams` for body failed".to_string());
             self
         }
 
@@ -13742,55 +13690,12 @@ pub mod builder {
                 route_name,
                 body,
             } = self;
-            let (organization_name, project_name, vpc_name, router_name, route_name, body) = match (
-                organization_name,
-                project_name,
-                vpc_name,
-                router_name,
-                route_name,
-                body,
-            ) {
-                (
-                    Some(organization_name),
-                    Some(project_name),
-                    Some(vpc_name),
-                    Some(router_name),
-                    Some(route_name),
-                    Some(body),
-                ) => (
-                    organization_name,
-                    project_name,
-                    vpc_name,
-                    router_name,
-                    route_name,
-                    body,
-                ),
-                (organization_name, project_name, vpc_name, router_name, route_name, body) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if project_name.is_none() {
-                        missing.push(stringify!(project_name));
-                    }
-                    if vpc_name.is_none() {
-                        missing.push(stringify!(vpc_name));
-                    }
-                    if router_name.is_none() {
-                        missing.push(stringify!(router_name));
-                    }
-                    if route_name.is_none() {
-                        missing.push(stringify!(route_name));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let router_name = router_name.map_err(Error::InvalidRequest)?;
+            let route_name = route_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
                 client.baseurl,
@@ -13822,47 +13727,72 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcRouterRouteDelete<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        router_name: Option<types::Name>,
-        route_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        router_name: Result<types::Name, String>,
+        route_name: Result<types::Name, String>,
     }
 
     impl<'a> VpcRouterRouteDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                router_name: None,
-                route_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                router_name: Err("router_name was not initialized".to_string()),
+                route_name: Err("route_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn router_name(mut self, value: types::Name) -> Self {
-            self.router_name = Some(value);
+        pub fn router_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.router_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for router_name failed".to_string());
             self
         }
 
-        pub fn route_name(mut self, value: types::Name) -> Self {
-            self.route_name = Some(value);
+        pub fn route_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.route_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for route_name failed".to_string());
             self
         }
 
@@ -13878,49 +13808,11 @@ pub mod builder {
                 router_name,
                 route_name,
             } = self;
-            let (organization_name, project_name, vpc_name, router_name, route_name) = match (
-                organization_name,
-                project_name,
-                vpc_name,
-                router_name,
-                route_name,
-            ) {
-                (
-                    Some(organization_name),
-                    Some(project_name),
-                    Some(vpc_name),
-                    Some(router_name),
-                    Some(route_name),
-                ) => (
-                    organization_name,
-                    project_name,
-                    vpc_name,
-                    router_name,
-                    route_name,
-                ),
-                (organization_name, project_name, vpc_name, router_name, route_name) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if project_name.is_none() {
-                        missing.push(stringify!(project_name));
-                    }
-                    if vpc_name.is_none() {
-                        missing.push(stringify!(vpc_name));
-                    }
-                    if router_name.is_none() {
-                        missing.push(stringify!(router_name));
-                    }
-                    if route_name.is_none() {
-                        missing.push(stringify!(route_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let router_name = router_name.map_err(Error::InvalidRequest)?;
+            let route_name = route_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
                 client.baseurl,
@@ -13952,54 +13844,85 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcSubnetList<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> VpcSubnetList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -14018,28 +13941,12 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
-            let (organization_name, project_name, vpc_name) =
-                match (organization_name, project_name, vpc_name) {
-                    (Some(organization_name), Some(project_name), Some(vpc_name)) => {
-                        (organization_name, project_name, vpc_name)
-                    }
-                    (organization_name, project_name, vpc_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
                 client.baseurl,
@@ -14083,9 +13990,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -14099,7 +14006,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -14128,40 +14035,60 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcSubnetCreate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        body: Option<types::VpcSubnetCreate>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        body: Result<types::VpcSubnetCreate, String>,
     }
 
     impl<'a> VpcSubnetCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::VpcSubnetCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::VpcSubnetCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `VpcSubnetCreate` for body failed".to_string());
             self
         }
 
@@ -14176,31 +14103,10 @@ pub mod builder {
                 vpc_name,
                 body,
             } = self;
-            let (organization_name, project_name, vpc_name, body) =
-                match (organization_name, project_name, vpc_name, body) {
-                    (Some(organization_name), Some(project_name), Some(vpc_name), Some(body)) => {
-                        (organization_name, project_name, vpc_name, body)
-                    }
-                    (organization_name, project_name, vpc_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
                 client.baseurl,
@@ -14230,40 +14136,60 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcSubnetView<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        subnet_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        subnet_name: Result<types::Name, String>,
     }
 
     impl<'a> VpcSubnetView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                subnet_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                subnet_name: Err("subnet_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn subnet_name(mut self, value: types::Name) -> Self {
-            self.subnet_name = Some(value);
+        pub fn subnet_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.subnet_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for subnet_name failed".to_string());
             self
         }
 
@@ -14278,34 +14204,10 @@ pub mod builder {
                 vpc_name,
                 subnet_name,
             } = self;
-            let (organization_name, project_name, vpc_name, subnet_name) =
-                match (organization_name, project_name, vpc_name, subnet_name) {
-                    (
-                        Some(organization_name),
-                        Some(project_name),
-                        Some(vpc_name),
-                        Some(subnet_name),
-                    ) => (organization_name, project_name, vpc_name, subnet_name),
-                    (organization_name, project_name, vpc_name, subnet_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        if subnet_name.is_none() {
-                            missing.push(stringify!(subnet_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
                 client.baseurl,
@@ -14336,47 +14238,72 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcSubnetUpdate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        subnet_name: Option<types::Name>,
-        body: Option<types::VpcSubnetUpdate>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        subnet_name: Result<types::Name, String>,
+        body: Result<types::VpcSubnetUpdate, String>,
     }
 
     impl<'a> VpcSubnetUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                subnet_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                subnet_name: Err("subnet_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn subnet_name(mut self, value: types::Name) -> Self {
-            self.subnet_name = Some(value);
+        pub fn subnet_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.subnet_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for subnet_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::VpcSubnetUpdate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::VpcSubnetUpdate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `VpcSubnetUpdate` for body failed".to_string());
             self
         }
 
@@ -14392,38 +14319,11 @@ pub mod builder {
                 subnet_name,
                 body,
             } = self;
-            let (organization_name, project_name, vpc_name, subnet_name, body) =
-                match (organization_name, project_name, vpc_name, subnet_name, body) {
-                    (
-                        Some(organization_name),
-                        Some(project_name),
-                        Some(vpc_name),
-                        Some(subnet_name),
-                        Some(body),
-                    ) => (organization_name, project_name, vpc_name, subnet_name, body),
-                    (organization_name, project_name, vpc_name, subnet_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        if subnet_name.is_none() {
-                            missing.push(stringify!(subnet_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
                 client.baseurl,
@@ -14454,40 +14354,60 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcSubnetDelete<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        subnet_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        subnet_name: Result<types::Name, String>,
     }
 
     impl<'a> VpcSubnetDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                subnet_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                subnet_name: Err("subnet_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn subnet_name(mut self, value: types::Name) -> Self {
-            self.subnet_name = Some(value);
+        pub fn subnet_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.subnet_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for subnet_name failed".to_string());
             self
         }
 
@@ -14502,34 +14422,10 @@ pub mod builder {
                 vpc_name,
                 subnet_name,
             } = self;
-            let (organization_name, project_name, vpc_name, subnet_name) =
-                match (organization_name, project_name, vpc_name, subnet_name) {
-                    (
-                        Some(organization_name),
-                        Some(project_name),
-                        Some(vpc_name),
-                        Some(subnet_name),
-                    ) => (organization_name, project_name, vpc_name, subnet_name),
-                    (organization_name, project_name, vpc_name, subnet_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        if subnet_name.is_none() {
-                            missing.push(stringify!(subnet_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
                 client.baseurl,
@@ -14560,61 +14456,97 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcSubnetListNetworkInterfaces<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        subnet_name: Option<types::Name>,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        subnet_name: Result<types::Name, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> VpcSubnetListNetworkInterfaces<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                subnet_name: None,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                subnet_name: Err("subnet_name was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn subnet_name(mut self, value: types::Name) -> Self {
-            self.subnet_name = Some(value);
+        pub fn subnet_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.subnet_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for subnet_name failed".to_string());
             self
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -14635,34 +14567,13 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
-            let (organization_name, project_name, vpc_name, subnet_name) =
-                match (organization_name, project_name, vpc_name, subnet_name) {
-                    (
-                        Some(organization_name),
-                        Some(project_name),
-                        Some(vpc_name),
-                        Some(subnet_name),
-                    ) => (organization_name, project_name, vpc_name, subnet_name),
-                    (organization_name, project_name, vpc_name, subnet_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        if subnet_name.is_none() {
-                            missing.push(stringify!(subnet_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}/network-interfaces",
                 client.baseurl,
@@ -14707,9 +14618,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -14723,7 +14634,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -14787,16 +14698,24 @@ pub mod builder {
     #[derive(Clone)]
     pub struct PolicyUpdate<'a> {
         client: &'a super::Client,
-        body: Option<types::FleetRolePolicy>,
+        body: Result<types::FleetRolePolicy, String>,
     }
 
     impl<'a> PolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::FleetRolePolicy) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::FleetRolePolicy>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `FleetRolePolicy` for body failed".to_string());
             self
         }
 
@@ -14805,19 +14724,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/policy", client.baseurl,);
             let request = client.client.put(url).json(&body).build()?;
             let result = client.client.execute(request).await;
@@ -14841,26 +14748,37 @@ pub mod builder {
     #[derive(Clone)]
     pub struct RoleList<'a> {
         client: &'a super::Client,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
     }
 
     impl<'a> RoleList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                limit: None,
-                page_token: None,
+                limit: Ok(None),
+                page_token: Ok(None),
             }
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
@@ -14873,6 +14791,8 @@ pub mod builder {
                 limit,
                 page_token,
             } = self;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/roles", client.baseurl,);
             let mut query = Vec::new();
             if let Some(v) = &limit {
@@ -14905,8 +14825,8 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
+                limit: Ok(None),
+                page_token: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -14920,7 +14840,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -14949,38 +14869,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct RoleView<'a> {
         client: &'a super::Client,
-        role_name: Option<String>,
+        role_name: Result<String, String>,
     }
 
     impl<'a> RoleView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                role_name: None,
+                role_name: Err("role_name was not initialized".to_string()),
             }
         }
 
-        pub fn role_name<S: ToString>(mut self, value: S) -> Self {
-            self.role_name = Some(value.to_string());
+        pub fn role_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.role_name = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for role_name failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/roles/{role_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Role>, Error<types::Error>> {
             let Self { client, role_name } = self;
-            let (role_name,) = match (role_name,) {
-                (Some(role_name),) => (role_name,),
-                (role_name,) => {
-                    let mut missing = Vec::new();
-                    if role_name.is_none() {
-                        missing.push(stringify!(role_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let role_name = role_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/roles/{}",
                 client.baseurl,
@@ -15008,33 +14921,49 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SagaList<'a> {
         client: &'a super::Client,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::IdSortMode>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::IdSortMode>, String>,
     }
 
     impl<'a> SagaList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::IdSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::IdSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < IdSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -15048,6 +14977,9 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/sagas", client.baseurl,);
             let mut query = Vec::new();
             if let Some(v) = &limit {
@@ -15083,9 +15015,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -15099,7 +15031,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -15128,38 +15060,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SagaView<'a> {
         client: &'a super::Client,
-        saga_id: Option<uuid::Uuid>,
+        saga_id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SagaView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                saga_id: None,
+                saga_id: Err("saga_id was not initialized".to_string()),
             }
         }
 
-        pub fn saga_id(mut self, value: uuid::Uuid) -> Self {
-            self.saga_id = Some(value);
+        pub fn saga_id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.saga_id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for saga_id failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/sagas/{saga_id}`
         pub async fn send(self) -> Result<ResponseValue<types::Saga>, Error<types::Error>> {
             let Self { client, saga_id } = self;
-            let (saga_id,) = match (saga_id,) {
-                (Some(saga_id),) => (saga_id,),
-                (saga_id,) => {
-                    let mut missing = Vec::new();
-                    if saga_id.is_none() {
-                        missing.push(stringify!(saga_id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let saga_id = saga_id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/sagas/{}",
                 client.baseurl,
@@ -15220,33 +15145,49 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SessionSshkeyList<'a> {
         client: &'a super::Client,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> SessionSshkeyList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -15260,6 +15201,9 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/sshkeys", client.baseurl,);
             let mut query = Vec::new();
             if let Some(v) = &limit {
@@ -15295,9 +15239,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -15311,7 +15255,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -15340,35 +15284,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SessionSshkeyCreate<'a> {
         client: &'a super::Client,
-        body: Option<types::SshKeyCreate>,
+        body: Result<types::SshKeyCreate, String>,
     }
 
     impl<'a> SessionSshkeyCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::SshKeyCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::SshKeyCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `SshKeyCreate` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/session/me/sshkeys`
         pub async fn send(self) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/sshkeys", client.baseurl,);
             let request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
@@ -15392,19 +15332,24 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SessionSshkeyView<'a> {
         client: &'a super::Client,
-        ssh_key_name: Option<types::Name>,
+        ssh_key_name: Result<types::Name, String>,
     }
 
     impl<'a> SessionSshkeyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                ssh_key_name: None,
+                ssh_key_name: Err("ssh_key_name was not initialized".to_string()),
             }
         }
 
-        pub fn ssh_key_name(mut self, value: types::Name) -> Self {
-            self.ssh_key_name = Some(value);
+        pub fn ssh_key_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.ssh_key_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for ssh_key_name failed".to_string());
             self
         }
 
@@ -15414,19 +15359,7 @@ pub mod builder {
                 client,
                 ssh_key_name,
             } = self;
-            let (ssh_key_name,) = match (ssh_key_name,) {
-                (Some(ssh_key_name),) => (ssh_key_name,),
-                (ssh_key_name,) => {
-                    let mut missing = Vec::new();
-                    if ssh_key_name.is_none() {
-                        missing.push(stringify!(ssh_key_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let ssh_key_name = ssh_key_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/session/me/sshkeys/{}",
                 client.baseurl,
@@ -15454,19 +15387,24 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SessionSshkeyDelete<'a> {
         client: &'a super::Client,
-        ssh_key_name: Option<types::Name>,
+        ssh_key_name: Result<types::Name, String>,
     }
 
     impl<'a> SessionSshkeyDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                ssh_key_name: None,
+                ssh_key_name: Err("ssh_key_name was not initialized".to_string()),
             }
         }
 
-        pub fn ssh_key_name(mut self, value: types::Name) -> Self {
-            self.ssh_key_name = Some(value);
+        pub fn ssh_key_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.ssh_key_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for ssh_key_name failed".to_string());
             self
         }
 
@@ -15476,19 +15414,7 @@ pub mod builder {
                 client,
                 ssh_key_name,
             } = self;
-            let (ssh_key_name,) = match (ssh_key_name,) {
-                (Some(ssh_key_name),) => (ssh_key_name,),
-                (ssh_key_name,) => {
-                    let mut missing = Vec::new();
-                    if ssh_key_name.is_none() {
-                        missing.push(stringify!(ssh_key_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let ssh_key_name = ssh_key_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/session/me/sshkeys/{}",
                 client.baseurl,
@@ -15516,33 +15442,49 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SiloList<'a> {
         client: &'a super::Client,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameOrIdSortMode>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameOrIdSortMode>, String>,
     }
 
     impl<'a> SiloList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameOrIdSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameOrIdSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameOrIdSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -15556,6 +15498,9 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/silos", client.baseurl,);
             let mut query = Vec::new();
             if let Some(v) = &limit {
@@ -15591,9 +15536,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -15607,7 +15552,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -15636,35 +15581,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SiloCreate<'a> {
         client: &'a super::Client,
-        body: Option<types::SiloCreate>,
+        body: Result<types::SiloCreate, String>,
     }
 
     impl<'a> SiloCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::SiloCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::SiloCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `SiloCreate` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/silos`
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/silos", client.baseurl,);
             let request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
@@ -15688,38 +15629,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SiloView<'a> {
         client: &'a super::Client,
-        silo_name: Option<types::Name>,
+        silo_name: Result<types::Name, String>,
     }
 
     impl<'a> SiloView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                silo_name: None,
+                silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
 
-        pub fn silo_name(mut self, value: types::Name) -> Self {
-            self.silo_name = Some(value);
+        pub fn silo_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.silo_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for silo_name failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/silos/{silo_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
             let Self { client, silo_name } = self;
-            let (silo_name,) = match (silo_name,) {
-                (Some(silo_name),) => (silo_name,),
-                (silo_name,) => {
-                    let mut missing = Vec::new();
-                    if silo_name.is_none() {
-                        missing.push(stringify!(silo_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/silos/{}",
                 client.baseurl,
@@ -15747,38 +15681,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SiloDelete<'a> {
         client: &'a super::Client,
-        silo_name: Option<types::Name>,
+        silo_name: Result<types::Name, String>,
     }
 
     impl<'a> SiloDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                silo_name: None,
+                silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
 
-        pub fn silo_name(mut self, value: types::Name) -> Self {
-            self.silo_name = Some(value);
+        pub fn silo_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.silo_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for silo_name failed".to_string());
             self
         }
 
         ///Sends a `DELETE` request to `/silos/{silo_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, silo_name } = self;
-            let (silo_name,) = match (silo_name,) {
-                (Some(silo_name),) => (silo_name,),
-                (silo_name,) => {
-                    let mut missing = Vec::new();
-                    if silo_name.is_none() {
-                        missing.push(stringify!(silo_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/silos/{}",
                 client.baseurl,
@@ -15806,40 +15733,61 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SiloIdentityProviderList<'a> {
         client: &'a super::Client,
-        silo_name: Option<types::Name>,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        silo_name: Result<types::Name, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> SiloIdentityProviderList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                silo_name: None,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                silo_name: Err("silo_name was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn silo_name(mut self, value: types::Name) -> Self {
-            self.silo_name = Some(value);
+        pub fn silo_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.silo_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for silo_name failed".to_string());
             self
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -15855,19 +15803,10 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
-            let (silo_name,) = match (silo_name,) {
-                (Some(silo_name),) => (silo_name,),
-                (silo_name,) => {
-                    let mut missing = Vec::new();
-                    if silo_name.is_none() {
-                        missing.push(stringify!(silo_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let silo_name = silo_name.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/silos/{}/identity-providers",
                 client.baseurl,
@@ -15907,9 +15846,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -15923,7 +15862,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -15952,19 +15891,24 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SiloPolicyView<'a> {
         client: &'a super::Client,
-        silo_name: Option<types::Name>,
+        silo_name: Result<types::Name, String>,
     }
 
     impl<'a> SiloPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                silo_name: None,
+                silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
 
-        pub fn silo_name(mut self, value: types::Name) -> Self {
-            self.silo_name = Some(value);
+        pub fn silo_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.silo_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for silo_name failed".to_string());
             self
         }
 
@@ -15973,19 +15917,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
             let Self { client, silo_name } = self;
-            let (silo_name,) = match (silo_name,) {
-                (Some(silo_name),) => (silo_name,),
-                (silo_name,) => {
-                    let mut missing = Vec::new();
-                    if silo_name.is_none() {
-                        missing.push(stringify!(silo_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/silos/{}/policy",
                 client.baseurl,
@@ -16013,26 +15945,36 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SiloPolicyUpdate<'a> {
         client: &'a super::Client,
-        silo_name: Option<types::Name>,
-        body: Option<types::SiloRolePolicy>,
+        silo_name: Result<types::Name, String>,
+        body: Result<types::SiloRolePolicy, String>,
     }
 
     impl<'a> SiloPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                silo_name: None,
-                body: None,
+                silo_name: Err("silo_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn silo_name(mut self, value: types::Name) -> Self {
-            self.silo_name = Some(value);
+        pub fn silo_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.silo_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for silo_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::SiloRolePolicy) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::SiloRolePolicy>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `SiloRolePolicy` for body failed".to_string());
             self
         }
 
@@ -16045,22 +15987,8 @@ pub mod builder {
                 silo_name,
                 body,
             } = self;
-            let (silo_name, body) = match (silo_name, body) {
-                (Some(silo_name), Some(body)) => (silo_name, body),
-                (silo_name, body) => {
-                    let mut missing = Vec::new();
-                    if silo_name.is_none() {
-                        missing.push(stringify!(silo_name));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let silo_name = silo_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/silos/{}/policy",
                 client.baseurl,
@@ -16088,26 +16016,36 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SiloIdentityProviderCreate<'a> {
         client: &'a super::Client,
-        silo_name: Option<types::Name>,
-        body: Option<types::SamlIdentityProviderCreate>,
+        silo_name: Result<types::Name, String>,
+        body: Result<types::SamlIdentityProviderCreate, String>,
     }
 
     impl<'a> SiloIdentityProviderCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                silo_name: None,
-                body: None,
+                silo_name: Err("silo_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn silo_name(mut self, value: types::Name) -> Self {
-            self.silo_name = Some(value);
+        pub fn silo_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.silo_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for silo_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::SamlIdentityProviderCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::SamlIdentityProviderCreate>,
+        {
+            self.body = value.try_into().map_err(|_| {
+                "conversion to `SamlIdentityProviderCreate` for body failed".to_string()
+            });
             self
         }
 
@@ -16121,22 +16059,8 @@ pub mod builder {
                 silo_name,
                 body,
             } = self;
-            let (silo_name, body) = match (silo_name, body) {
-                (Some(silo_name), Some(body)) => (silo_name, body),
-                (silo_name, body) => {
-                    let mut missing = Vec::new();
-                    if silo_name.is_none() {
-                        missing.push(stringify!(silo_name));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let silo_name = silo_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/silos/{}/saml-identity-providers",
                 client.baseurl,
@@ -16164,26 +16088,36 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SiloIdentityProviderView<'a> {
         client: &'a super::Client,
-        silo_name: Option<types::Name>,
-        provider_name: Option<types::Name>,
+        silo_name: Result<types::Name, String>,
+        provider_name: Result<types::Name, String>,
     }
 
     impl<'a> SiloIdentityProviderView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                silo_name: None,
-                provider_name: None,
+                silo_name: Err("silo_name was not initialized".to_string()),
+                provider_name: Err("provider_name was not initialized".to_string()),
             }
         }
 
-        pub fn silo_name(mut self, value: types::Name) -> Self {
-            self.silo_name = Some(value);
+        pub fn silo_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.silo_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for silo_name failed".to_string());
             self
         }
 
-        pub fn provider_name(mut self, value: types::Name) -> Self {
-            self.provider_name = Some(value);
+        pub fn provider_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.provider_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for provider_name failed".to_string());
             self
         }
 
@@ -16197,22 +16131,8 @@ pub mod builder {
                 silo_name,
                 provider_name,
             } = self;
-            let (silo_name, provider_name) = match (silo_name, provider_name) {
-                (Some(silo_name), Some(provider_name)) => (silo_name, provider_name),
-                (silo_name, provider_name) => {
-                    let mut missing = Vec::new();
-                    if silo_name.is_none() {
-                        missing.push(stringify!(silo_name));
-                    }
-                    if provider_name.is_none() {
-                        missing.push(stringify!(provider_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let silo_name = silo_name.map_err(Error::InvalidRequest)?;
+            let provider_name = provider_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/silos/{}/saml-identity-providers/{}",
                 client.baseurl,
@@ -16241,33 +16161,49 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SystemUserList<'a> {
         client: &'a super::Client,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> SystemUserList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -16281,6 +16217,9 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/user", client.baseurl,);
             let mut query = Vec::new();
             if let Some(v) = &limit {
@@ -16316,9 +16255,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -16332,7 +16271,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -16361,38 +16300,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SystemUserView<'a> {
         client: &'a super::Client,
-        user_name: Option<types::Name>,
+        user_name: Result<types::Name, String>,
     }
 
     impl<'a> SystemUserView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                user_name: None,
+                user_name: Err("user_name was not initialized".to_string()),
             }
         }
 
-        pub fn user_name(mut self, value: types::Name) -> Self {
-            self.user_name = Some(value);
+        pub fn user_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.user_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for user_name failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/system/user/{user_name}`
         pub async fn send(self) -> Result<ResponseValue<types::UserBuiltin>, Error<types::Error>> {
             let Self { client, user_name } = self;
-            let (user_name,) = match (user_name,) {
-                (Some(user_name),) => (user_name,),
-                (user_name,) => {
-                    let mut missing = Vec::new();
-                    if user_name.is_none() {
-                        missing.push(stringify!(user_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let user_name = user_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/system/user/{}",
                 client.baseurl,
@@ -16420,26 +16352,37 @@ pub mod builder {
     #[derive(Clone)]
     pub struct TimeseriesSchemaGet<'a> {
         client: &'a super::Client,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
     }
 
     impl<'a> TimeseriesSchemaGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                limit: None,
-                page_token: None,
+                limit: Ok(None),
+                page_token: Ok(None),
             }
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
@@ -16453,6 +16396,8 @@ pub mod builder {
                 limit,
                 page_token,
             } = self;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/timeseries/schema", client.baseurl,);
             let mut query = Vec::new();
             if let Some(v) = &limit {
@@ -16485,8 +16430,8 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
+                limit: Ok(None),
+                page_token: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -16500,7 +16445,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -16562,33 +16507,49 @@ pub mod builder {
     #[derive(Clone)]
     pub struct UserList<'a> {
         client: &'a super::Client,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::IdSortMode>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::IdSortMode>, String>,
     }
 
     impl<'a> UserList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::IdSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::IdSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < IdSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -16602,6 +16563,9 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/users", client.baseurl,);
             let mut query = Vec::new();
             if let Some(v) = &limit {
@@ -16637,9 +16601,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -16653,7 +16617,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()

--- a/progenitor-impl/tests/output/nexus-builder.out
+++ b/progenitor-impl/tests/output/nexus-builder.out
@@ -3,6 +3,8 @@ use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
+    #[allow(unused_imports)]
+    use std::convert::TryFrom;
     #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
     pub struct BlockSize(i64);
     impl std::ops::Deref for BlockSize {
@@ -4978,41 +4980,39 @@ pub mod builder {
     use super::types;
     #[allow(unused_imports)]
     use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    #[allow(unused_imports)]
+    use std::convert::TryInto;
     ///Builder for [`Client::disk_view_by_id`]
     ///
     ///[`Client::disk_view_by_id`]: super::Client::disk_view_by_id
     #[derive(Clone)]
     pub struct DiskViewById<'a> {
         client: &'a super::Client,
-        id: Option<uuid::Uuid>,
+        id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> DiskViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, id: None }
+            Self {
+                client,
+                id: Err("id was not initialized".to_string()),
+            }
         }
 
-        pub fn id(mut self, value: uuid::Uuid) -> Self {
-            self.id = Some(value);
+        pub fn id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for id failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/by-id/disks/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self { client, id } = self;
-            let (id,) = match (id,) {
-                (Some(id),) => (id,),
-                (id,) => {
-                    let mut missing = Vec::new();
-                    if id.is_none() {
-                        missing.push(stringify!(id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let id = id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/by-id/disks/{}",
                 client.baseurl,
@@ -5040,35 +5040,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ImageGlobalViewById<'a> {
         client: &'a super::Client,
-        id: Option<uuid::Uuid>,
+        id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> ImageGlobalViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, id: None }
+            Self {
+                client,
+                id: Err("id was not initialized".to_string()),
+            }
         }
 
-        pub fn id(mut self, value: uuid::Uuid) -> Self {
-            self.id = Some(value);
+        pub fn id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for id failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/by-id/global-images/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
             let Self { client, id } = self;
-            let (id,) = match (id,) {
-                (Some(id),) => (id,),
-                (id,) => {
-                    let mut missing = Vec::new();
-                    if id.is_none() {
-                        missing.push(stringify!(id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let id = id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/by-id/global-images/{}",
                 client.baseurl,
@@ -5096,35 +5092,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ImageViewById<'a> {
         client: &'a super::Client,
-        id: Option<uuid::Uuid>,
+        id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> ImageViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, id: None }
+            Self {
+                client,
+                id: Err("id was not initialized".to_string()),
+            }
         }
 
-        pub fn id(mut self, value: uuid::Uuid) -> Self {
-            self.id = Some(value);
+        pub fn id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for id failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/by-id/images/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
             let Self { client, id } = self;
-            let (id,) = match (id,) {
-                (Some(id),) => (id,),
-                (id,) => {
-                    let mut missing = Vec::new();
-                    if id.is_none() {
-                        missing.push(stringify!(id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let id = id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/by-id/images/{}",
                 client.baseurl,
@@ -5152,35 +5144,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceViewById<'a> {
         client: &'a super::Client,
-        id: Option<uuid::Uuid>,
+        id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> InstanceViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, id: None }
+            Self {
+                client,
+                id: Err("id was not initialized".to_string()),
+            }
         }
 
-        pub fn id(mut self, value: uuid::Uuid) -> Self {
-            self.id = Some(value);
+        pub fn id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for id failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/by-id/instances/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self { client, id } = self;
-            let (id,) = match (id,) {
-                (Some(id),) => (id,),
-                (id,) => {
-                    let mut missing = Vec::new();
-                    if id.is_none() {
-                        missing.push(stringify!(id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let id = id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/by-id/instances/{}",
                 client.baseurl,
@@ -5208,16 +5196,24 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceNetworkInterfaceViewById<'a> {
         client: &'a super::Client,
-        id: Option<uuid::Uuid>,
+        id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> InstanceNetworkInterfaceViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, id: None }
+            Self {
+                client,
+                id: Err("id was not initialized".to_string()),
+            }
         }
 
-        pub fn id(mut self, value: uuid::Uuid) -> Self {
-            self.id = Some(value);
+        pub fn id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for id failed".to_string());
             self
         }
 
@@ -5226,19 +5222,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
             let Self { client, id } = self;
-            let (id,) = match (id,) {
-                (Some(id),) => (id,),
-                (id,) => {
-                    let mut missing = Vec::new();
-                    if id.is_none() {
-                        missing.push(stringify!(id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let id = id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/by-id/network-interfaces/{}",
                 client.baseurl,
@@ -5266,35 +5250,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct OrganizationViewById<'a> {
         client: &'a super::Client,
-        id: Option<uuid::Uuid>,
+        id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> OrganizationViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, id: None }
+            Self {
+                client,
+                id: Err("id was not initialized".to_string()),
+            }
         }
 
-        pub fn id(mut self, value: uuid::Uuid) -> Self {
-            self.id = Some(value);
+        pub fn id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for id failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/by-id/organizations/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self { client, id } = self;
-            let (id,) = match (id,) {
-                (Some(id),) => (id,),
-                (id,) => {
-                    let mut missing = Vec::new();
-                    if id.is_none() {
-                        missing.push(stringify!(id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let id = id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/by-id/organizations/{}",
                 client.baseurl,
@@ -5322,35 +5302,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ProjectViewById<'a> {
         client: &'a super::Client,
-        id: Option<uuid::Uuid>,
+        id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> ProjectViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, id: None }
+            Self {
+                client,
+                id: Err("id was not initialized".to_string()),
+            }
         }
 
-        pub fn id(mut self, value: uuid::Uuid) -> Self {
-            self.id = Some(value);
+        pub fn id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for id failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/by-id/projects/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self { client, id } = self;
-            let (id,) = match (id,) {
-                (Some(id),) => (id,),
-                (id,) => {
-                    let mut missing = Vec::new();
-                    if id.is_none() {
-                        missing.push(stringify!(id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let id = id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/by-id/projects/{}",
                 client.baseurl,
@@ -5378,35 +5354,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SnapshotViewById<'a> {
         client: &'a super::Client,
-        id: Option<uuid::Uuid>,
+        id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SnapshotViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, id: None }
+            Self {
+                client,
+                id: Err("id was not initialized".to_string()),
+            }
         }
 
-        pub fn id(mut self, value: uuid::Uuid) -> Self {
-            self.id = Some(value);
+        pub fn id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for id failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/by-id/snapshots/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
             let Self { client, id } = self;
-            let (id,) = match (id,) {
-                (Some(id),) => (id,),
-                (id,) => {
-                    let mut missing = Vec::new();
-                    if id.is_none() {
-                        missing.push(stringify!(id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let id = id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/by-id/snapshots/{}",
                 client.baseurl,
@@ -5434,35 +5406,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcRouterRouteViewById<'a> {
         client: &'a super::Client,
-        id: Option<uuid::Uuid>,
+        id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcRouterRouteViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, id: None }
+            Self {
+                client,
+                id: Err("id was not initialized".to_string()),
+            }
         }
 
-        pub fn id(mut self, value: uuid::Uuid) -> Self {
-            self.id = Some(value);
+        pub fn id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for id failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/by-id/vpc-router-routes/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self { client, id } = self;
-            let (id,) = match (id,) {
-                (Some(id),) => (id,),
-                (id,) => {
-                    let mut missing = Vec::new();
-                    if id.is_none() {
-                        missing.push(stringify!(id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let id = id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/by-id/vpc-router-routes/{}",
                 client.baseurl,
@@ -5490,35 +5458,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcRouterViewById<'a> {
         client: &'a super::Client,
-        id: Option<uuid::Uuid>,
+        id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcRouterViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, id: None }
+            Self {
+                client,
+                id: Err("id was not initialized".to_string()),
+            }
         }
 
-        pub fn id(mut self, value: uuid::Uuid) -> Self {
-            self.id = Some(value);
+        pub fn id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for id failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/by-id/vpc-routers/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self { client, id } = self;
-            let (id,) = match (id,) {
-                (Some(id),) => (id,),
-                (id,) => {
-                    let mut missing = Vec::new();
-                    if id.is_none() {
-                        missing.push(stringify!(id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let id = id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/by-id/vpc-routers/{}",
                 client.baseurl,
@@ -5546,35 +5510,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcSubnetViewById<'a> {
         client: &'a super::Client,
-        id: Option<uuid::Uuid>,
+        id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcSubnetViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, id: None }
+            Self {
+                client,
+                id: Err("id was not initialized".to_string()),
+            }
         }
 
-        pub fn id(mut self, value: uuid::Uuid) -> Self {
-            self.id = Some(value);
+        pub fn id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for id failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/by-id/vpc-subnets/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self { client, id } = self;
-            let (id,) = match (id,) {
-                (Some(id),) => (id,),
-                (id,) => {
-                    let mut missing = Vec::new();
-                    if id.is_none() {
-                        missing.push(stringify!(id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let id = id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/by-id/vpc-subnets/{}",
                 client.baseurl,
@@ -5602,35 +5562,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcViewById<'a> {
         client: &'a super::Client,
-        id: Option<uuid::Uuid>,
+        id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, id: None }
+            Self {
+                client,
+                id: Err("id was not initialized".to_string()),
+            }
         }
 
-        pub fn id(mut self, value: uuid::Uuid) -> Self {
-            self.id = Some(value);
+        pub fn id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for id failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/by-id/vpcs/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self { client, id } = self;
-            let (id,) = match (id,) {
-                (Some(id),) => (id,),
-                (id,) => {
-                    let mut missing = Vec::new();
-                    if id.is_none() {
-                        missing.push(stringify!(id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let id = id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/by-id/vpcs/{}",
                 client.baseurl,
@@ -5658,35 +5614,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct DeviceAuthRequest<'a> {
         client: &'a super::Client,
-        body: Option<types::DeviceAuthRequest>,
+        body: Result<types::DeviceAuthRequest, String>,
     }
 
     impl<'a> DeviceAuthRequest<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::DeviceAuthRequest) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::DeviceAuthRequest>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `DeviceAuthRequest` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/device/auth`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/device/auth", client.baseurl,);
             let request = client.client.post(url).form_urlencoded(&body)?.build()?;
             let result = client.client.execute(request).await;
@@ -5704,35 +5656,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct DeviceAuthConfirm<'a> {
         client: &'a super::Client,
-        body: Option<types::DeviceAuthVerify>,
+        body: Result<types::DeviceAuthVerify, String>,
     }
 
     impl<'a> DeviceAuthConfirm<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::DeviceAuthVerify) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::DeviceAuthVerify>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `DeviceAuthVerify` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/device/confirm`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/device/confirm", client.baseurl,);
             let request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
@@ -5756,35 +5704,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct DeviceAccessToken<'a> {
         client: &'a super::Client,
-        body: Option<types::DeviceAccessTokenRequest>,
+        body: Result<types::DeviceAccessTokenRequest, String>,
     }
 
     impl<'a> DeviceAccessToken<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::DeviceAccessTokenRequest) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::DeviceAccessTokenRequest>,
+        {
+            self.body = value.try_into().map_err(|_| {
+                "conversion to `DeviceAccessTokenRequest` for body failed".to_string()
+            });
             self
         }
 
         ///Sends a `POST` request to `/device/token`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/device/token", client.baseurl,);
             let request = client.client.post(url).form_urlencoded(&body)?.build()?;
             let result = client.client.execute(request).await;
@@ -5802,33 +5746,49 @@ pub mod builder {
     #[derive(Clone)]
     pub struct RackList<'a> {
         client: &'a super::Client,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::IdSortMode>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::IdSortMode>, String>,
     }
 
     impl<'a> RackList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::IdSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::IdSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < IdSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -5842,6 +5802,9 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/hardware/racks", client.baseurl,);
             let mut query = Vec::new();
             if let Some(v) = &limit {
@@ -5877,9 +5840,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -5893,7 +5856,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -5922,38 +5885,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct RackView<'a> {
         client: &'a super::Client,
-        rack_id: Option<uuid::Uuid>,
+        rack_id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> RackView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                rack_id: None,
+                rack_id: Err("rack_id was not initialized".to_string()),
             }
         }
 
-        pub fn rack_id(mut self, value: uuid::Uuid) -> Self {
-            self.rack_id = Some(value);
+        pub fn rack_id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.rack_id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for rack_id failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/hardware/racks/{rack_id}`
         pub async fn send(self) -> Result<ResponseValue<types::Rack>, Error<types::Error>> {
             let Self { client, rack_id } = self;
-            let (rack_id,) = match (rack_id,) {
-                (Some(rack_id),) => (rack_id,),
-                (rack_id,) => {
-                    let mut missing = Vec::new();
-                    if rack_id.is_none() {
-                        missing.push(stringify!(rack_id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let rack_id = rack_id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/hardware/racks/{}",
                 client.baseurl,
@@ -5981,33 +5937,49 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SledList<'a> {
         client: &'a super::Client,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::IdSortMode>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::IdSortMode>, String>,
     }
 
     impl<'a> SledList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::IdSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::IdSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < IdSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -6021,6 +5993,9 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/hardware/sleds", client.baseurl,);
             let mut query = Vec::new();
             if let Some(v) = &limit {
@@ -6056,9 +6031,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -6072,7 +6047,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -6101,38 +6076,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SledView<'a> {
         client: &'a super::Client,
-        sled_id: Option<uuid::Uuid>,
+        sled_id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SledView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                sled_id: None,
+                sled_id: Err("sled_id was not initialized".to_string()),
             }
         }
 
-        pub fn sled_id(mut self, value: uuid::Uuid) -> Self {
-            self.sled_id = Some(value);
+        pub fn sled_id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.sled_id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for sled_id failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/hardware/sleds/{sled_id}`
         pub async fn send(self) -> Result<ResponseValue<types::Sled>, Error<types::Error>> {
             let Self { client, sled_id } = self;
-            let (sled_id,) = match (sled_id,) {
-                (Some(sled_id),) => (sled_id,),
-                (sled_id,) => {
-                    let mut missing = Vec::new();
-                    if sled_id.is_none() {
-                        missing.push(stringify!(sled_id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let sled_id = sled_id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/hardware/sleds/{}",
                 client.baseurl,
@@ -6160,33 +6128,49 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ImageGlobalList<'a> {
         client: &'a super::Client,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> ImageGlobalList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -6200,6 +6184,9 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/images", client.baseurl,);
             let mut query = Vec::new();
             if let Some(v) = &limit {
@@ -6235,9 +6222,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -6251,7 +6238,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -6280,35 +6267,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ImageGlobalCreate<'a> {
         client: &'a super::Client,
-        body: Option<types::GlobalImageCreate>,
+        body: Result<types::GlobalImageCreate, String>,
     }
 
     impl<'a> ImageGlobalCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::GlobalImageCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::GlobalImageCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `GlobalImageCreate` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/images`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/images", client.baseurl,);
             let request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
@@ -6332,38 +6315,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ImageGlobalView<'a> {
         client: &'a super::Client,
-        image_name: Option<types::Name>,
+        image_name: Result<types::Name, String>,
     }
 
     impl<'a> ImageGlobalView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                image_name: None,
+                image_name: Err("image_name was not initialized".to_string()),
             }
         }
 
-        pub fn image_name(mut self, value: types::Name) -> Self {
-            self.image_name = Some(value);
+        pub fn image_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.image_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for image_name failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/images/{image_name}`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
             let Self { client, image_name } = self;
-            let (image_name,) = match (image_name,) {
-                (Some(image_name),) => (image_name,),
-                (image_name,) => {
-                    let mut missing = Vec::new();
-                    if image_name.is_none() {
-                        missing.push(stringify!(image_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let image_name = image_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/images/{}",
                 client.baseurl,
@@ -6391,38 +6367,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ImageGlobalDelete<'a> {
         client: &'a super::Client,
-        image_name: Option<types::Name>,
+        image_name: Result<types::Name, String>,
     }
 
     impl<'a> ImageGlobalDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                image_name: None,
+                image_name: Err("image_name was not initialized".to_string()),
             }
         }
 
-        pub fn image_name(mut self, value: types::Name) -> Self {
-            self.image_name = Some(value);
+        pub fn image_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.image_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for image_name failed".to_string());
             self
         }
 
         ///Sends a `DELETE` request to `/images/{image_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, image_name } = self;
-            let (image_name,) = match (image_name,) {
-                (Some(image_name),) => (image_name,),
-                (image_name,) => {
-                    let mut missing = Vec::new();
-                    if image_name.is_none() {
-                        missing.push(stringify!(image_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let image_name = image_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/images/{}",
                 client.baseurl,
@@ -6450,33 +6419,49 @@ pub mod builder {
     #[derive(Clone)]
     pub struct IpPoolList<'a> {
         client: &'a super::Client,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameOrIdSortMode>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameOrIdSortMode>, String>,
     }
 
     impl<'a> IpPoolList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameOrIdSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameOrIdSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameOrIdSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -6490,6 +6475,9 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/ip-pools", client.baseurl,);
             let mut query = Vec::new();
             if let Some(v) = &limit {
@@ -6525,9 +6513,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -6541,7 +6529,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -6570,35 +6558,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct IpPoolCreate<'a> {
         client: &'a super::Client,
-        body: Option<types::IpPoolCreate>,
+        body: Result<types::IpPoolCreate, String>,
     }
 
     impl<'a> IpPoolCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::IpPoolCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::IpPoolCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `IpPoolCreate` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/ip-pools`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/ip-pools", client.baseurl,);
             let request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
@@ -6622,38 +6606,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct IpPoolView<'a> {
         client: &'a super::Client,
-        pool_name: Option<types::Name>,
+        pool_name: Result<types::Name, String>,
     }
 
     impl<'a> IpPoolView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                pool_name: None,
+                pool_name: Err("pool_name was not initialized".to_string()),
             }
         }
 
-        pub fn pool_name(mut self, value: types::Name) -> Self {
-            self.pool_name = Some(value);
+        pub fn pool_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.pool_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for pool_name failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/ip-pools/{pool_name}`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client, pool_name } = self;
-            let (pool_name,) = match (pool_name,) {
-                (Some(pool_name),) => (pool_name,),
-                (pool_name,) => {
-                    let mut missing = Vec::new();
-                    if pool_name.is_none() {
-                        missing.push(stringify!(pool_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/ip-pools/{}",
                 client.baseurl,
@@ -6681,26 +6658,36 @@ pub mod builder {
     #[derive(Clone)]
     pub struct IpPoolUpdate<'a> {
         client: &'a super::Client,
-        pool_name: Option<types::Name>,
-        body: Option<types::IpPoolUpdate>,
+        pool_name: Result<types::Name, String>,
+        body: Result<types::IpPoolUpdate, String>,
     }
 
     impl<'a> IpPoolUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                pool_name: None,
-                body: None,
+                pool_name: Err("pool_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn pool_name(mut self, value: types::Name) -> Self {
-            self.pool_name = Some(value);
+        pub fn pool_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.pool_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for pool_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::IpPoolUpdate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::IpPoolUpdate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `IpPoolUpdate` for body failed".to_string());
             self
         }
 
@@ -6711,22 +6698,8 @@ pub mod builder {
                 pool_name,
                 body,
             } = self;
-            let (pool_name, body) = match (pool_name, body) {
-                (Some(pool_name), Some(body)) => (pool_name, body),
-                (pool_name, body) => {
-                    let mut missing = Vec::new();
-                    if pool_name.is_none() {
-                        missing.push(stringify!(pool_name));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let pool_name = pool_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/ip-pools/{}",
                 client.baseurl,
@@ -6754,38 +6727,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct IpPoolDelete<'a> {
         client: &'a super::Client,
-        pool_name: Option<types::Name>,
+        pool_name: Result<types::Name, String>,
     }
 
     impl<'a> IpPoolDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                pool_name: None,
+                pool_name: Err("pool_name was not initialized".to_string()),
             }
         }
 
-        pub fn pool_name(mut self, value: types::Name) -> Self {
-            self.pool_name = Some(value);
+        pub fn pool_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.pool_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for pool_name failed".to_string());
             self
         }
 
         ///Sends a `DELETE` request to `/ip-pools/{pool_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, pool_name } = self;
-            let (pool_name,) = match (pool_name,) {
-                (Some(pool_name),) => (pool_name,),
-                (pool_name,) => {
-                    let mut missing = Vec::new();
-                    if pool_name.is_none() {
-                        missing.push(stringify!(pool_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/ip-pools/{}",
                 client.baseurl,
@@ -6813,33 +6779,49 @@ pub mod builder {
     #[derive(Clone)]
     pub struct IpPoolRangeList<'a> {
         client: &'a super::Client,
-        pool_name: Option<types::Name>,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
+        pool_name: Result<types::Name, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
     }
 
     impl<'a> IpPoolRangeList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                pool_name: None,
-                limit: None,
-                page_token: None,
+                pool_name: Err("pool_name was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
             }
         }
 
-        pub fn pool_name(mut self, value: types::Name) -> Self {
-            self.pool_name = Some(value);
+        pub fn pool_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.pool_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for pool_name failed".to_string());
             self
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
@@ -6853,19 +6835,9 @@ pub mod builder {
                 limit,
                 page_token,
             } = self;
-            let (pool_name,) = match (pool_name,) {
-                (Some(pool_name),) => (pool_name,),
-                (pool_name,) => {
-                    let mut missing = Vec::new();
-                    if pool_name.is_none() {
-                        missing.push(stringify!(pool_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let pool_name = pool_name.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/ip-pools/{}/ranges",
                 client.baseurl,
@@ -6902,8 +6874,8 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
+                limit: Ok(None),
+                page_token: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -6917,7 +6889,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -6946,26 +6918,36 @@ pub mod builder {
     #[derive(Clone)]
     pub struct IpPoolRangeAdd<'a> {
         client: &'a super::Client,
-        pool_name: Option<types::Name>,
-        body: Option<types::IpRange>,
+        pool_name: Result<types::Name, String>,
+        body: Result<types::IpRange, String>,
     }
 
     impl<'a> IpPoolRangeAdd<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                pool_name: None,
-                body: None,
+                pool_name: Err("pool_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn pool_name(mut self, value: types::Name) -> Self {
-            self.pool_name = Some(value);
+        pub fn pool_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.pool_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for pool_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::IpRange) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::IpRange>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `IpRange` for body failed".to_string());
             self
         }
 
@@ -6976,22 +6958,8 @@ pub mod builder {
                 pool_name,
                 body,
             } = self;
-            let (pool_name, body) = match (pool_name, body) {
-                (Some(pool_name), Some(body)) => (pool_name, body),
-                (pool_name, body) => {
-                    let mut missing = Vec::new();
-                    if pool_name.is_none() {
-                        missing.push(stringify!(pool_name));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let pool_name = pool_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/ip-pools/{}/ranges/add",
                 client.baseurl,
@@ -7019,26 +6987,36 @@ pub mod builder {
     #[derive(Clone)]
     pub struct IpPoolRangeRemove<'a> {
         client: &'a super::Client,
-        pool_name: Option<types::Name>,
-        body: Option<types::IpRange>,
+        pool_name: Result<types::Name, String>,
+        body: Result<types::IpRange, String>,
     }
 
     impl<'a> IpPoolRangeRemove<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                pool_name: None,
-                body: None,
+                pool_name: Err("pool_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn pool_name(mut self, value: types::Name) -> Self {
-            self.pool_name = Some(value);
+        pub fn pool_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.pool_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for pool_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::IpRange) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::IpRange>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `IpRange` for body failed".to_string());
             self
         }
 
@@ -7049,22 +7027,8 @@ pub mod builder {
                 pool_name,
                 body,
             } = self;
-            let (pool_name, body) = match (pool_name, body) {
-                (Some(pool_name), Some(body)) => (pool_name, body),
-                (pool_name, body) => {
-                    let mut missing = Vec::new();
-                    if pool_name.is_none() {
-                        missing.push(stringify!(pool_name));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let pool_name = pool_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/ip-pools/{}/ranges/remove",
                 client.baseurl,
@@ -7092,35 +7056,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SpoofLogin<'a> {
         client: &'a super::Client,
-        body: Option<types::SpoofLoginBody>,
+        body: Result<types::SpoofLoginBody, String>,
     }
 
     impl<'a> SpoofLogin<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::SpoofLoginBody) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::SpoofLoginBody>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `SpoofLoginBody` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/login`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/login", client.baseurl,);
             let request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
@@ -7138,26 +7098,36 @@ pub mod builder {
     #[derive(Clone)]
     pub struct Login<'a> {
         client: &'a super::Client,
-        silo_name: Option<types::Name>,
-        provider_name: Option<types::Name>,
+        silo_name: Result<types::Name, String>,
+        provider_name: Result<types::Name, String>,
     }
 
     impl<'a> Login<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                silo_name: None,
-                provider_name: None,
+                silo_name: Err("silo_name was not initialized".to_string()),
+                provider_name: Err("provider_name was not initialized".to_string()),
             }
         }
 
-        pub fn silo_name(mut self, value: types::Name) -> Self {
-            self.silo_name = Some(value);
+        pub fn silo_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.silo_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for silo_name failed".to_string());
             self
         }
 
-        pub fn provider_name(mut self, value: types::Name) -> Self {
-            self.provider_name = Some(value);
+        pub fn provider_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.provider_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for provider_name failed".to_string());
             self
         }
 
@@ -7168,22 +7138,8 @@ pub mod builder {
                 silo_name,
                 provider_name,
             } = self;
-            let (silo_name, provider_name) = match (silo_name, provider_name) {
-                (Some(silo_name), Some(provider_name)) => (silo_name, provider_name),
-                (silo_name, provider_name) => {
-                    let mut missing = Vec::new();
-                    if silo_name.is_none() {
-                        missing.push(stringify!(silo_name));
-                    }
-                    if provider_name.is_none() {
-                        missing.push(stringify!(provider_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let silo_name = silo_name.map_err(Error::InvalidRequest)?;
+            let provider_name = provider_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/login/{}/{}",
                 client.baseurl,
@@ -7205,33 +7161,48 @@ pub mod builder {
     ///[`Client::consume_credentials`]: super::Client::consume_credentials
     pub struct ConsumeCredentials<'a> {
         client: &'a super::Client,
-        silo_name: Option<types::Name>,
-        provider_name: Option<types::Name>,
-        body: Option<reqwest::Body>,
+        silo_name: Result<types::Name, String>,
+        provider_name: Result<types::Name, String>,
+        body: Result<reqwest::Body, String>,
     }
 
     impl<'a> ConsumeCredentials<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                silo_name: None,
-                provider_name: None,
-                body: None,
+                silo_name: Err("silo_name was not initialized".to_string()),
+                provider_name: Err("provider_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn silo_name(mut self, value: types::Name) -> Self {
-            self.silo_name = Some(value);
+        pub fn silo_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.silo_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for silo_name failed".to_string());
             self
         }
 
-        pub fn provider_name(mut self, value: types::Name) -> Self {
-            self.provider_name = Some(value);
+        pub fn provider_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.provider_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for provider_name failed".to_string());
             self
         }
 
-        pub fn body<B: Into<reqwest::Body>>(mut self, value: B) -> Self {
-            self.body = Some(value.into());
+        pub fn body<B>(mut self, value: B) -> Self
+        where
+            B: TryInto<reqwest::Body>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `reqwest::Body` for body failed".to_string());
             self
         }
 
@@ -7243,27 +7214,9 @@ pub mod builder {
                 provider_name,
                 body,
             } = self;
-            let (silo_name, provider_name, body) = match (silo_name, provider_name, body) {
-                (Some(silo_name), Some(provider_name), Some(body)) => {
-                    (silo_name, provider_name, body)
-                }
-                (silo_name, provider_name, body) => {
-                    let mut missing = Vec::new();
-                    if silo_name.is_none() {
-                        missing.push(stringify!(silo_name));
-                    }
-                    if provider_name.is_none() {
-                        missing.push(stringify!(provider_name));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let silo_name = silo_name.map_err(Error::InvalidRequest)?;
+            let provider_name = provider_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/login/{}/{}",
                 client.baseurl,
@@ -7321,33 +7274,49 @@ pub mod builder {
     #[derive(Clone)]
     pub struct OrganizationList<'a> {
         client: &'a super::Client,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameOrIdSortMode>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameOrIdSortMode>, String>,
     }
 
     impl<'a> OrganizationList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameOrIdSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameOrIdSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameOrIdSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -7361,6 +7330,9 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/organizations", client.baseurl,);
             let mut query = Vec::new();
             if let Some(v) = &limit {
@@ -7396,9 +7368,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -7412,7 +7384,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -7441,35 +7413,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct OrganizationCreate<'a> {
         client: &'a super::Client,
-        body: Option<types::OrganizationCreate>,
+        body: Result<types::OrganizationCreate, String>,
     }
 
     impl<'a> OrganizationCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::OrganizationCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::OrganizationCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `OrganizationCreate` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/organizations`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/organizations", client.baseurl,);
             let request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
@@ -7493,19 +7461,24 @@ pub mod builder {
     #[derive(Clone)]
     pub struct OrganizationView<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
     }
 
     impl<'a> OrganizationView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
@@ -7515,19 +7488,7 @@ pub mod builder {
                 client,
                 organization_name,
             } = self;
-            let (organization_name,) = match (organization_name,) {
-                (Some(organization_name),) => (organization_name,),
-                (organization_name,) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}",
                 client.baseurl,
@@ -7555,26 +7516,36 @@ pub mod builder {
     #[derive(Clone)]
     pub struct OrganizationUpdate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        body: Option<types::OrganizationUpdate>,
+        organization_name: Result<types::Name, String>,
+        body: Result<types::OrganizationUpdate, String>,
     }
 
     impl<'a> OrganizationUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::OrganizationUpdate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::OrganizationUpdate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `OrganizationUpdate` for body failed".to_string());
             self
         }
 
@@ -7585,22 +7556,8 @@ pub mod builder {
                 organization_name,
                 body,
             } = self;
-            let (organization_name, body) = match (organization_name, body) {
-                (Some(organization_name), Some(body)) => (organization_name, body),
-                (organization_name, body) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}",
                 client.baseurl,
@@ -7628,19 +7585,24 @@ pub mod builder {
     #[derive(Clone)]
     pub struct OrganizationDelete<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
     }
 
     impl<'a> OrganizationDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
@@ -7650,19 +7612,7 @@ pub mod builder {
                 client,
                 organization_name,
             } = self;
-            let (organization_name,) = match (organization_name,) {
-                (Some(organization_name),) => (organization_name,),
-                (organization_name,) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}",
                 client.baseurl,
@@ -7690,19 +7640,24 @@ pub mod builder {
     #[derive(Clone)]
     pub struct OrganizationPolicyView<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
     }
 
     impl<'a> OrganizationPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
@@ -7714,19 +7669,7 @@ pub mod builder {
                 client,
                 organization_name,
             } = self;
-            let (organization_name,) = match (organization_name,) {
-                (Some(organization_name),) => (organization_name,),
-                (organization_name,) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/policy",
                 client.baseurl,
@@ -7754,26 +7697,36 @@ pub mod builder {
     #[derive(Clone)]
     pub struct OrganizationPolicyUpdate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        body: Option<types::OrganizationRolePolicy>,
+        organization_name: Result<types::Name, String>,
+        body: Result<types::OrganizationRolePolicy, String>,
     }
 
     impl<'a> OrganizationPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::OrganizationRolePolicy) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::OrganizationRolePolicy>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `OrganizationRolePolicy` for body failed".to_string());
             self
         }
 
@@ -7786,22 +7739,8 @@ pub mod builder {
                 organization_name,
                 body,
             } = self;
-            let (organization_name, body) = match (organization_name, body) {
-                (Some(organization_name), Some(body)) => (organization_name, body),
-                (organization_name, body) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/policy",
                 client.baseurl,
@@ -7829,40 +7768,61 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ProjectList<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameOrIdSortMode>,
+        organization_name: Result<types::Name, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameOrIdSortMode>, String>,
     }
 
     impl<'a> ProjectList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameOrIdSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameOrIdSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameOrIdSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -7878,19 +7838,10 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
-            let (organization_name,) = match (organization_name,) {
-                (Some(organization_name),) => (organization_name,),
-                (organization_name,) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects",
                 client.baseurl,
@@ -7931,9 +7882,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -7947,7 +7898,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -7976,26 +7927,36 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ProjectCreate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        body: Option<types::ProjectCreate>,
+        organization_name: Result<types::Name, String>,
+        body: Result<types::ProjectCreate, String>,
     }
 
     impl<'a> ProjectCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::ProjectCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::ProjectCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `ProjectCreate` for body failed".to_string());
             self
         }
 
@@ -8007,22 +7968,8 @@ pub mod builder {
                 organization_name,
                 body,
             } = self;
-            let (organization_name, body) = match (organization_name, body) {
-                (Some(organization_name), Some(body)) => (organization_name, body),
-                (organization_name, body) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects",
                 client.baseurl,
@@ -8050,26 +7997,36 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ProjectView<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
     }
 
     impl<'a> ProjectView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
@@ -8081,22 +8038,8 @@ pub mod builder {
                 organization_name,
                 project_name,
             } = self;
-            let (organization_name, project_name) = match (organization_name, project_name) {
-                (Some(organization_name), Some(project_name)) => (organization_name, project_name),
-                (organization_name, project_name) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if project_name.is_none() {
-                        missing.push(stringify!(project_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}",
                 client.baseurl,
@@ -8125,33 +8068,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ProjectUpdate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        body: Option<types::ProjectUpdate>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        body: Result<types::ProjectUpdate, String>,
     }
 
     impl<'a> ProjectUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::ProjectUpdate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::ProjectUpdate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `ProjectUpdate` for body failed".to_string());
             self
         }
 
@@ -8164,28 +8122,9 @@ pub mod builder {
                 project_name,
                 body,
             } = self;
-            let (organization_name, project_name, body) =
-                match (organization_name, project_name, body) {
-                    (Some(organization_name), Some(project_name), Some(body)) => {
-                        (organization_name, project_name, body)
-                    }
-                    (organization_name, project_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}",
                 client.baseurl,
@@ -8214,26 +8153,36 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ProjectDelete<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
     }
 
     impl<'a> ProjectDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
@@ -8245,22 +8194,8 @@ pub mod builder {
                 organization_name,
                 project_name,
             } = self;
-            let (organization_name, project_name) = match (organization_name, project_name) {
-                (Some(organization_name), Some(project_name)) => (organization_name, project_name),
-                (organization_name, project_name) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if project_name.is_none() {
-                        missing.push(stringify!(project_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}",
                 client.baseurl,
@@ -8289,47 +8224,73 @@ pub mod builder {
     #[derive(Clone)]
     pub struct DiskList<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> DiskList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -8346,22 +8307,11 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
-            let (organization_name, project_name) = match (organization_name, project_name) {
-                (Some(organization_name), Some(project_name)) => (organization_name, project_name),
-                (organization_name, project_name) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if project_name.is_none() {
-                        missing.push(stringify!(project_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/disks",
                 client.baseurl,
@@ -8403,9 +8353,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -8419,7 +8369,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -8448,33 +8398,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct DiskCreate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        body: Option<types::DiskCreate>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        body: Result<types::DiskCreate, String>,
     }
 
     impl<'a> DiskCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::DiskCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::DiskCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `DiskCreate` for body failed".to_string());
             self
         }
 
@@ -8487,28 +8452,9 @@ pub mod builder {
                 project_name,
                 body,
             } = self;
-            let (organization_name, project_name, body) =
-                match (organization_name, project_name, body) {
-                    (Some(organization_name), Some(project_name), Some(body)) => {
-                        (organization_name, project_name, body)
-                    }
-                    (organization_name, project_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/disks",
                 client.baseurl,
@@ -8537,33 +8483,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct DiskView<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        disk_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        disk_name: Result<types::Name, String>,
     }
 
     impl<'a> DiskView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                disk_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                disk_name: Err("disk_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn disk_name(mut self, value: types::Name) -> Self {
-            self.disk_name = Some(value);
+        pub fn disk_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.disk_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for disk_name failed".to_string());
             self
         }
 
@@ -8577,28 +8538,9 @@ pub mod builder {
                 project_name,
                 disk_name,
             } = self;
-            let (organization_name, project_name, disk_name) =
-                match (organization_name, project_name, disk_name) {
-                    (Some(organization_name), Some(project_name), Some(disk_name)) => {
-                        (organization_name, project_name, disk_name)
-                    }
-                    (organization_name, project_name, disk_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if disk_name.is_none() {
-                            missing.push(stringify!(disk_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let disk_name = disk_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/disks/{}",
                 client.baseurl,
@@ -8628,33 +8570,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct DiskDelete<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        disk_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        disk_name: Result<types::Name, String>,
     }
 
     impl<'a> DiskDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                disk_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                disk_name: Err("disk_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn disk_name(mut self, value: types::Name) -> Self {
-            self.disk_name = Some(value);
+        pub fn disk_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.disk_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for disk_name failed".to_string());
             self
         }
 
@@ -8668,28 +8625,9 @@ pub mod builder {
                 project_name,
                 disk_name,
             } = self;
-            let (organization_name, project_name, disk_name) =
-                match (organization_name, project_name, disk_name) {
-                    (Some(organization_name), Some(project_name), Some(disk_name)) => {
-                        (organization_name, project_name, disk_name)
-                    }
-                    (organization_name, project_name, disk_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if disk_name.is_none() {
-                            missing.push(stringify!(disk_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let disk_name = disk_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/disks/{}",
                 client.baseurl,
@@ -8719,47 +8657,73 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ImageList<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> ImageList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -8776,22 +8740,11 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
-            let (organization_name, project_name) = match (organization_name, project_name) {
-                (Some(organization_name), Some(project_name)) => (organization_name, project_name),
-                (organization_name, project_name) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if project_name.is_none() {
-                        missing.push(stringify!(project_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/images",
                 client.baseurl,
@@ -8833,9 +8786,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -8849,7 +8802,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -8878,33 +8831,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ImageCreate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        body: Option<types::ImageCreate>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        body: Result<types::ImageCreate, String>,
     }
 
     impl<'a> ImageCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::ImageCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::ImageCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `ImageCreate` for body failed".to_string());
             self
         }
 
@@ -8917,28 +8885,9 @@ pub mod builder {
                 project_name,
                 body,
             } = self;
-            let (organization_name, project_name, body) =
-                match (organization_name, project_name, body) {
-                    (Some(organization_name), Some(project_name), Some(body)) => {
-                        (organization_name, project_name, body)
-                    }
-                    (organization_name, project_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/images",
                 client.baseurl,
@@ -8967,33 +8916,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ImageView<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        image_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        image_name: Result<types::Name, String>,
     }
 
     impl<'a> ImageView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                image_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                image_name: Err("image_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn image_name(mut self, value: types::Name) -> Self {
-            self.image_name = Some(value);
+        pub fn image_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.image_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for image_name failed".to_string());
             self
         }
 
@@ -9007,28 +8971,9 @@ pub mod builder {
                 project_name,
                 image_name,
             } = self;
-            let (organization_name, project_name, image_name) =
-                match (organization_name, project_name, image_name) {
-                    (Some(organization_name), Some(project_name), Some(image_name)) => {
-                        (organization_name, project_name, image_name)
-                    }
-                    (organization_name, project_name, image_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if image_name.is_none() {
-                            missing.push(stringify!(image_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let image_name = image_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/images/{}",
                 client.baseurl,
@@ -9058,33 +9003,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ImageDelete<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        image_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        image_name: Result<types::Name, String>,
     }
 
     impl<'a> ImageDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                image_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                image_name: Err("image_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn image_name(mut self, value: types::Name) -> Self {
-            self.image_name = Some(value);
+        pub fn image_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.image_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for image_name failed".to_string());
             self
         }
 
@@ -9098,28 +9058,9 @@ pub mod builder {
                 project_name,
                 image_name,
             } = self;
-            let (organization_name, project_name, image_name) =
-                match (organization_name, project_name, image_name) {
-                    (Some(organization_name), Some(project_name), Some(image_name)) => {
-                        (organization_name, project_name, image_name)
-                    }
-                    (organization_name, project_name, image_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if image_name.is_none() {
-                            missing.push(stringify!(image_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let image_name = image_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/images/{}",
                 client.baseurl,
@@ -9149,47 +9090,73 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceList<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> InstanceList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -9207,22 +9174,11 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
-            let (organization_name, project_name) = match (organization_name, project_name) {
-                (Some(organization_name), Some(project_name)) => (organization_name, project_name),
-                (organization_name, project_name) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if project_name.is_none() {
-                        missing.push(stringify!(project_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances",
                 client.baseurl,
@@ -9265,9 +9221,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -9281,7 +9237,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -9310,33 +9266,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceCreate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        body: Option<types::InstanceCreate>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        body: Result<types::InstanceCreate, String>,
     }
 
     impl<'a> InstanceCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::InstanceCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::InstanceCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `InstanceCreate` for body failed".to_string());
             self
         }
 
@@ -9350,28 +9321,9 @@ pub mod builder {
                 project_name,
                 body,
             } = self;
-            let (organization_name, project_name, body) =
-                match (organization_name, project_name, body) {
-                    (Some(organization_name), Some(project_name), Some(body)) => {
-                        (organization_name, project_name, body)
-                    }
-                    (organization_name, project_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances",
                 client.baseurl,
@@ -9400,33 +9352,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceView<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
     }
 
     impl<'a> InstanceView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
@@ -9440,28 +9407,9 @@ pub mod builder {
                 project_name,
                 instance_name,
             } = self;
-            let (organization_name, project_name, instance_name) =
-                match (organization_name, project_name, instance_name) {
-                    (Some(organization_name), Some(project_name), Some(instance_name)) => {
-                        (organization_name, project_name, instance_name)
-                    }
-                    (organization_name, project_name, instance_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if instance_name.is_none() {
-                            missing.push(stringify!(instance_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}",
                 client.baseurl,
@@ -9491,33 +9439,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceDelete<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
     }
 
     impl<'a> InstanceDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
@@ -9531,28 +9494,9 @@ pub mod builder {
                 project_name,
                 instance_name,
             } = self;
-            let (organization_name, project_name, instance_name) =
-                match (organization_name, project_name, instance_name) {
-                    (Some(organization_name), Some(project_name), Some(instance_name)) => {
-                        (organization_name, project_name, instance_name)
-                    }
-                    (organization_name, project_name, instance_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if instance_name.is_none() {
-                            missing.push(stringify!(instance_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}",
                 client.baseurl,
@@ -9582,54 +9526,85 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceDiskList<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> InstanceDiskList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -9648,28 +9623,12 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
-            let (organization_name, project_name, instance_name) =
-                match (organization_name, project_name, instance_name) {
-                    (Some(organization_name), Some(project_name), Some(instance_name)) => {
-                        (organization_name, project_name, instance_name)
-                    }
-                    (organization_name, project_name, instance_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if instance_name.is_none() {
-                            missing.push(stringify!(instance_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks",
                 client.baseurl,
@@ -9713,9 +9672,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -9729,7 +9688,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -9758,40 +9717,60 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceDiskAttach<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
-        body: Option<types::DiskIdentifier>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
+        body: Result<types::DiskIdentifier, String>,
     }
 
     impl<'a> InstanceDiskAttach<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::DiskIdentifier) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::DiskIdentifier>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `DiskIdentifier` for body failed".to_string());
             self
         }
 
@@ -9806,34 +9785,10 @@ pub mod builder {
                 instance_name,
                 body,
             } = self;
-            let (organization_name, project_name, instance_name, body) =
-                match (organization_name, project_name, instance_name, body) {
-                    (
-                        Some(organization_name),
-                        Some(project_name),
-                        Some(instance_name),
-                        Some(body),
-                    ) => (organization_name, project_name, instance_name, body),
-                    (organization_name, project_name, instance_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if instance_name.is_none() {
-                            missing.push(stringify!(instance_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks/attach",
                 client.baseurl,
@@ -9863,40 +9818,60 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceDiskDetach<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
-        body: Option<types::DiskIdentifier>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
+        body: Result<types::DiskIdentifier, String>,
     }
 
     impl<'a> InstanceDiskDetach<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::DiskIdentifier) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::DiskIdentifier>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `DiskIdentifier` for body failed".to_string());
             self
         }
 
@@ -9911,34 +9886,10 @@ pub mod builder {
                 instance_name,
                 body,
             } = self;
-            let (organization_name, project_name, instance_name, body) =
-                match (organization_name, project_name, instance_name, body) {
-                    (
-                        Some(organization_name),
-                        Some(project_name),
-                        Some(instance_name),
-                        Some(body),
-                    ) => (organization_name, project_name, instance_name, body),
-                    (organization_name, project_name, instance_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if instance_name.is_none() {
-                            missing.push(stringify!(instance_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks/detach",
                 client.baseurl,
@@ -9968,40 +9919,60 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceMigrate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
-        body: Option<types::InstanceMigrate>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
+        body: Result<types::InstanceMigrate, String>,
     }
 
     impl<'a> InstanceMigrate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::InstanceMigrate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::InstanceMigrate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `InstanceMigrate` for body failed".to_string());
             self
         }
 
@@ -10016,34 +9987,10 @@ pub mod builder {
                 instance_name,
                 body,
             } = self;
-            let (organization_name, project_name, instance_name, body) =
-                match (organization_name, project_name, instance_name, body) {
-                    (
-                        Some(organization_name),
-                        Some(project_name),
-                        Some(instance_name),
-                        Some(body),
-                    ) => (organization_name, project_name, instance_name, body),
-                    (organization_name, project_name, instance_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if instance_name.is_none() {
-                            missing.push(stringify!(instance_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/migrate",
                 client.baseurl,
@@ -10073,54 +10020,85 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceNetworkInterfaceList<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> InstanceNetworkInterfaceList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -10140,28 +10118,12 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
-            let (organization_name, project_name, instance_name) =
-                match (organization_name, project_name, instance_name) {
-                    (Some(organization_name), Some(project_name), Some(instance_name)) => {
-                        (organization_name, project_name, instance_name)
-                    }
-                    (organization_name, project_name, instance_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if instance_name.is_none() {
-                            missing.push(stringify!(instance_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
                 client.baseurl,
@@ -10205,9 +10167,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -10221,7 +10183,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -10250,40 +10212,60 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceNetworkInterfaceCreate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
-        body: Option<types::NetworkInterfaceCreate>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
+        body: Result<types::NetworkInterfaceCreate, String>,
     }
 
     impl<'a> InstanceNetworkInterfaceCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::NetworkInterfaceCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NetworkInterfaceCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `NetworkInterfaceCreate` for body failed".to_string());
             self
         }
 
@@ -10300,34 +10282,10 @@ pub mod builder {
                 instance_name,
                 body,
             } = self;
-            let (organization_name, project_name, instance_name, body) =
-                match (organization_name, project_name, instance_name, body) {
-                    (
-                        Some(organization_name),
-                        Some(project_name),
-                        Some(instance_name),
-                        Some(body),
-                    ) => (organization_name, project_name, instance_name, body),
-                    (organization_name, project_name, instance_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if instance_name.is_none() {
-                            missing.push(stringify!(instance_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
                 client.baseurl,
@@ -10357,40 +10315,60 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceNetworkInterfaceView<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
-        interface_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
+        interface_name: Result<types::Name, String>,
     }
 
     impl<'a> InstanceNetworkInterfaceView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
-                interface_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
+                interface_name: Err("interface_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
-        pub fn interface_name(mut self, value: types::Name) -> Self {
-            self.interface_name = Some(value);
+        pub fn interface_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.interface_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for interface_name failed".to_string());
             self
         }
 
@@ -10407,43 +10385,10 @@ pub mod builder {
                 instance_name,
                 interface_name,
             } = self;
-            let (organization_name, project_name, instance_name, interface_name) = match (
-                organization_name,
-                project_name,
-                instance_name,
-                interface_name,
-            ) {
-                (
-                    Some(organization_name),
-                    Some(project_name),
-                    Some(instance_name),
-                    Some(interface_name),
-                ) => (
-                    organization_name,
-                    project_name,
-                    instance_name,
-                    interface_name,
-                ),
-                (organization_name, project_name, instance_name, interface_name) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if project_name.is_none() {
-                        missing.push(stringify!(project_name));
-                    }
-                    if instance_name.is_none() {
-                        missing.push(stringify!(instance_name));
-                    }
-                    if interface_name.is_none() {
-                        missing.push(stringify!(interface_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
+            let interface_name = interface_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
                 client.baseurl,
@@ -10474,47 +10419,72 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceNetworkInterfaceUpdate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
-        interface_name: Option<types::Name>,
-        body: Option<types::NetworkInterfaceUpdate>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
+        interface_name: Result<types::Name, String>,
+        body: Result<types::NetworkInterfaceUpdate, String>,
     }
 
     impl<'a> InstanceNetworkInterfaceUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
-                interface_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
+                interface_name: Err("interface_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
-        pub fn interface_name(mut self, value: types::Name) -> Self {
-            self.interface_name = Some(value);
+        pub fn interface_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.interface_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for interface_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::NetworkInterfaceUpdate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NetworkInterfaceUpdate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `NetworkInterfaceUpdate` for body failed".to_string());
             self
         }
 
@@ -10532,49 +10502,11 @@ pub mod builder {
                 interface_name,
                 body,
             } = self;
-            let (organization_name, project_name, instance_name, interface_name, body) = match (
-                organization_name,
-                project_name,
-                instance_name,
-                interface_name,
-                body,
-            ) {
-                (
-                    Some(organization_name),
-                    Some(project_name),
-                    Some(instance_name),
-                    Some(interface_name),
-                    Some(body),
-                ) => (
-                    organization_name,
-                    project_name,
-                    instance_name,
-                    interface_name,
-                    body,
-                ),
-                (organization_name, project_name, instance_name, interface_name, body) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if project_name.is_none() {
-                        missing.push(stringify!(project_name));
-                    }
-                    if instance_name.is_none() {
-                        missing.push(stringify!(instance_name));
-                    }
-                    if interface_name.is_none() {
-                        missing.push(stringify!(interface_name));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
+            let interface_name = interface_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
                 client.baseurl,
@@ -10605,40 +10537,60 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceNetworkInterfaceDelete<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
-        interface_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
+        interface_name: Result<types::Name, String>,
     }
 
     impl<'a> InstanceNetworkInterfaceDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
-                interface_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
+                interface_name: Err("interface_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
-        pub fn interface_name(mut self, value: types::Name) -> Self {
-            self.interface_name = Some(value);
+        pub fn interface_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.interface_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for interface_name failed".to_string());
             self
         }
 
@@ -10653,43 +10605,10 @@ pub mod builder {
                 instance_name,
                 interface_name,
             } = self;
-            let (organization_name, project_name, instance_name, interface_name) = match (
-                organization_name,
-                project_name,
-                instance_name,
-                interface_name,
-            ) {
-                (
-                    Some(organization_name),
-                    Some(project_name),
-                    Some(instance_name),
-                    Some(interface_name),
-                ) => (
-                    organization_name,
-                    project_name,
-                    instance_name,
-                    interface_name,
-                ),
-                (organization_name, project_name, instance_name, interface_name) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if project_name.is_none() {
-                        missing.push(stringify!(project_name));
-                    }
-                    if instance_name.is_none() {
-                        missing.push(stringify!(instance_name));
-                    }
-                    if interface_name.is_none() {
-                        missing.push(stringify!(interface_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
+            let interface_name = interface_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
                 client.baseurl,
@@ -10720,33 +10639,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceReboot<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
     }
 
     impl<'a> InstanceReboot<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
@@ -10760,28 +10694,9 @@ pub mod builder {
                 project_name,
                 instance_name,
             } = self;
-            let (organization_name, project_name, instance_name) =
-                match (organization_name, project_name, instance_name) {
-                    (Some(organization_name), Some(project_name), Some(instance_name)) => {
-                        (organization_name, project_name, instance_name)
-                    }
-                    (organization_name, project_name, instance_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if instance_name.is_none() {
-                            missing.push(stringify!(instance_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/reboot",
                 client.baseurl,
@@ -10811,54 +10726,87 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceSerialConsole<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
-        from_start: Option<u64>,
-        max_bytes: Option<u64>,
-        most_recent: Option<u64>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
+        from_start: Result<Option<u64>, String>,
+        max_bytes: Result<Option<u64>, String>,
+        most_recent: Result<Option<u64>, String>,
     }
 
     impl<'a> InstanceSerialConsole<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
-                from_start: None,
-                max_bytes: None,
-                most_recent: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
+                from_start: Ok(None),
+                max_bytes: Ok(None),
+                most_recent: Ok(None),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
-        pub fn from_start(mut self, value: u64) -> Self {
-            self.from_start = Some(value);
+        pub fn from_start<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<u64>,
+        {
+            self.from_start = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < u64 >` for from_start failed".to_string());
             self
         }
 
-        pub fn max_bytes(mut self, value: u64) -> Self {
-            self.max_bytes = Some(value);
+        pub fn max_bytes<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<u64>,
+        {
+            self.max_bytes = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < u64 >` for max_bytes failed".to_string());
             self
         }
 
-        pub fn most_recent(mut self, value: u64) -> Self {
-            self.most_recent = Some(value);
+        pub fn most_recent<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<u64>,
+        {
+            self.most_recent = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < u64 >` for most_recent failed".to_string());
             self
         }
 
@@ -10877,28 +10825,12 @@ pub mod builder {
                 max_bytes,
                 most_recent,
             } = self;
-            let (organization_name, project_name, instance_name) =
-                match (organization_name, project_name, instance_name) {
-                    (Some(organization_name), Some(project_name), Some(instance_name)) => {
-                        (organization_name, project_name, instance_name)
-                    }
-                    (organization_name, project_name, instance_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if instance_name.is_none() {
-                            missing.push(stringify!(instance_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
+            let from_start = from_start.map_err(Error::InvalidRequest)?;
+            let max_bytes = max_bytes.map_err(Error::InvalidRequest)?;
+            let most_recent = most_recent.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/serial-console",
                 client.baseurl,
@@ -10938,33 +10870,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceStart<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
     }
 
     impl<'a> InstanceStart<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
@@ -10978,28 +10925,9 @@ pub mod builder {
                 project_name,
                 instance_name,
             } = self;
-            let (organization_name, project_name, instance_name) =
-                match (organization_name, project_name, instance_name) {
-                    (Some(organization_name), Some(project_name), Some(instance_name)) => {
-                        (organization_name, project_name, instance_name)
-                    }
-                    (organization_name, project_name, instance_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if instance_name.is_none() {
-                            missing.push(stringify!(instance_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/start",
                 client.baseurl,
@@ -11029,33 +10957,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct InstanceStop<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        instance_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        instance_name: Result<types::Name, String>,
     }
 
     impl<'a> InstanceStop<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                instance_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                instance_name: Err("instance_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn instance_name(mut self, value: types::Name) -> Self {
-            self.instance_name = Some(value);
+        pub fn instance_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.instance_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for instance_name failed".to_string());
             self
         }
 
@@ -11069,28 +11012,9 @@ pub mod builder {
                 project_name,
                 instance_name,
             } = self;
-            let (organization_name, project_name, instance_name) =
-                match (organization_name, project_name, instance_name) {
-                    (Some(organization_name), Some(project_name), Some(instance_name)) => {
-                        (organization_name, project_name, instance_name)
-                    }
-                    (organization_name, project_name, instance_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if instance_name.is_none() {
-                            missing.push(stringify!(instance_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/stop",
                 client.baseurl,
@@ -11120,26 +11044,36 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ProjectPolicyView<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
     }
 
     impl<'a> ProjectPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
@@ -11153,22 +11087,8 @@ pub mod builder {
                 organization_name,
                 project_name,
             } = self;
-            let (organization_name, project_name) = match (organization_name, project_name) {
-                (Some(organization_name), Some(project_name)) => (organization_name, project_name),
-                (organization_name, project_name) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if project_name.is_none() {
-                        missing.push(stringify!(project_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/policy",
                 client.baseurl,
@@ -11197,33 +11117,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct ProjectPolicyUpdate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        body: Option<types::ProjectRolePolicy>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        body: Result<types::ProjectRolePolicy, String>,
     }
 
     impl<'a> ProjectPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::ProjectRolePolicy) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::ProjectRolePolicy>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `ProjectRolePolicy` for body failed".to_string());
             self
         }
 
@@ -11238,28 +11173,9 @@ pub mod builder {
                 project_name,
                 body,
             } = self;
-            let (organization_name, project_name, body) =
-                match (organization_name, project_name, body) {
-                    (Some(organization_name), Some(project_name), Some(body)) => {
-                        (organization_name, project_name, body)
-                    }
-                    (organization_name, project_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/policy",
                 client.baseurl,
@@ -11288,47 +11204,73 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SnapshotList<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> SnapshotList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -11346,22 +11288,11 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
-            let (organization_name, project_name) = match (organization_name, project_name) {
-                (Some(organization_name), Some(project_name)) => (organization_name, project_name),
-                (organization_name, project_name) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if project_name.is_none() {
-                        missing.push(stringify!(project_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/snapshots",
                 client.baseurl,
@@ -11404,9 +11335,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -11420,7 +11351,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -11449,33 +11380,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SnapshotCreate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        body: Option<types::SnapshotCreate>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        body: Result<types::SnapshotCreate, String>,
     }
 
     impl<'a> SnapshotCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::SnapshotCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::SnapshotCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `SnapshotCreate` for body failed".to_string());
             self
         }
 
@@ -11489,28 +11435,9 @@ pub mod builder {
                 project_name,
                 body,
             } = self;
-            let (organization_name, project_name, body) =
-                match (organization_name, project_name, body) {
-                    (Some(organization_name), Some(project_name), Some(body)) => {
-                        (organization_name, project_name, body)
-                    }
-                    (organization_name, project_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/snapshots",
                 client.baseurl,
@@ -11539,33 +11466,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SnapshotView<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        snapshot_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        snapshot_name: Result<types::Name, String>,
     }
 
     impl<'a> SnapshotView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                snapshot_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                snapshot_name: Err("snapshot_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn snapshot_name(mut self, value: types::Name) -> Self {
-            self.snapshot_name = Some(value);
+        pub fn snapshot_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.snapshot_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for snapshot_name failed".to_string());
             self
         }
 
@@ -11579,28 +11521,9 @@ pub mod builder {
                 project_name,
                 snapshot_name,
             } = self;
-            let (organization_name, project_name, snapshot_name) =
-                match (organization_name, project_name, snapshot_name) {
-                    (Some(organization_name), Some(project_name), Some(snapshot_name)) => {
-                        (organization_name, project_name, snapshot_name)
-                    }
-                    (organization_name, project_name, snapshot_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if snapshot_name.is_none() {
-                            missing.push(stringify!(snapshot_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let snapshot_name = snapshot_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/snapshots/{}",
                 client.baseurl,
@@ -11630,33 +11553,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SnapshotDelete<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        snapshot_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        snapshot_name: Result<types::Name, String>,
     }
 
     impl<'a> SnapshotDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                snapshot_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                snapshot_name: Err("snapshot_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn snapshot_name(mut self, value: types::Name) -> Self {
-            self.snapshot_name = Some(value);
+        pub fn snapshot_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.snapshot_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for snapshot_name failed".to_string());
             self
         }
 
@@ -11670,28 +11608,9 @@ pub mod builder {
                 project_name,
                 snapshot_name,
             } = self;
-            let (organization_name, project_name, snapshot_name) =
-                match (organization_name, project_name, snapshot_name) {
-                    (Some(organization_name), Some(project_name), Some(snapshot_name)) => {
-                        (organization_name, project_name, snapshot_name)
-                    }
-                    (organization_name, project_name, snapshot_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if snapshot_name.is_none() {
-                            missing.push(stringify!(snapshot_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let snapshot_name = snapshot_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/snapshots/{}",
                 client.baseurl,
@@ -11721,47 +11640,73 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcList<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> VpcList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -11778,22 +11723,11 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
-            let (organization_name, project_name) = match (organization_name, project_name) {
-                (Some(organization_name), Some(project_name)) => (organization_name, project_name),
-                (organization_name, project_name) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if project_name.is_none() {
-                        missing.push(stringify!(project_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs",
                 client.baseurl,
@@ -11835,9 +11769,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -11851,7 +11785,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -11880,33 +11814,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcCreate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        body: Option<types::VpcCreate>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        body: Result<types::VpcCreate, String>,
     }
 
     impl<'a> VpcCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::VpcCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::VpcCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `VpcCreate` for body failed".to_string());
             self
         }
 
@@ -11919,28 +11868,9 @@ pub mod builder {
                 project_name,
                 body,
             } = self;
-            let (organization_name, project_name, body) =
-                match (organization_name, project_name, body) {
-                    (Some(organization_name), Some(project_name), Some(body)) => {
-                        (organization_name, project_name, body)
-                    }
-                    (organization_name, project_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs",
                 client.baseurl,
@@ -11969,33 +11899,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcView<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
     }
 
     impl<'a> VpcView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
@@ -12009,28 +11954,9 @@ pub mod builder {
                 project_name,
                 vpc_name,
             } = self;
-            let (organization_name, project_name, vpc_name) =
-                match (organization_name, project_name, vpc_name) {
-                    (Some(organization_name), Some(project_name), Some(vpc_name)) => {
-                        (organization_name, project_name, vpc_name)
-                    }
-                    (organization_name, project_name, vpc_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
                 client.baseurl,
@@ -12060,40 +11986,60 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcUpdate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        body: Option<types::VpcUpdate>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        body: Result<types::VpcUpdate, String>,
     }
 
     impl<'a> VpcUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::VpcUpdate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::VpcUpdate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `VpcUpdate` for body failed".to_string());
             self
         }
 
@@ -12108,31 +12054,10 @@ pub mod builder {
                 vpc_name,
                 body,
             } = self;
-            let (organization_name, project_name, vpc_name, body) =
-                match (organization_name, project_name, vpc_name, body) {
-                    (Some(organization_name), Some(project_name), Some(vpc_name), Some(body)) => {
-                        (organization_name, project_name, vpc_name, body)
-                    }
-                    (organization_name, project_name, vpc_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
                 client.baseurl,
@@ -12162,33 +12087,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcDelete<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
     }
 
     impl<'a> VpcDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
@@ -12202,28 +12142,9 @@ pub mod builder {
                 project_name,
                 vpc_name,
             } = self;
-            let (organization_name, project_name, vpc_name) =
-                match (organization_name, project_name, vpc_name) {
-                    (Some(organization_name), Some(project_name), Some(vpc_name)) => {
-                        (organization_name, project_name, vpc_name)
-                    }
-                    (organization_name, project_name, vpc_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
                 client.baseurl,
@@ -12253,33 +12174,48 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcFirewallRulesView<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
     }
 
     impl<'a> VpcFirewallRulesView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
@@ -12295,28 +12231,9 @@ pub mod builder {
                 project_name,
                 vpc_name,
             } = self;
-            let (organization_name, project_name, vpc_name) =
-                match (organization_name, project_name, vpc_name) {
-                    (Some(organization_name), Some(project_name), Some(vpc_name)) => {
-                        (organization_name, project_name, vpc_name)
-                    }
-                    (organization_name, project_name, vpc_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
                 client.baseurl,
@@ -12346,40 +12263,60 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcFirewallRulesUpdate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        body: Option<types::VpcFirewallRuleUpdateParams>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        body: Result<types::VpcFirewallRuleUpdateParams, String>,
     }
 
     impl<'a> VpcFirewallRulesUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::VpcFirewallRuleUpdateParams) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::VpcFirewallRuleUpdateParams>,
+        {
+            self.body = value.try_into().map_err(|_| {
+                "conversion to `VpcFirewallRuleUpdateParams` for body failed".to_string()
+            });
             self
         }
 
@@ -12396,31 +12333,10 @@ pub mod builder {
                 vpc_name,
                 body,
             } = self;
-            let (organization_name, project_name, vpc_name, body) =
-                match (organization_name, project_name, vpc_name, body) {
-                    (Some(organization_name), Some(project_name), Some(vpc_name), Some(body)) => {
-                        (organization_name, project_name, vpc_name, body)
-                    }
-                    (organization_name, project_name, vpc_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
                 client.baseurl,
@@ -12450,54 +12366,85 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcRouterList<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> VpcRouterList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -12516,28 +12463,12 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
-            let (organization_name, project_name, vpc_name) =
-                match (organization_name, project_name, vpc_name) {
-                    (Some(organization_name), Some(project_name), Some(vpc_name)) => {
-                        (organization_name, project_name, vpc_name)
-                    }
-                    (organization_name, project_name, vpc_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers",
                 client.baseurl,
@@ -12581,9 +12512,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -12597,7 +12528,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -12626,40 +12557,60 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcRouterCreate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        body: Option<types::VpcRouterCreate>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        body: Result<types::VpcRouterCreate, String>,
     }
 
     impl<'a> VpcRouterCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::VpcRouterCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::VpcRouterCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `VpcRouterCreate` for body failed".to_string());
             self
         }
 
@@ -12674,31 +12625,10 @@ pub mod builder {
                 vpc_name,
                 body,
             } = self;
-            let (organization_name, project_name, vpc_name, body) =
-                match (organization_name, project_name, vpc_name, body) {
-                    (Some(organization_name), Some(project_name), Some(vpc_name), Some(body)) => {
-                        (organization_name, project_name, vpc_name, body)
-                    }
-                    (organization_name, project_name, vpc_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers",
                 client.baseurl,
@@ -12728,40 +12658,60 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcRouterView<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        router_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        router_name: Result<types::Name, String>,
     }
 
     impl<'a> VpcRouterView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                router_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                router_name: Err("router_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn router_name(mut self, value: types::Name) -> Self {
-            self.router_name = Some(value);
+        pub fn router_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.router_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for router_name failed".to_string());
             self
         }
 
@@ -12776,34 +12726,10 @@ pub mod builder {
                 vpc_name,
                 router_name,
             } = self;
-            let (organization_name, project_name, vpc_name, router_name) =
-                match (organization_name, project_name, vpc_name, router_name) {
-                    (
-                        Some(organization_name),
-                        Some(project_name),
-                        Some(vpc_name),
-                        Some(router_name),
-                    ) => (organization_name, project_name, vpc_name, router_name),
-                    (organization_name, project_name, vpc_name, router_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        if router_name.is_none() {
-                            missing.push(stringify!(router_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let router_name = router_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
                 client.baseurl,
@@ -12834,47 +12760,72 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcRouterUpdate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        router_name: Option<types::Name>,
-        body: Option<types::VpcRouterUpdate>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        router_name: Result<types::Name, String>,
+        body: Result<types::VpcRouterUpdate, String>,
     }
 
     impl<'a> VpcRouterUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                router_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                router_name: Err("router_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn router_name(mut self, value: types::Name) -> Self {
-            self.router_name = Some(value);
+        pub fn router_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.router_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for router_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::VpcRouterUpdate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::VpcRouterUpdate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `VpcRouterUpdate` for body failed".to_string());
             self
         }
 
@@ -12890,38 +12841,11 @@ pub mod builder {
                 router_name,
                 body,
             } = self;
-            let (organization_name, project_name, vpc_name, router_name, body) =
-                match (organization_name, project_name, vpc_name, router_name, body) {
-                    (
-                        Some(organization_name),
-                        Some(project_name),
-                        Some(vpc_name),
-                        Some(router_name),
-                        Some(body),
-                    ) => (organization_name, project_name, vpc_name, router_name, body),
-                    (organization_name, project_name, vpc_name, router_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        if router_name.is_none() {
-                            missing.push(stringify!(router_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let router_name = router_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
                 client.baseurl,
@@ -12952,40 +12876,60 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcRouterDelete<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        router_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        router_name: Result<types::Name, String>,
     }
 
     impl<'a> VpcRouterDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                router_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                router_name: Err("router_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn router_name(mut self, value: types::Name) -> Self {
-            self.router_name = Some(value);
+        pub fn router_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.router_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for router_name failed".to_string());
             self
         }
 
@@ -13000,34 +12944,10 @@ pub mod builder {
                 vpc_name,
                 router_name,
             } = self;
-            let (organization_name, project_name, vpc_name, router_name) =
-                match (organization_name, project_name, vpc_name, router_name) {
-                    (
-                        Some(organization_name),
-                        Some(project_name),
-                        Some(vpc_name),
-                        Some(router_name),
-                    ) => (organization_name, project_name, vpc_name, router_name),
-                    (organization_name, project_name, vpc_name, router_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        if router_name.is_none() {
-                            missing.push(stringify!(router_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let router_name = router_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
                 client.baseurl,
@@ -13058,61 +12978,97 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcRouterRouteList<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        router_name: Option<types::Name>,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        router_name: Result<types::Name, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> VpcRouterRouteList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                router_name: None,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                router_name: Err("router_name was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn router_name(mut self, value: types::Name) -> Self {
-            self.router_name = Some(value);
+        pub fn router_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.router_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for router_name failed".to_string());
             self
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -13132,34 +13088,13 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
-            let (organization_name, project_name, vpc_name, router_name) =
-                match (organization_name, project_name, vpc_name, router_name) {
-                    (
-                        Some(organization_name),
-                        Some(project_name),
-                        Some(vpc_name),
-                        Some(router_name),
-                    ) => (organization_name, project_name, vpc_name, router_name),
-                    (organization_name, project_name, vpc_name, router_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        if router_name.is_none() {
-                            missing.push(stringify!(router_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let router_name = router_name.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
                 client.baseurl,
@@ -13204,9 +13139,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -13220,7 +13155,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -13249,47 +13184,72 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcRouterRouteCreate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        router_name: Option<types::Name>,
-        body: Option<types::RouterRouteCreateParams>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        router_name: Result<types::Name, String>,
+        body: Result<types::RouterRouteCreateParams, String>,
     }
 
     impl<'a> VpcRouterRouteCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                router_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                router_name: Err("router_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn router_name(mut self, value: types::Name) -> Self {
-            self.router_name = Some(value);
+        pub fn router_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.router_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for router_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::RouterRouteCreateParams) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::RouterRouteCreateParams>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `RouterRouteCreateParams` for body failed".to_string());
             self
         }
 
@@ -13305,38 +13265,11 @@ pub mod builder {
                 router_name,
                 body,
             } = self;
-            let (organization_name, project_name, vpc_name, router_name, body) =
-                match (organization_name, project_name, vpc_name, router_name, body) {
-                    (
-                        Some(organization_name),
-                        Some(project_name),
-                        Some(vpc_name),
-                        Some(router_name),
-                        Some(body),
-                    ) => (organization_name, project_name, vpc_name, router_name, body),
-                    (organization_name, project_name, vpc_name, router_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        if router_name.is_none() {
-                            missing.push(stringify!(router_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let router_name = router_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
                 client.baseurl,
@@ -13367,47 +13300,72 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcRouterRouteView<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        router_name: Option<types::Name>,
-        route_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        router_name: Result<types::Name, String>,
+        route_name: Result<types::Name, String>,
     }
 
     impl<'a> VpcRouterRouteView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                router_name: None,
-                route_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                router_name: Err("router_name was not initialized".to_string()),
+                route_name: Err("route_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn router_name(mut self, value: types::Name) -> Self {
-            self.router_name = Some(value);
+        pub fn router_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.router_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for router_name failed".to_string());
             self
         }
 
-        pub fn route_name(mut self, value: types::Name) -> Self {
-            self.route_name = Some(value);
+        pub fn route_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.route_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for route_name failed".to_string());
             self
         }
 
@@ -13423,49 +13381,11 @@ pub mod builder {
                 router_name,
                 route_name,
             } = self;
-            let (organization_name, project_name, vpc_name, router_name, route_name) = match (
-                organization_name,
-                project_name,
-                vpc_name,
-                router_name,
-                route_name,
-            ) {
-                (
-                    Some(organization_name),
-                    Some(project_name),
-                    Some(vpc_name),
-                    Some(router_name),
-                    Some(route_name),
-                ) => (
-                    organization_name,
-                    project_name,
-                    vpc_name,
-                    router_name,
-                    route_name,
-                ),
-                (organization_name, project_name, vpc_name, router_name, route_name) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if project_name.is_none() {
-                        missing.push(stringify!(project_name));
-                    }
-                    if vpc_name.is_none() {
-                        missing.push(stringify!(vpc_name));
-                    }
-                    if router_name.is_none() {
-                        missing.push(stringify!(router_name));
-                    }
-                    if route_name.is_none() {
-                        missing.push(stringify!(route_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let router_name = router_name.map_err(Error::InvalidRequest)?;
+            let route_name = route_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
                 client.baseurl,
@@ -13497,54 +13417,84 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcRouterRouteUpdate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        router_name: Option<types::Name>,
-        route_name: Option<types::Name>,
-        body: Option<types::RouterRouteUpdateParams>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        router_name: Result<types::Name, String>,
+        route_name: Result<types::Name, String>,
+        body: Result<types::RouterRouteUpdateParams, String>,
     }
 
     impl<'a> VpcRouterRouteUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                router_name: None,
-                route_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                router_name: Err("router_name was not initialized".to_string()),
+                route_name: Err("route_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn router_name(mut self, value: types::Name) -> Self {
-            self.router_name = Some(value);
+        pub fn router_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.router_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for router_name failed".to_string());
             self
         }
 
-        pub fn route_name(mut self, value: types::Name) -> Self {
-            self.route_name = Some(value);
+        pub fn route_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.route_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for route_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::RouterRouteUpdateParams) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::RouterRouteUpdateParams>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `RouterRouteUpdateParams` for body failed".to_string());
             self
         }
 
@@ -13561,55 +13511,12 @@ pub mod builder {
                 route_name,
                 body,
             } = self;
-            let (organization_name, project_name, vpc_name, router_name, route_name, body) = match (
-                organization_name,
-                project_name,
-                vpc_name,
-                router_name,
-                route_name,
-                body,
-            ) {
-                (
-                    Some(organization_name),
-                    Some(project_name),
-                    Some(vpc_name),
-                    Some(router_name),
-                    Some(route_name),
-                    Some(body),
-                ) => (
-                    organization_name,
-                    project_name,
-                    vpc_name,
-                    router_name,
-                    route_name,
-                    body,
-                ),
-                (organization_name, project_name, vpc_name, router_name, route_name, body) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if project_name.is_none() {
-                        missing.push(stringify!(project_name));
-                    }
-                    if vpc_name.is_none() {
-                        missing.push(stringify!(vpc_name));
-                    }
-                    if router_name.is_none() {
-                        missing.push(stringify!(router_name));
-                    }
-                    if route_name.is_none() {
-                        missing.push(stringify!(route_name));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let router_name = router_name.map_err(Error::InvalidRequest)?;
+            let route_name = route_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
                 client.baseurl,
@@ -13641,47 +13548,72 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcRouterRouteDelete<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        router_name: Option<types::Name>,
-        route_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        router_name: Result<types::Name, String>,
+        route_name: Result<types::Name, String>,
     }
 
     impl<'a> VpcRouterRouteDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                router_name: None,
-                route_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                router_name: Err("router_name was not initialized".to_string()),
+                route_name: Err("route_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn router_name(mut self, value: types::Name) -> Self {
-            self.router_name = Some(value);
+        pub fn router_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.router_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for router_name failed".to_string());
             self
         }
 
-        pub fn route_name(mut self, value: types::Name) -> Self {
-            self.route_name = Some(value);
+        pub fn route_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.route_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for route_name failed".to_string());
             self
         }
 
@@ -13697,49 +13629,11 @@ pub mod builder {
                 router_name,
                 route_name,
             } = self;
-            let (organization_name, project_name, vpc_name, router_name, route_name) = match (
-                organization_name,
-                project_name,
-                vpc_name,
-                router_name,
-                route_name,
-            ) {
-                (
-                    Some(organization_name),
-                    Some(project_name),
-                    Some(vpc_name),
-                    Some(router_name),
-                    Some(route_name),
-                ) => (
-                    organization_name,
-                    project_name,
-                    vpc_name,
-                    router_name,
-                    route_name,
-                ),
-                (organization_name, project_name, vpc_name, router_name, route_name) => {
-                    let mut missing = Vec::new();
-                    if organization_name.is_none() {
-                        missing.push(stringify!(organization_name));
-                    }
-                    if project_name.is_none() {
-                        missing.push(stringify!(project_name));
-                    }
-                    if vpc_name.is_none() {
-                        missing.push(stringify!(vpc_name));
-                    }
-                    if router_name.is_none() {
-                        missing.push(stringify!(router_name));
-                    }
-                    if route_name.is_none() {
-                        missing.push(stringify!(route_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let router_name = router_name.map_err(Error::InvalidRequest)?;
+            let route_name = route_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
                 client.baseurl,
@@ -13771,54 +13665,85 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcSubnetList<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> VpcSubnetList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -13837,28 +13762,12 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
-            let (organization_name, project_name, vpc_name) =
-                match (organization_name, project_name, vpc_name) {
-                    (Some(organization_name), Some(project_name), Some(vpc_name)) => {
-                        (organization_name, project_name, vpc_name)
-                    }
-                    (organization_name, project_name, vpc_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
                 client.baseurl,
@@ -13902,9 +13811,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -13918,7 +13827,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -13947,40 +13856,60 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcSubnetCreate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        body: Option<types::VpcSubnetCreate>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        body: Result<types::VpcSubnetCreate, String>,
     }
 
     impl<'a> VpcSubnetCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::VpcSubnetCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::VpcSubnetCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `VpcSubnetCreate` for body failed".to_string());
             self
         }
 
@@ -13995,31 +13924,10 @@ pub mod builder {
                 vpc_name,
                 body,
             } = self;
-            let (organization_name, project_name, vpc_name, body) =
-                match (organization_name, project_name, vpc_name, body) {
-                    (Some(organization_name), Some(project_name), Some(vpc_name), Some(body)) => {
-                        (organization_name, project_name, vpc_name, body)
-                    }
-                    (organization_name, project_name, vpc_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
                 client.baseurl,
@@ -14049,40 +13957,60 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcSubnetView<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        subnet_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        subnet_name: Result<types::Name, String>,
     }
 
     impl<'a> VpcSubnetView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                subnet_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                subnet_name: Err("subnet_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn subnet_name(mut self, value: types::Name) -> Self {
-            self.subnet_name = Some(value);
+        pub fn subnet_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.subnet_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for subnet_name failed".to_string());
             self
         }
 
@@ -14097,34 +14025,10 @@ pub mod builder {
                 vpc_name,
                 subnet_name,
             } = self;
-            let (organization_name, project_name, vpc_name, subnet_name) =
-                match (organization_name, project_name, vpc_name, subnet_name) {
-                    (
-                        Some(organization_name),
-                        Some(project_name),
-                        Some(vpc_name),
-                        Some(subnet_name),
-                    ) => (organization_name, project_name, vpc_name, subnet_name),
-                    (organization_name, project_name, vpc_name, subnet_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        if subnet_name.is_none() {
-                            missing.push(stringify!(subnet_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
                 client.baseurl,
@@ -14155,47 +14059,72 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcSubnetUpdate<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        subnet_name: Option<types::Name>,
-        body: Option<types::VpcSubnetUpdate>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        subnet_name: Result<types::Name, String>,
+        body: Result<types::VpcSubnetUpdate, String>,
     }
 
     impl<'a> VpcSubnetUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                subnet_name: None,
-                body: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                subnet_name: Err("subnet_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn subnet_name(mut self, value: types::Name) -> Self {
-            self.subnet_name = Some(value);
+        pub fn subnet_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.subnet_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for subnet_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::VpcSubnetUpdate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::VpcSubnetUpdate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `VpcSubnetUpdate` for body failed".to_string());
             self
         }
 
@@ -14211,38 +14140,11 @@ pub mod builder {
                 subnet_name,
                 body,
             } = self;
-            let (organization_name, project_name, vpc_name, subnet_name, body) =
-                match (organization_name, project_name, vpc_name, subnet_name, body) {
-                    (
-                        Some(organization_name),
-                        Some(project_name),
-                        Some(vpc_name),
-                        Some(subnet_name),
-                        Some(body),
-                    ) => (organization_name, project_name, vpc_name, subnet_name, body),
-                    (organization_name, project_name, vpc_name, subnet_name, body) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        if subnet_name.is_none() {
-                            missing.push(stringify!(subnet_name));
-                        }
-                        if body.is_none() {
-                            missing.push(stringify!(body));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
                 client.baseurl,
@@ -14273,40 +14175,60 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcSubnetDelete<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        subnet_name: Option<types::Name>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        subnet_name: Result<types::Name, String>,
     }
 
     impl<'a> VpcSubnetDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                subnet_name: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                subnet_name: Err("subnet_name was not initialized".to_string()),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn subnet_name(mut self, value: types::Name) -> Self {
-            self.subnet_name = Some(value);
+        pub fn subnet_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.subnet_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for subnet_name failed".to_string());
             self
         }
 
@@ -14321,34 +14243,10 @@ pub mod builder {
                 vpc_name,
                 subnet_name,
             } = self;
-            let (organization_name, project_name, vpc_name, subnet_name) =
-                match (organization_name, project_name, vpc_name, subnet_name) {
-                    (
-                        Some(organization_name),
-                        Some(project_name),
-                        Some(vpc_name),
-                        Some(subnet_name),
-                    ) => (organization_name, project_name, vpc_name, subnet_name),
-                    (organization_name, project_name, vpc_name, subnet_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        if subnet_name.is_none() {
-                            missing.push(stringify!(subnet_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
                 client.baseurl,
@@ -14379,61 +14277,97 @@ pub mod builder {
     #[derive(Clone)]
     pub struct VpcSubnetListNetworkInterfaces<'a> {
         client: &'a super::Client,
-        organization_name: Option<types::Name>,
-        project_name: Option<types::Name>,
-        vpc_name: Option<types::Name>,
-        subnet_name: Option<types::Name>,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        organization_name: Result<types::Name, String>,
+        project_name: Result<types::Name, String>,
+        vpc_name: Result<types::Name, String>,
+        subnet_name: Result<types::Name, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> VpcSubnetListNetworkInterfaces<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                organization_name: None,
-                project_name: None,
-                vpc_name: None,
-                subnet_name: None,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                organization_name: Err("organization_name was not initialized".to_string()),
+                project_name: Err("project_name was not initialized".to_string()),
+                vpc_name: Err("vpc_name was not initialized".to_string()),
+                subnet_name: Err("subnet_name was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn organization_name(mut self, value: types::Name) -> Self {
-            self.organization_name = Some(value);
+        pub fn organization_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.organization_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for organization_name failed".to_string());
             self
         }
 
-        pub fn project_name(mut self, value: types::Name) -> Self {
-            self.project_name = Some(value);
+        pub fn project_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.project_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for project_name failed".to_string());
             self
         }
 
-        pub fn vpc_name(mut self, value: types::Name) -> Self {
-            self.vpc_name = Some(value);
+        pub fn vpc_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.vpc_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for vpc_name failed".to_string());
             self
         }
 
-        pub fn subnet_name(mut self, value: types::Name) -> Self {
-            self.subnet_name = Some(value);
+        pub fn subnet_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.subnet_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for subnet_name failed".to_string());
             self
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -14454,34 +14388,13 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
-            let (organization_name, project_name, vpc_name, subnet_name) =
-                match (organization_name, project_name, vpc_name, subnet_name) {
-                    (
-                        Some(organization_name),
-                        Some(project_name),
-                        Some(vpc_name),
-                        Some(subnet_name),
-                    ) => (organization_name, project_name, vpc_name, subnet_name),
-                    (organization_name, project_name, vpc_name, subnet_name) => {
-                        let mut missing = Vec::new();
-                        if organization_name.is_none() {
-                            missing.push(stringify!(organization_name));
-                        }
-                        if project_name.is_none() {
-                            missing.push(stringify!(project_name));
-                        }
-                        if vpc_name.is_none() {
-                            missing.push(stringify!(vpc_name));
-                        }
-                        if subnet_name.is_none() {
-                            missing.push(stringify!(subnet_name));
-                        }
-                        return Err(super::Error::InvalidRequest(format!(
-                            "the following parameters are required: {}",
-                            missing.join(", "),
-                        )));
-                    }
-                };
+            let organization_name = organization_name.map_err(Error::InvalidRequest)?;
+            let project_name = project_name.map_err(Error::InvalidRequest)?;
+            let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
+            let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}/network-interfaces",
                 client.baseurl,
@@ -14526,9 +14439,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -14542,7 +14455,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -14606,16 +14519,24 @@ pub mod builder {
     #[derive(Clone)]
     pub struct PolicyUpdate<'a> {
         client: &'a super::Client,
-        body: Option<types::FleetRolePolicy>,
+        body: Result<types::FleetRolePolicy, String>,
     }
 
     impl<'a> PolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::FleetRolePolicy) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::FleetRolePolicy>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `FleetRolePolicy` for body failed".to_string());
             self
         }
 
@@ -14624,19 +14545,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/policy", client.baseurl,);
             let request = client.client.put(url).json(&body).build()?;
             let result = client.client.execute(request).await;
@@ -14660,26 +14569,37 @@ pub mod builder {
     #[derive(Clone)]
     pub struct RoleList<'a> {
         client: &'a super::Client,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
     }
 
     impl<'a> RoleList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                limit: None,
-                page_token: None,
+                limit: Ok(None),
+                page_token: Ok(None),
             }
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
@@ -14692,6 +14612,8 @@ pub mod builder {
                 limit,
                 page_token,
             } = self;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/roles", client.baseurl,);
             let mut query = Vec::new();
             if let Some(v) = &limit {
@@ -14724,8 +14646,8 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
+                limit: Ok(None),
+                page_token: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -14739,7 +14661,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -14768,38 +14690,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct RoleView<'a> {
         client: &'a super::Client,
-        role_name: Option<String>,
+        role_name: Result<String, String>,
     }
 
     impl<'a> RoleView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                role_name: None,
+                role_name: Err("role_name was not initialized".to_string()),
             }
         }
 
-        pub fn role_name<S: ToString>(mut self, value: S) -> Self {
-            self.role_name = Some(value.to_string());
+        pub fn role_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.role_name = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for role_name failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/roles/{role_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Role>, Error<types::Error>> {
             let Self { client, role_name } = self;
-            let (role_name,) = match (role_name,) {
-                (Some(role_name),) => (role_name,),
-                (role_name,) => {
-                    let mut missing = Vec::new();
-                    if role_name.is_none() {
-                        missing.push(stringify!(role_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let role_name = role_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/roles/{}",
                 client.baseurl,
@@ -14827,33 +14742,49 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SagaList<'a> {
         client: &'a super::Client,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::IdSortMode>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::IdSortMode>, String>,
     }
 
     impl<'a> SagaList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::IdSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::IdSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < IdSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -14867,6 +14798,9 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/sagas", client.baseurl,);
             let mut query = Vec::new();
             if let Some(v) = &limit {
@@ -14902,9 +14836,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -14918,7 +14852,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -14947,38 +14881,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SagaView<'a> {
         client: &'a super::Client,
-        saga_id: Option<uuid::Uuid>,
+        saga_id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SagaView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                saga_id: None,
+                saga_id: Err("saga_id was not initialized".to_string()),
             }
         }
 
-        pub fn saga_id(mut self, value: uuid::Uuid) -> Self {
-            self.saga_id = Some(value);
+        pub fn saga_id<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<uuid::Uuid>,
+        {
+            self.saga_id = value
+                .try_into()
+                .map_err(|_| "conversion to `uuid :: Uuid` for saga_id failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/sagas/{saga_id}`
         pub async fn send(self) -> Result<ResponseValue<types::Saga>, Error<types::Error>> {
             let Self { client, saga_id } = self;
-            let (saga_id,) = match (saga_id,) {
-                (Some(saga_id),) => (saga_id,),
-                (saga_id,) => {
-                    let mut missing = Vec::new();
-                    if saga_id.is_none() {
-                        missing.push(stringify!(saga_id));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let saga_id = saga_id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/sagas/{}",
                 client.baseurl,
@@ -15039,33 +14966,49 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SessionSshkeyList<'a> {
         client: &'a super::Client,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> SessionSshkeyList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -15079,6 +15022,9 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/sshkeys", client.baseurl,);
             let mut query = Vec::new();
             if let Some(v) = &limit {
@@ -15114,9 +15060,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -15130,7 +15076,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -15159,35 +15105,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SessionSshkeyCreate<'a> {
         client: &'a super::Client,
-        body: Option<types::SshKeyCreate>,
+        body: Result<types::SshKeyCreate, String>,
     }
 
     impl<'a> SessionSshkeyCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::SshKeyCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::SshKeyCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `SshKeyCreate` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/session/me/sshkeys`
         pub async fn send(self) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/sshkeys", client.baseurl,);
             let request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
@@ -15211,19 +15153,24 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SessionSshkeyView<'a> {
         client: &'a super::Client,
-        ssh_key_name: Option<types::Name>,
+        ssh_key_name: Result<types::Name, String>,
     }
 
     impl<'a> SessionSshkeyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                ssh_key_name: None,
+                ssh_key_name: Err("ssh_key_name was not initialized".to_string()),
             }
         }
 
-        pub fn ssh_key_name(mut self, value: types::Name) -> Self {
-            self.ssh_key_name = Some(value);
+        pub fn ssh_key_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.ssh_key_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for ssh_key_name failed".to_string());
             self
         }
 
@@ -15233,19 +15180,7 @@ pub mod builder {
                 client,
                 ssh_key_name,
             } = self;
-            let (ssh_key_name,) = match (ssh_key_name,) {
-                (Some(ssh_key_name),) => (ssh_key_name,),
-                (ssh_key_name,) => {
-                    let mut missing = Vec::new();
-                    if ssh_key_name.is_none() {
-                        missing.push(stringify!(ssh_key_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let ssh_key_name = ssh_key_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/session/me/sshkeys/{}",
                 client.baseurl,
@@ -15273,19 +15208,24 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SessionSshkeyDelete<'a> {
         client: &'a super::Client,
-        ssh_key_name: Option<types::Name>,
+        ssh_key_name: Result<types::Name, String>,
     }
 
     impl<'a> SessionSshkeyDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                ssh_key_name: None,
+                ssh_key_name: Err("ssh_key_name was not initialized".to_string()),
             }
         }
 
-        pub fn ssh_key_name(mut self, value: types::Name) -> Self {
-            self.ssh_key_name = Some(value);
+        pub fn ssh_key_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.ssh_key_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for ssh_key_name failed".to_string());
             self
         }
 
@@ -15295,19 +15235,7 @@ pub mod builder {
                 client,
                 ssh_key_name,
             } = self;
-            let (ssh_key_name,) = match (ssh_key_name,) {
-                (Some(ssh_key_name),) => (ssh_key_name,),
-                (ssh_key_name,) => {
-                    let mut missing = Vec::new();
-                    if ssh_key_name.is_none() {
-                        missing.push(stringify!(ssh_key_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let ssh_key_name = ssh_key_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/session/me/sshkeys/{}",
                 client.baseurl,
@@ -15335,33 +15263,49 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SiloList<'a> {
         client: &'a super::Client,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameOrIdSortMode>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameOrIdSortMode>, String>,
     }
 
     impl<'a> SiloList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameOrIdSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameOrIdSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameOrIdSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -15375,6 +15319,9 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/silos", client.baseurl,);
             let mut query = Vec::new();
             if let Some(v) = &limit {
@@ -15410,9 +15357,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -15426,7 +15373,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -15455,35 +15402,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SiloCreate<'a> {
         client: &'a super::Client,
-        body: Option<types::SiloCreate>,
+        body: Result<types::SiloCreate, String>,
     }
 
     impl<'a> SiloCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client, body: None }
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
         }
 
-        pub fn body(mut self, value: types::SiloCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::SiloCreate>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `SiloCreate` for body failed".to_string());
             self
         }
 
         ///Sends a `POST` request to `/silos`
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
             let Self { client, body } = self;
-            let (body,) = match (body,) {
-                (Some(body),) => (body,),
-                (body,) => {
-                    let mut missing = Vec::new();
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/silos", client.baseurl,);
             let request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
@@ -15507,38 +15450,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SiloView<'a> {
         client: &'a super::Client,
-        silo_name: Option<types::Name>,
+        silo_name: Result<types::Name, String>,
     }
 
     impl<'a> SiloView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                silo_name: None,
+                silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
 
-        pub fn silo_name(mut self, value: types::Name) -> Self {
-            self.silo_name = Some(value);
+        pub fn silo_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.silo_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for silo_name failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/silos/{silo_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
             let Self { client, silo_name } = self;
-            let (silo_name,) = match (silo_name,) {
-                (Some(silo_name),) => (silo_name,),
-                (silo_name,) => {
-                    let mut missing = Vec::new();
-                    if silo_name.is_none() {
-                        missing.push(stringify!(silo_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/silos/{}",
                 client.baseurl,
@@ -15566,38 +15502,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SiloDelete<'a> {
         client: &'a super::Client,
-        silo_name: Option<types::Name>,
+        silo_name: Result<types::Name, String>,
     }
 
     impl<'a> SiloDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                silo_name: None,
+                silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
 
-        pub fn silo_name(mut self, value: types::Name) -> Self {
-            self.silo_name = Some(value);
+        pub fn silo_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.silo_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for silo_name failed".to_string());
             self
         }
 
         ///Sends a `DELETE` request to `/silos/{silo_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, silo_name } = self;
-            let (silo_name,) = match (silo_name,) {
-                (Some(silo_name),) => (silo_name,),
-                (silo_name,) => {
-                    let mut missing = Vec::new();
-                    if silo_name.is_none() {
-                        missing.push(stringify!(silo_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/silos/{}",
                 client.baseurl,
@@ -15625,40 +15554,61 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SiloIdentityProviderList<'a> {
         client: &'a super::Client,
-        silo_name: Option<types::Name>,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        silo_name: Result<types::Name, String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> SiloIdentityProviderList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                silo_name: None,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                silo_name: Err("silo_name was not initialized".to_string()),
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn silo_name(mut self, value: types::Name) -> Self {
-            self.silo_name = Some(value);
+        pub fn silo_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.silo_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for silo_name failed".to_string());
             self
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -15674,19 +15624,10 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
-            let (silo_name,) = match (silo_name,) {
-                (Some(silo_name),) => (silo_name,),
-                (silo_name,) => {
-                    let mut missing = Vec::new();
-                    if silo_name.is_none() {
-                        missing.push(stringify!(silo_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let silo_name = silo_name.map_err(Error::InvalidRequest)?;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/silos/{}/identity-providers",
                 client.baseurl,
@@ -15726,9 +15667,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -15742,7 +15683,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -15771,19 +15712,24 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SiloPolicyView<'a> {
         client: &'a super::Client,
-        silo_name: Option<types::Name>,
+        silo_name: Result<types::Name, String>,
     }
 
     impl<'a> SiloPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                silo_name: None,
+                silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
 
-        pub fn silo_name(mut self, value: types::Name) -> Self {
-            self.silo_name = Some(value);
+        pub fn silo_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.silo_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for silo_name failed".to_string());
             self
         }
 
@@ -15792,19 +15738,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
             let Self { client, silo_name } = self;
-            let (silo_name,) = match (silo_name,) {
-                (Some(silo_name),) => (silo_name,),
-                (silo_name,) => {
-                    let mut missing = Vec::new();
-                    if silo_name.is_none() {
-                        missing.push(stringify!(silo_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/silos/{}/policy",
                 client.baseurl,
@@ -15832,26 +15766,36 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SiloPolicyUpdate<'a> {
         client: &'a super::Client,
-        silo_name: Option<types::Name>,
-        body: Option<types::SiloRolePolicy>,
+        silo_name: Result<types::Name, String>,
+        body: Result<types::SiloRolePolicy, String>,
     }
 
     impl<'a> SiloPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                silo_name: None,
-                body: None,
+                silo_name: Err("silo_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn silo_name(mut self, value: types::Name) -> Self {
-            self.silo_name = Some(value);
+        pub fn silo_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.silo_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for silo_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::SiloRolePolicy) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::SiloRolePolicy>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `SiloRolePolicy` for body failed".to_string());
             self
         }
 
@@ -15864,22 +15808,8 @@ pub mod builder {
                 silo_name,
                 body,
             } = self;
-            let (silo_name, body) = match (silo_name, body) {
-                (Some(silo_name), Some(body)) => (silo_name, body),
-                (silo_name, body) => {
-                    let mut missing = Vec::new();
-                    if silo_name.is_none() {
-                        missing.push(stringify!(silo_name));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let silo_name = silo_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/silos/{}/policy",
                 client.baseurl,
@@ -15907,26 +15837,36 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SiloIdentityProviderCreate<'a> {
         client: &'a super::Client,
-        silo_name: Option<types::Name>,
-        body: Option<types::SamlIdentityProviderCreate>,
+        silo_name: Result<types::Name, String>,
+        body: Result<types::SamlIdentityProviderCreate, String>,
     }
 
     impl<'a> SiloIdentityProviderCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                silo_name: None,
-                body: None,
+                silo_name: Err("silo_name was not initialized".to_string()),
+                body: Err("body was not initialized".to_string()),
             }
         }
 
-        pub fn silo_name(mut self, value: types::Name) -> Self {
-            self.silo_name = Some(value);
+        pub fn silo_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.silo_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for silo_name failed".to_string());
             self
         }
 
-        pub fn body(mut self, value: types::SamlIdentityProviderCreate) -> Self {
-            self.body = Some(value);
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::SamlIdentityProviderCreate>,
+        {
+            self.body = value.try_into().map_err(|_| {
+                "conversion to `SamlIdentityProviderCreate` for body failed".to_string()
+            });
             self
         }
 
@@ -15940,22 +15880,8 @@ pub mod builder {
                 silo_name,
                 body,
             } = self;
-            let (silo_name, body) = match (silo_name, body) {
-                (Some(silo_name), Some(body)) => (silo_name, body),
-                (silo_name, body) => {
-                    let mut missing = Vec::new();
-                    if silo_name.is_none() {
-                        missing.push(stringify!(silo_name));
-                    }
-                    if body.is_none() {
-                        missing.push(stringify!(body));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let silo_name = silo_name.map_err(Error::InvalidRequest)?;
+            let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/silos/{}/saml-identity-providers",
                 client.baseurl,
@@ -15983,26 +15909,36 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SiloIdentityProviderView<'a> {
         client: &'a super::Client,
-        silo_name: Option<types::Name>,
-        provider_name: Option<types::Name>,
+        silo_name: Result<types::Name, String>,
+        provider_name: Result<types::Name, String>,
     }
 
     impl<'a> SiloIdentityProviderView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                silo_name: None,
-                provider_name: None,
+                silo_name: Err("silo_name was not initialized".to_string()),
+                provider_name: Err("provider_name was not initialized".to_string()),
             }
         }
 
-        pub fn silo_name(mut self, value: types::Name) -> Self {
-            self.silo_name = Some(value);
+        pub fn silo_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.silo_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for silo_name failed".to_string());
             self
         }
 
-        pub fn provider_name(mut self, value: types::Name) -> Self {
-            self.provider_name = Some(value);
+        pub fn provider_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.provider_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for provider_name failed".to_string());
             self
         }
 
@@ -16016,22 +15952,8 @@ pub mod builder {
                 silo_name,
                 provider_name,
             } = self;
-            let (silo_name, provider_name) = match (silo_name, provider_name) {
-                (Some(silo_name), Some(provider_name)) => (silo_name, provider_name),
-                (silo_name, provider_name) => {
-                    let mut missing = Vec::new();
-                    if silo_name.is_none() {
-                        missing.push(stringify!(silo_name));
-                    }
-                    if provider_name.is_none() {
-                        missing.push(stringify!(provider_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let silo_name = silo_name.map_err(Error::InvalidRequest)?;
+            let provider_name = provider_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/silos/{}/saml-identity-providers/{}",
                 client.baseurl,
@@ -16060,33 +15982,49 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SystemUserList<'a> {
         client: &'a super::Client,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::NameSortMode>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::NameSortMode>, String>,
     }
 
     impl<'a> SystemUserList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::NameSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::NameSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < NameSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -16100,6 +16038,9 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/user", client.baseurl,);
             let mut query = Vec::new();
             if let Some(v) = &limit {
@@ -16135,9 +16076,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -16151,7 +16092,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -16180,38 +16121,31 @@ pub mod builder {
     #[derive(Clone)]
     pub struct SystemUserView<'a> {
         client: &'a super::Client,
-        user_name: Option<types::Name>,
+        user_name: Result<types::Name, String>,
     }
 
     impl<'a> SystemUserView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                user_name: None,
+                user_name: Err("user_name was not initialized".to_string()),
             }
         }
 
-        pub fn user_name(mut self, value: types::Name) -> Self {
-            self.user_name = Some(value);
+        pub fn user_name<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::Name>,
+        {
+            self.user_name = value
+                .try_into()
+                .map_err(|_| "conversion to `Name` for user_name failed".to_string());
             self
         }
 
         ///Sends a `GET` request to `/system/user/{user_name}`
         pub async fn send(self) -> Result<ResponseValue<types::UserBuiltin>, Error<types::Error>> {
             let Self { client, user_name } = self;
-            let (user_name,) = match (user_name,) {
-                (Some(user_name),) => (user_name,),
-                (user_name,) => {
-                    let mut missing = Vec::new();
-                    if user_name.is_none() {
-                        missing.push(stringify!(user_name));
-                    }
-                    return Err(super::Error::InvalidRequest(format!(
-                        "the following parameters are required: {}",
-                        missing.join(", "),
-                    )));
-                }
-            };
+            let user_name = user_name.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/system/user/{}",
                 client.baseurl,
@@ -16239,26 +16173,37 @@ pub mod builder {
     #[derive(Clone)]
     pub struct TimeseriesSchemaGet<'a> {
         client: &'a super::Client,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
     }
 
     impl<'a> TimeseriesSchemaGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                limit: None,
-                page_token: None,
+                limit: Ok(None),
+                page_token: Ok(None),
             }
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
@@ -16272,6 +16217,8 @@ pub mod builder {
                 limit,
                 page_token,
             } = self;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/timeseries/schema", client.baseurl,);
             let mut query = Vec::new();
             if let Some(v) = &limit {
@@ -16304,8 +16251,8 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
+                limit: Ok(None),
+                page_token: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -16319,7 +16266,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()
@@ -16381,33 +16328,49 @@ pub mod builder {
     #[derive(Clone)]
     pub struct UserList<'a> {
         client: &'a super::Client,
-        limit: Option<std::num::NonZeroU32>,
-        page_token: Option<String>,
-        sort_by: Option<types::IdSortMode>,
+        limit: Result<Option<std::num::NonZeroU32>, String>,
+        page_token: Result<Option<String>, String>,
+        sort_by: Result<Option<types::IdSortMode>, String>,
     }
 
     impl<'a> UserList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
             }
         }
 
-        pub fn limit(mut self, value: std::num::NonZeroU32) -> Self {
-            self.limit = Some(value);
+        pub fn limit<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<std::num::NonZeroU32>,
+        {
+            self.limit = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < std :: num :: NonZeroU32 >` for limit failed".to_string()
+            });
             self
         }
 
-        pub fn page_token(mut self, value: String) -> Self {
-            self.page_token = Some(value);
+        pub fn page_token<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<String>,
+        {
+            self.page_token = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `Option < String >` for page_token failed".to_string());
             self
         }
 
-        pub fn sort_by(mut self, value: types::IdSortMode) -> Self {
-            self.sort_by = Some(value);
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: TryInto<types::IdSortMode>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `Option < IdSortMode >` for sort_by failed".to_string()
+            });
             self
         }
 
@@ -16421,6 +16384,9 @@ pub mod builder {
                 page_token,
                 sort_by,
             } = self;
+            let limit = limit.map_err(Error::InvalidRequest)?;
+            let page_token = page_token.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/users", client.baseurl,);
             let mut query = Vec::new();
             if let Some(v) = &limit {
@@ -16456,9 +16422,9 @@ pub mod builder {
             use futures::TryFutureExt;
             use futures::TryStreamExt;
             let next = Self {
-                limit: None,
-                page_token: None,
-                sort_by: None,
+                limit: Ok(None),
+                page_token: Ok(None),
+                sort_by: Ok(None),
                 ..self.clone()
             };
             self.send()
@@ -16472,7 +16438,7 @@ pub mod builder {
                                 Ok(None)
                             } else {
                                 Self {
-                                    page_token: next_page,
+                                    page_token: Ok(next_page),
                                     ..next.clone()
                                 }
                                 .send()

--- a/progenitor-impl/tests/output/nexus-positional.out
+++ b/progenitor-impl/tests/output/nexus-positional.out
@@ -3,6 +3,8 @@ use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
+    #[allow(unused_imports)]
+    use std::convert::TryFrom;
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct BlockSize(i64);
     impl std::ops::Deref for BlockSize {

--- a/progenitor-impl/tests/output/test_default_params.out
+++ b/progenitor-impl/tests/output/test_default_params.out
@@ -3,6 +3,8 @@ use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
+    #[allow(unused_imports)]
+    use std::convert::TryFrom;
     mod defaults {
         pub(super) fn default_u64<T, const V: u64>() -> T
         where

--- a/progenitor-impl/tests/output/test_freeform_response.out
+++ b/progenitor-impl/tests/output/test_freeform_response.out
@@ -3,6 +3,8 @@ use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
+    #[allow(unused_imports)]
+    use std::convert::TryFrom;
     ///Error information from a response.
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct Error {

--- a/progenitor-impl/tests/output/test_renamed_parameters.out
+++ b/progenitor-impl/tests/output/test_renamed_parameters.out
@@ -3,6 +3,8 @@ use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
+    #[allow(unused_imports)]
+    use std::convert::TryFrom;
     ///Error information from a response.
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct Error {

--- a/progenitor/tests/build_nexus.rs
+++ b/progenitor/tests/build_nexus.rs
@@ -34,15 +34,15 @@ mod builder_untagged {
         );
     }
 
-    use nexus_client::{types, Client};
+    use nexus_client::Client;
 
     pub fn _ignore() {
         let client = Client::new("");
         let stream = client
             .instance_disk_list()
-            .organization_name(types::Name::try_from("org").unwrap())
-            .project_name(types::Name::try_from("project").unwrap())
-            .instance_name(types::Name::try_from("instance").unwrap())
+            .organization_name("org")
+            .project_name("project")
+            .instance_name("instance")
             .stream();
         let _ = stream.collect::<Vec<_>>();
     }
@@ -59,15 +59,15 @@ mod builder_tagged {
         );
     }
 
-    use nexus_client::{types, Client, ClientInstancesExt};
+    use nexus_client::{Client, ClientInstancesExt};
 
     fn _ignore() {
         let client = Client::new("");
         let stream = client
             .instance_disk_list()
-            .organization_name(types::Name::try_from("org").unwrap())
-            .project_name(types::Name::try_from("project").unwrap())
-            .instance_name(types::Name::try_from("instance").unwrap())
+            .organization_name("org")
+            .project_name("project")
+            .instance_name("instance")
             .stream();
         let _ = stream.collect::<Vec<_>>();
     }

--- a/sample_openapi/nexus.json
+++ b/sample_openapi/nexus.json
@@ -7830,7 +7830,8 @@
           "user_data": {
             "description": "User data for instance initialization systems (such as cloud-init). Must be a Base64-encoded string, as specified in RFC 4648 § 4 (+ and / characters with padding). Maximum 32 KiB unencoded data.",
             "default": "",
-            "type": "string"
+            "type": "string",
+            "format": "byte"
           }
         },
         "required": [


### PR DESCRIPTION
Change builder methods for setting a parameter with type T to accept a TryInto<T> rather than a T. This makes constrained types a bit more ergonomic and will allow us to accept fallible builders more easily