### PR TITLE
Derive Debug for types

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,6 +17,7 @@ https://github.com/oxidecomputer/progenitor/compare/v0.1.1\...HEAD[Full list of 
 
 * Add support for a builder-style generation in addition to the positional style (#86)
 * Add support for body parameters with application/x-www-form-urlencoded media type (#109)
+* Derive Debug for Client and builders for the various operations (#145)
 
 == 0.1.1 (released 2022-05-13)
 

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -219,7 +219,7 @@ impl Generator {
                 #(#types)*
             }
 
-            #[derive(Clone)]
+            #[derive(Clone, Debug)]
             pub struct Client {
                 pub(crate) baseurl: String,
                 pub(crate) client: reqwest::Client,

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -1418,7 +1418,14 @@ impl Generator {
             }
         });
 
-        let maybe_clone = cloneable.then(|| quote! { #[derive(Clone, Debug)] });
+        let mut derives = vec![quote! { Debug }];
+        if cloneable {
+            derives.push(quote! { Clone });
+        }
+
+        let derive = quote! {
+            #[derive( #( #derives ),* )]
+        };
 
         // Build a reasonable doc comment depending on whether this struct is
         // the output from
@@ -1480,7 +1487,7 @@ impl Generator {
 
         Ok(quote! {
             #[doc = #struct_doc]
-            #maybe_clone
+            #derive
             pub struct #struct_ident<'a> {
                 client: &'a super::Client,
                 #( #param_names: #param_types, )*

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -1418,7 +1418,7 @@ impl Generator {
             }
         });
 
-        let maybe_clone = cloneable.then(|| quote! { #[derive(Clone)] });
+        let maybe_clone = cloneable.then(|| quote! { #[derive(Clone, Debug)] });
 
         // Build a reasonable doc comment depending on whether this struct is
         // the output from

--- a/progenitor-impl/tests/output/buildomat-builder-tagged.out
+++ b/progenitor-impl/tests/output/buildomat-builder-tagged.out
@@ -134,7 +134,7 @@ pub mod types {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
@@ -373,7 +373,7 @@ pub mod builder {
     ///Builder for [`Client::control_hold`]
     ///
     ///[`Client::control_hold`]: super::Client::control_hold
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ControlHold<'a> {
         client: &'a super::Client,
     }
@@ -400,7 +400,7 @@ pub mod builder {
     ///Builder for [`Client::control_resume`]
     ///
     ///[`Client::control_resume`]: super::Client::control_resume
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ControlResume<'a> {
         client: &'a super::Client,
     }
@@ -427,7 +427,7 @@ pub mod builder {
     ///Builder for [`Client::task_get`]
     ///
     ///[`Client::task_get`]: super::Client::task_get
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct TaskGet<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -473,7 +473,7 @@ pub mod builder {
     ///Builder for [`Client::tasks_get`]
     ///
     ///[`Client::tasks_get`]: super::Client::tasks_get
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct TasksGet<'a> {
         client: &'a super::Client,
     }
@@ -500,7 +500,7 @@ pub mod builder {
     ///Builder for [`Client::task_submit`]
     ///
     ///[`Client::task_submit`]: super::Client::task_submit
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct TaskSubmit<'a> {
         client: &'a super::Client,
         body: Result<types::TaskSubmit, String>,
@@ -542,7 +542,7 @@ pub mod builder {
     ///Builder for [`Client::task_events_get`]
     ///
     ///[`Client::task_events_get`]: super::Client::task_events_get
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct TaskEventsGet<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -610,7 +610,7 @@ pub mod builder {
     ///Builder for [`Client::task_outputs_get`]
     ///
     ///[`Client::task_outputs_get`]: super::Client::task_outputs_get
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct TaskOutputsGet<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -656,7 +656,7 @@ pub mod builder {
     ///Builder for [`Client::task_output_download`]
     ///
     ///[`Client::task_output_download`]: super::Client::task_output_download
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct TaskOutputDownload<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -720,7 +720,7 @@ pub mod builder {
     ///Builder for [`Client::user_create`]
     ///
     ///[`Client::user_create`]: super::Client::user_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct UserCreate<'a> {
         client: &'a super::Client,
         body: Result<types::UserCreate, String>,
@@ -762,7 +762,7 @@ pub mod builder {
     ///Builder for [`Client::whoami`]
     ///
     ///[`Client::whoami`]: super::Client::whoami
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct Whoami<'a> {
         client: &'a super::Client,
     }
@@ -789,7 +789,7 @@ pub mod builder {
     ///Builder for [`Client::worker_bootstrap`]
     ///
     ///[`Client::worker_bootstrap`]: super::Client::worker_bootstrap
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct WorkerBootstrap<'a> {
         client: &'a super::Client,
         body: Result<types::WorkerBootstrap, String>,
@@ -831,7 +831,7 @@ pub mod builder {
     ///Builder for [`Client::worker_ping`]
     ///
     ///[`Client::worker_ping`]: super::Client::worker_ping
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct WorkerPing<'a> {
         client: &'a super::Client,
     }
@@ -858,7 +858,7 @@ pub mod builder {
     ///Builder for [`Client::worker_task_append`]
     ///
     ///[`Client::worker_task_append`]: super::Client::worker_task_append
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct WorkerTaskAppend<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -983,7 +983,7 @@ pub mod builder {
     ///Builder for [`Client::worker_task_complete`]
     ///
     ///[`Client::worker_task_complete`]: super::Client::worker_task_complete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct WorkerTaskComplete<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -1042,7 +1042,7 @@ pub mod builder {
     ///Builder for [`Client::worker_task_add_output`]
     ///
     ///[`Client::worker_task_add_output`]: super::Client::worker_task_add_output
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct WorkerTaskAddOutput<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -1101,7 +1101,7 @@ pub mod builder {
     ///Builder for [`Client::workers_list`]
     ///
     ///[`Client::workers_list`]: super::Client::workers_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct WorkersList<'a> {
         client: &'a super::Client,
     }
@@ -1128,7 +1128,7 @@ pub mod builder {
     ///Builder for [`Client::workers_recycle`]
     ///
     ///[`Client::workers_recycle`]: super::Client::workers_recycle
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct WorkersRecycle<'a> {
         client: &'a super::Client,
     }

--- a/progenitor-impl/tests/output/buildomat-builder-tagged.out
+++ b/progenitor-impl/tests/output/buildomat-builder-tagged.out
@@ -373,7 +373,7 @@ pub mod builder {
     ///Builder for [`Client::control_hold`]
     ///
     ///[`Client::control_hold`]: super::Client::control_hold
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ControlHold<'a> {
         client: &'a super::Client,
     }
@@ -400,7 +400,7 @@ pub mod builder {
     ///Builder for [`Client::control_resume`]
     ///
     ///[`Client::control_resume`]: super::Client::control_resume
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ControlResume<'a> {
         client: &'a super::Client,
     }
@@ -427,7 +427,7 @@ pub mod builder {
     ///Builder for [`Client::task_get`]
     ///
     ///[`Client::task_get`]: super::Client::task_get
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct TaskGet<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -473,7 +473,7 @@ pub mod builder {
     ///Builder for [`Client::tasks_get`]
     ///
     ///[`Client::tasks_get`]: super::Client::tasks_get
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct TasksGet<'a> {
         client: &'a super::Client,
     }
@@ -500,7 +500,7 @@ pub mod builder {
     ///Builder for [`Client::task_submit`]
     ///
     ///[`Client::task_submit`]: super::Client::task_submit
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct TaskSubmit<'a> {
         client: &'a super::Client,
         body: Result<types::TaskSubmit, String>,
@@ -542,7 +542,7 @@ pub mod builder {
     ///Builder for [`Client::task_events_get`]
     ///
     ///[`Client::task_events_get`]: super::Client::task_events_get
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct TaskEventsGet<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -610,7 +610,7 @@ pub mod builder {
     ///Builder for [`Client::task_outputs_get`]
     ///
     ///[`Client::task_outputs_get`]: super::Client::task_outputs_get
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct TaskOutputsGet<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -656,7 +656,7 @@ pub mod builder {
     ///Builder for [`Client::task_output_download`]
     ///
     ///[`Client::task_output_download`]: super::Client::task_output_download
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct TaskOutputDownload<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -720,7 +720,7 @@ pub mod builder {
     ///Builder for [`Client::user_create`]
     ///
     ///[`Client::user_create`]: super::Client::user_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct UserCreate<'a> {
         client: &'a super::Client,
         body: Result<types::UserCreate, String>,
@@ -762,7 +762,7 @@ pub mod builder {
     ///Builder for [`Client::whoami`]
     ///
     ///[`Client::whoami`]: super::Client::whoami
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct Whoami<'a> {
         client: &'a super::Client,
     }
@@ -789,7 +789,7 @@ pub mod builder {
     ///Builder for [`Client::worker_bootstrap`]
     ///
     ///[`Client::worker_bootstrap`]: super::Client::worker_bootstrap
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct WorkerBootstrap<'a> {
         client: &'a super::Client,
         body: Result<types::WorkerBootstrap, String>,
@@ -831,7 +831,7 @@ pub mod builder {
     ///Builder for [`Client::worker_ping`]
     ///
     ///[`Client::worker_ping`]: super::Client::worker_ping
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct WorkerPing<'a> {
         client: &'a super::Client,
     }
@@ -858,7 +858,7 @@ pub mod builder {
     ///Builder for [`Client::worker_task_append`]
     ///
     ///[`Client::worker_task_append`]: super::Client::worker_task_append
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct WorkerTaskAppend<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -917,6 +917,7 @@ pub mod builder {
     ///Builder for [`Client::worker_task_upload_chunk`]
     ///
     ///[`Client::worker_task_upload_chunk`]: super::Client::worker_task_upload_chunk
+    #[derive(Debug)]
     pub struct WorkerTaskUploadChunk<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -983,7 +984,7 @@ pub mod builder {
     ///Builder for [`Client::worker_task_complete`]
     ///
     ///[`Client::worker_task_complete`]: super::Client::worker_task_complete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct WorkerTaskComplete<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -1042,7 +1043,7 @@ pub mod builder {
     ///Builder for [`Client::worker_task_add_output`]
     ///
     ///[`Client::worker_task_add_output`]: super::Client::worker_task_add_output
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct WorkerTaskAddOutput<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -1101,7 +1102,7 @@ pub mod builder {
     ///Builder for [`Client::workers_list`]
     ///
     ///[`Client::workers_list`]: super::Client::workers_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct WorkersList<'a> {
         client: &'a super::Client,
     }
@@ -1128,7 +1129,7 @@ pub mod builder {
     ///Builder for [`Client::workers_recycle`]
     ///
     ///[`Client::workers_recycle`]: super::Client::workers_recycle
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct WorkersRecycle<'a> {
         client: &'a super::Client,
     }

--- a/progenitor-impl/tests/output/buildomat-builder.out
+++ b/progenitor-impl/tests/output/buildomat-builder.out
@@ -375,7 +375,7 @@ pub mod builder {
     ///Builder for [`Client::control_hold`]
     ///
     ///[`Client::control_hold`]: super::Client::control_hold
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ControlHold<'a> {
         client: &'a super::Client,
     }
@@ -402,7 +402,7 @@ pub mod builder {
     ///Builder for [`Client::control_resume`]
     ///
     ///[`Client::control_resume`]: super::Client::control_resume
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ControlResume<'a> {
         client: &'a super::Client,
     }
@@ -429,7 +429,7 @@ pub mod builder {
     ///Builder for [`Client::task_get`]
     ///
     ///[`Client::task_get`]: super::Client::task_get
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct TaskGet<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -475,7 +475,7 @@ pub mod builder {
     ///Builder for [`Client::tasks_get`]
     ///
     ///[`Client::tasks_get`]: super::Client::tasks_get
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct TasksGet<'a> {
         client: &'a super::Client,
     }
@@ -502,7 +502,7 @@ pub mod builder {
     ///Builder for [`Client::task_submit`]
     ///
     ///[`Client::task_submit`]: super::Client::task_submit
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct TaskSubmit<'a> {
         client: &'a super::Client,
         body: Result<types::TaskSubmit, String>,
@@ -544,7 +544,7 @@ pub mod builder {
     ///Builder for [`Client::task_events_get`]
     ///
     ///[`Client::task_events_get`]: super::Client::task_events_get
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct TaskEventsGet<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -612,7 +612,7 @@ pub mod builder {
     ///Builder for [`Client::task_outputs_get`]
     ///
     ///[`Client::task_outputs_get`]: super::Client::task_outputs_get
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct TaskOutputsGet<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -658,7 +658,7 @@ pub mod builder {
     ///Builder for [`Client::task_output_download`]
     ///
     ///[`Client::task_output_download`]: super::Client::task_output_download
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct TaskOutputDownload<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -722,7 +722,7 @@ pub mod builder {
     ///Builder for [`Client::user_create`]
     ///
     ///[`Client::user_create`]: super::Client::user_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct UserCreate<'a> {
         client: &'a super::Client,
         body: Result<types::UserCreate, String>,
@@ -764,7 +764,7 @@ pub mod builder {
     ///Builder for [`Client::whoami`]
     ///
     ///[`Client::whoami`]: super::Client::whoami
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct Whoami<'a> {
         client: &'a super::Client,
     }
@@ -791,7 +791,7 @@ pub mod builder {
     ///Builder for [`Client::worker_bootstrap`]
     ///
     ///[`Client::worker_bootstrap`]: super::Client::worker_bootstrap
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct WorkerBootstrap<'a> {
         client: &'a super::Client,
         body: Result<types::WorkerBootstrap, String>,
@@ -833,7 +833,7 @@ pub mod builder {
     ///Builder for [`Client::worker_ping`]
     ///
     ///[`Client::worker_ping`]: super::Client::worker_ping
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct WorkerPing<'a> {
         client: &'a super::Client,
     }
@@ -860,7 +860,7 @@ pub mod builder {
     ///Builder for [`Client::worker_task_append`]
     ///
     ///[`Client::worker_task_append`]: super::Client::worker_task_append
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct WorkerTaskAppend<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -919,6 +919,7 @@ pub mod builder {
     ///Builder for [`Client::worker_task_upload_chunk`]
     ///
     ///[`Client::worker_task_upload_chunk`]: super::Client::worker_task_upload_chunk
+    #[derive(Debug)]
     pub struct WorkerTaskUploadChunk<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -985,7 +986,7 @@ pub mod builder {
     ///Builder for [`Client::worker_task_complete`]
     ///
     ///[`Client::worker_task_complete`]: super::Client::worker_task_complete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct WorkerTaskComplete<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -1044,7 +1045,7 @@ pub mod builder {
     ///Builder for [`Client::worker_task_add_output`]
     ///
     ///[`Client::worker_task_add_output`]: super::Client::worker_task_add_output
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct WorkerTaskAddOutput<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -1103,7 +1104,7 @@ pub mod builder {
     ///Builder for [`Client::workers_list`]
     ///
     ///[`Client::workers_list`]: super::Client::workers_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct WorkersList<'a> {
         client: &'a super::Client,
     }
@@ -1130,7 +1131,7 @@ pub mod builder {
     ///Builder for [`Client::workers_recycle`]
     ///
     ///[`Client::workers_recycle`]: super::Client::workers_recycle
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct WorkersRecycle<'a> {
         client: &'a super::Client,
     }

--- a/progenitor-impl/tests/output/buildomat-builder.out
+++ b/progenitor-impl/tests/output/buildomat-builder.out
@@ -134,7 +134,7 @@ pub mod types {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
@@ -375,7 +375,7 @@ pub mod builder {
     ///Builder for [`Client::control_hold`]
     ///
     ///[`Client::control_hold`]: super::Client::control_hold
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ControlHold<'a> {
         client: &'a super::Client,
     }
@@ -402,7 +402,7 @@ pub mod builder {
     ///Builder for [`Client::control_resume`]
     ///
     ///[`Client::control_resume`]: super::Client::control_resume
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ControlResume<'a> {
         client: &'a super::Client,
     }
@@ -429,7 +429,7 @@ pub mod builder {
     ///Builder for [`Client::task_get`]
     ///
     ///[`Client::task_get`]: super::Client::task_get
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct TaskGet<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -475,7 +475,7 @@ pub mod builder {
     ///Builder for [`Client::tasks_get`]
     ///
     ///[`Client::tasks_get`]: super::Client::tasks_get
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct TasksGet<'a> {
         client: &'a super::Client,
     }
@@ -502,7 +502,7 @@ pub mod builder {
     ///Builder for [`Client::task_submit`]
     ///
     ///[`Client::task_submit`]: super::Client::task_submit
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct TaskSubmit<'a> {
         client: &'a super::Client,
         body: Result<types::TaskSubmit, String>,
@@ -544,7 +544,7 @@ pub mod builder {
     ///Builder for [`Client::task_events_get`]
     ///
     ///[`Client::task_events_get`]: super::Client::task_events_get
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct TaskEventsGet<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -612,7 +612,7 @@ pub mod builder {
     ///Builder for [`Client::task_outputs_get`]
     ///
     ///[`Client::task_outputs_get`]: super::Client::task_outputs_get
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct TaskOutputsGet<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -658,7 +658,7 @@ pub mod builder {
     ///Builder for [`Client::task_output_download`]
     ///
     ///[`Client::task_output_download`]: super::Client::task_output_download
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct TaskOutputDownload<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -722,7 +722,7 @@ pub mod builder {
     ///Builder for [`Client::user_create`]
     ///
     ///[`Client::user_create`]: super::Client::user_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct UserCreate<'a> {
         client: &'a super::Client,
         body: Result<types::UserCreate, String>,
@@ -764,7 +764,7 @@ pub mod builder {
     ///Builder for [`Client::whoami`]
     ///
     ///[`Client::whoami`]: super::Client::whoami
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct Whoami<'a> {
         client: &'a super::Client,
     }
@@ -791,7 +791,7 @@ pub mod builder {
     ///Builder for [`Client::worker_bootstrap`]
     ///
     ///[`Client::worker_bootstrap`]: super::Client::worker_bootstrap
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct WorkerBootstrap<'a> {
         client: &'a super::Client,
         body: Result<types::WorkerBootstrap, String>,
@@ -833,7 +833,7 @@ pub mod builder {
     ///Builder for [`Client::worker_ping`]
     ///
     ///[`Client::worker_ping`]: super::Client::worker_ping
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct WorkerPing<'a> {
         client: &'a super::Client,
     }
@@ -860,7 +860,7 @@ pub mod builder {
     ///Builder for [`Client::worker_task_append`]
     ///
     ///[`Client::worker_task_append`]: super::Client::worker_task_append
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct WorkerTaskAppend<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -985,7 +985,7 @@ pub mod builder {
     ///Builder for [`Client::worker_task_complete`]
     ///
     ///[`Client::worker_task_complete`]: super::Client::worker_task_complete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct WorkerTaskComplete<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -1044,7 +1044,7 @@ pub mod builder {
     ///Builder for [`Client::worker_task_add_output`]
     ///
     ///[`Client::worker_task_add_output`]: super::Client::worker_task_add_output
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct WorkerTaskAddOutput<'a> {
         client: &'a super::Client,
         task: Result<String, String>,
@@ -1103,7 +1103,7 @@ pub mod builder {
     ///Builder for [`Client::workers_list`]
     ///
     ///[`Client::workers_list`]: super::Client::workers_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct WorkersList<'a> {
         client: &'a super::Client,
     }
@@ -1130,7 +1130,7 @@ pub mod builder {
     ///Builder for [`Client::workers_recycle`]
     ///
     ///[`Client::workers_recycle`]: super::Client::workers_recycle
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct WorkersRecycle<'a> {
         client: &'a super::Client,
     }

--- a/progenitor-impl/tests/output/buildomat-positional.out
+++ b/progenitor-impl/tests/output/buildomat-positional.out
@@ -134,7 +134,7 @@ pub mod types {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,

--- a/progenitor-impl/tests/output/keeper-builder-tagged.out
+++ b/progenitor-impl/tests/output/keeper-builder-tagged.out
@@ -75,7 +75,7 @@ pub mod types {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
@@ -181,7 +181,7 @@ pub mod builder {
     ///Builder for [`Client::enrol`]
     ///
     ///[`Client::enrol`]: super::Client::enrol
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct Enrol<'a> {
         client: &'a super::Client,
         body: Result<types::EnrolBody, String>,
@@ -223,7 +223,7 @@ pub mod builder {
     ///Builder for [`Client::global_jobs`]
     ///
     ///[`Client::global_jobs`]: super::Client::global_jobs
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct GlobalJobs<'a> {
         client: &'a super::Client,
     }
@@ -250,7 +250,7 @@ pub mod builder {
     ///Builder for [`Client::ping`]
     ///
     ///[`Client::ping`]: super::Client::ping
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct Ping<'a> {
         client: &'a super::Client,
     }
@@ -277,7 +277,7 @@ pub mod builder {
     ///Builder for [`Client::report_finish`]
     ///
     ///[`Client::report_finish`]: super::Client::report_finish
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ReportFinish<'a> {
         client: &'a super::Client,
         body: Result<types::ReportFinishBody, String>,
@@ -319,7 +319,7 @@ pub mod builder {
     ///Builder for [`Client::report_output`]
     ///
     ///[`Client::report_output`]: super::Client::report_output
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ReportOutput<'a> {
         client: &'a super::Client,
         body: Result<types::ReportOutputBody, String>,
@@ -361,7 +361,7 @@ pub mod builder {
     ///Builder for [`Client::report_start`]
     ///
     ///[`Client::report_start`]: super::Client::report_start
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ReportStart<'a> {
         client: &'a super::Client,
         body: Result<types::ReportStartBody, String>,

--- a/progenitor-impl/tests/output/keeper-builder-tagged.out
+++ b/progenitor-impl/tests/output/keeper-builder-tagged.out
@@ -181,7 +181,7 @@ pub mod builder {
     ///Builder for [`Client::enrol`]
     ///
     ///[`Client::enrol`]: super::Client::enrol
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct Enrol<'a> {
         client: &'a super::Client,
         body: Result<types::EnrolBody, String>,
@@ -223,7 +223,7 @@ pub mod builder {
     ///Builder for [`Client::global_jobs`]
     ///
     ///[`Client::global_jobs`]: super::Client::global_jobs
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct GlobalJobs<'a> {
         client: &'a super::Client,
     }
@@ -250,7 +250,7 @@ pub mod builder {
     ///Builder for [`Client::ping`]
     ///
     ///[`Client::ping`]: super::Client::ping
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct Ping<'a> {
         client: &'a super::Client,
     }
@@ -277,7 +277,7 @@ pub mod builder {
     ///Builder for [`Client::report_finish`]
     ///
     ///[`Client::report_finish`]: super::Client::report_finish
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ReportFinish<'a> {
         client: &'a super::Client,
         body: Result<types::ReportFinishBody, String>,
@@ -319,7 +319,7 @@ pub mod builder {
     ///Builder for [`Client::report_output`]
     ///
     ///[`Client::report_output`]: super::Client::report_output
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ReportOutput<'a> {
         client: &'a super::Client,
         body: Result<types::ReportOutputBody, String>,
@@ -361,7 +361,7 @@ pub mod builder {
     ///Builder for [`Client::report_start`]
     ///
     ///[`Client::report_start`]: super::Client::report_start
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ReportStart<'a> {
         client: &'a super::Client,
         body: Result<types::ReportStartBody, String>,

--- a/progenitor-impl/tests/output/keeper-builder.out
+++ b/progenitor-impl/tests/output/keeper-builder.out
@@ -75,7 +75,7 @@ pub mod types {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
@@ -183,7 +183,7 @@ pub mod builder {
     ///Builder for [`Client::enrol`]
     ///
     ///[`Client::enrol`]: super::Client::enrol
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct Enrol<'a> {
         client: &'a super::Client,
         body: Result<types::EnrolBody, String>,
@@ -225,7 +225,7 @@ pub mod builder {
     ///Builder for [`Client::global_jobs`]
     ///
     ///[`Client::global_jobs`]: super::Client::global_jobs
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct GlobalJobs<'a> {
         client: &'a super::Client,
     }
@@ -252,7 +252,7 @@ pub mod builder {
     ///Builder for [`Client::ping`]
     ///
     ///[`Client::ping`]: super::Client::ping
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct Ping<'a> {
         client: &'a super::Client,
     }
@@ -279,7 +279,7 @@ pub mod builder {
     ///Builder for [`Client::report_finish`]
     ///
     ///[`Client::report_finish`]: super::Client::report_finish
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ReportFinish<'a> {
         client: &'a super::Client,
         body: Result<types::ReportFinishBody, String>,
@@ -321,7 +321,7 @@ pub mod builder {
     ///Builder for [`Client::report_output`]
     ///
     ///[`Client::report_output`]: super::Client::report_output
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ReportOutput<'a> {
         client: &'a super::Client,
         body: Result<types::ReportOutputBody, String>,
@@ -363,7 +363,7 @@ pub mod builder {
     ///Builder for [`Client::report_start`]
     ///
     ///[`Client::report_start`]: super::Client::report_start
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ReportStart<'a> {
         client: &'a super::Client,
         body: Result<types::ReportStartBody, String>,

--- a/progenitor-impl/tests/output/keeper-builder.out
+++ b/progenitor-impl/tests/output/keeper-builder.out
@@ -183,7 +183,7 @@ pub mod builder {
     ///Builder for [`Client::enrol`]
     ///
     ///[`Client::enrol`]: super::Client::enrol
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct Enrol<'a> {
         client: &'a super::Client,
         body: Result<types::EnrolBody, String>,
@@ -225,7 +225,7 @@ pub mod builder {
     ///Builder for [`Client::global_jobs`]
     ///
     ///[`Client::global_jobs`]: super::Client::global_jobs
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct GlobalJobs<'a> {
         client: &'a super::Client,
     }
@@ -252,7 +252,7 @@ pub mod builder {
     ///Builder for [`Client::ping`]
     ///
     ///[`Client::ping`]: super::Client::ping
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct Ping<'a> {
         client: &'a super::Client,
     }
@@ -279,7 +279,7 @@ pub mod builder {
     ///Builder for [`Client::report_finish`]
     ///
     ///[`Client::report_finish`]: super::Client::report_finish
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ReportFinish<'a> {
         client: &'a super::Client,
         body: Result<types::ReportFinishBody, String>,
@@ -321,7 +321,7 @@ pub mod builder {
     ///Builder for [`Client::report_output`]
     ///
     ///[`Client::report_output`]: super::Client::report_output
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ReportOutput<'a> {
         client: &'a super::Client,
         body: Result<types::ReportOutputBody, String>,
@@ -363,7 +363,7 @@ pub mod builder {
     ///Builder for [`Client::report_start`]
     ///
     ///[`Client::report_start`]: super::Client::report_start
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ReportStart<'a> {
         client: &'a super::Client,
         body: Result<types::ReportStartBody, String>,

--- a/progenitor-impl/tests/output/keeper-positional.out
+++ b/progenitor-impl/tests/output/keeper-positional.out
@@ -75,7 +75,7 @@ pub mod types {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,

--- a/progenitor-impl/tests/output/nexus-builder-tagged.out
+++ b/progenitor-impl/tests/output/nexus-builder-tagged.out
@@ -2885,7 +2885,7 @@ pub mod types {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
@@ -5513,7 +5513,7 @@ pub mod builder {
     ///Builder for [`ClientDisksExt::disk_view_by_id`]
     ///
     ///[`ClientDisksExt::disk_view_by_id`]: super::ClientDisksExt::disk_view_by_id
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct DiskViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5565,7 +5565,7 @@ pub mod builder {
     ///Builder for [`ClientImagesGlobalExt::image_global_view_by_id`]
     ///
     ///[`ClientImagesGlobalExt::image_global_view_by_id`]: super::ClientImagesGlobalExt::image_global_view_by_id
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ImageGlobalViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5617,7 +5617,7 @@ pub mod builder {
     ///Builder for [`ClientImagesExt::image_view_by_id`]
     ///
     ///[`ClientImagesExt::image_view_by_id`]: super::ClientImagesExt::image_view_by_id
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ImageViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5669,7 +5669,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_view_by_id`]
     ///
     ///[`ClientInstancesExt::instance_view_by_id`]: super::ClientInstancesExt::instance_view_by_id
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5722,7 +5722,7 @@ pub mod builder {
     /// [`ClientInstancesExt::instance_network_interface_view_by_id`]
     ///
     ///[`ClientInstancesExt::instance_network_interface_view_by_id`]: super::ClientInstancesExt::instance_network_interface_view_by_id
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceNetworkInterfaceViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5776,7 +5776,7 @@ pub mod builder {
     ///Builder for [`ClientOrganizationsExt::organization_view_by_id`]
     ///
     ///[`ClientOrganizationsExt::organization_view_by_id`]: super::ClientOrganizationsExt::organization_view_by_id
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct OrganizationViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5828,7 +5828,7 @@ pub mod builder {
     ///Builder for [`ClientProjectsExt::project_view_by_id`]
     ///
     ///[`ClientProjectsExt::project_view_by_id`]: super::ClientProjectsExt::project_view_by_id
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ProjectViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5880,7 +5880,7 @@ pub mod builder {
     ///Builder for [`ClientSnapshotsExt::snapshot_view_by_id`]
     ///
     ///[`ClientSnapshotsExt::snapshot_view_by_id`]: super::ClientSnapshotsExt::snapshot_view_by_id
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SnapshotViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5932,7 +5932,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_router_route_view_by_id`]
     ///
     ///[`ClientVpcsExt::vpc_router_route_view_by_id`]: super::ClientVpcsExt::vpc_router_route_view_by_id
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcRouterRouteViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5984,7 +5984,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_router_view_by_id`]
     ///
     ///[`ClientVpcsExt::vpc_router_view_by_id`]: super::ClientVpcsExt::vpc_router_view_by_id
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcRouterViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -6036,7 +6036,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_subnet_view_by_id`]
     ///
     ///[`ClientVpcsExt::vpc_subnet_view_by_id`]: super::ClientVpcsExt::vpc_subnet_view_by_id
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcSubnetViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -6088,7 +6088,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_view_by_id`]
     ///
     ///[`ClientVpcsExt::vpc_view_by_id`]: super::ClientVpcsExt::vpc_view_by_id
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -6140,7 +6140,7 @@ pub mod builder {
     ///Builder for [`ClientHiddenExt::device_auth_request`]
     ///
     ///[`ClientHiddenExt::device_auth_request`]: super::ClientHiddenExt::device_auth_request
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct DeviceAuthRequest<'a> {
         client: &'a super::Client,
         body: Result<types::DeviceAuthRequest, String>,
@@ -6182,7 +6182,7 @@ pub mod builder {
     ///Builder for [`ClientHiddenExt::device_auth_confirm`]
     ///
     ///[`ClientHiddenExt::device_auth_confirm`]: super::ClientHiddenExt::device_auth_confirm
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct DeviceAuthConfirm<'a> {
         client: &'a super::Client,
         body: Result<types::DeviceAuthVerify, String>,
@@ -6230,7 +6230,7 @@ pub mod builder {
     ///Builder for [`ClientHiddenExt::device_access_token`]
     ///
     ///[`ClientHiddenExt::device_access_token`]: super::ClientHiddenExt::device_access_token
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct DeviceAccessToken<'a> {
         client: &'a super::Client,
         body: Result<types::DeviceAccessTokenRequest, String>,
@@ -6272,7 +6272,7 @@ pub mod builder {
     ///Builder for [`ClientHardwareExt::rack_list`]
     ///
     ///[`ClientHardwareExt::rack_list`]: super::ClientHardwareExt::rack_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct RackList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -6411,7 +6411,7 @@ pub mod builder {
     ///Builder for [`ClientHardwareExt::rack_view`]
     ///
     ///[`ClientHardwareExt::rack_view`]: super::ClientHardwareExt::rack_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct RackView<'a> {
         client: &'a super::Client,
         rack_id: Result<uuid::Uuid, String>,
@@ -6463,7 +6463,7 @@ pub mod builder {
     ///Builder for [`ClientHardwareExt::sled_list`]
     ///
     ///[`ClientHardwareExt::sled_list`]: super::ClientHardwareExt::sled_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SledList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -6602,7 +6602,7 @@ pub mod builder {
     ///Builder for [`ClientHardwareExt::sled_view`]
     ///
     ///[`ClientHardwareExt::sled_view`]: super::ClientHardwareExt::sled_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SledView<'a> {
         client: &'a super::Client,
         sled_id: Result<uuid::Uuid, String>,
@@ -6654,7 +6654,7 @@ pub mod builder {
     ///Builder for [`ClientImagesGlobalExt::image_global_list`]
     ///
     ///[`ClientImagesGlobalExt::image_global_list`]: super::ClientImagesGlobalExt::image_global_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ImageGlobalList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -6793,7 +6793,7 @@ pub mod builder {
     ///Builder for [`ClientImagesGlobalExt::image_global_create`]
     ///
     ///[`ClientImagesGlobalExt::image_global_create`]: super::ClientImagesGlobalExt::image_global_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ImageGlobalCreate<'a> {
         client: &'a super::Client,
         body: Result<types::GlobalImageCreate, String>,
@@ -6841,7 +6841,7 @@ pub mod builder {
     ///Builder for [`ClientImagesGlobalExt::image_global_view`]
     ///
     ///[`ClientImagesGlobalExt::image_global_view`]: super::ClientImagesGlobalExt::image_global_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ImageGlobalView<'a> {
         client: &'a super::Client,
         image_name: Result<types::Name, String>,
@@ -6893,7 +6893,7 @@ pub mod builder {
     ///Builder for [`ClientImagesGlobalExt::image_global_delete`]
     ///
     ///[`ClientImagesGlobalExt::image_global_delete`]: super::ClientImagesGlobalExt::image_global_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ImageGlobalDelete<'a> {
         client: &'a super::Client,
         image_name: Result<types::Name, String>,
@@ -6945,7 +6945,7 @@ pub mod builder {
     ///Builder for [`ClientIpPoolsExt::ip_pool_list`]
     ///
     ///[`ClientIpPoolsExt::ip_pool_list`]: super::ClientIpPoolsExt::ip_pool_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct IpPoolList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -7084,7 +7084,7 @@ pub mod builder {
     ///Builder for [`ClientIpPoolsExt::ip_pool_create`]
     ///
     ///[`ClientIpPoolsExt::ip_pool_create`]: super::ClientIpPoolsExt::ip_pool_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct IpPoolCreate<'a> {
         client: &'a super::Client,
         body: Result<types::IpPoolCreate, String>,
@@ -7132,7 +7132,7 @@ pub mod builder {
     ///Builder for [`ClientIpPoolsExt::ip_pool_view`]
     ///
     ///[`ClientIpPoolsExt::ip_pool_view`]: super::ClientIpPoolsExt::ip_pool_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct IpPoolView<'a> {
         client: &'a super::Client,
         pool_name: Result<types::Name, String>,
@@ -7184,7 +7184,7 @@ pub mod builder {
     ///Builder for [`ClientIpPoolsExt::ip_pool_update`]
     ///
     ///[`ClientIpPoolsExt::ip_pool_update`]: super::ClientIpPoolsExt::ip_pool_update
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct IpPoolUpdate<'a> {
         client: &'a super::Client,
         pool_name: Result<types::Name, String>,
@@ -7253,7 +7253,7 @@ pub mod builder {
     ///Builder for [`ClientIpPoolsExt::ip_pool_delete`]
     ///
     ///[`ClientIpPoolsExt::ip_pool_delete`]: super::ClientIpPoolsExt::ip_pool_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct IpPoolDelete<'a> {
         client: &'a super::Client,
         pool_name: Result<types::Name, String>,
@@ -7305,7 +7305,7 @@ pub mod builder {
     ///Builder for [`ClientIpPoolsExt::ip_pool_range_list`]
     ///
     ///[`ClientIpPoolsExt::ip_pool_range_list`]: super::ClientIpPoolsExt::ip_pool_range_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct IpPoolRangeList<'a> {
         client: &'a super::Client,
         pool_name: Result<types::Name, String>,
@@ -7444,7 +7444,7 @@ pub mod builder {
     ///Builder for [`ClientIpPoolsExt::ip_pool_range_add`]
     ///
     ///[`ClientIpPoolsExt::ip_pool_range_add`]: super::ClientIpPoolsExt::ip_pool_range_add
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct IpPoolRangeAdd<'a> {
         client: &'a super::Client,
         pool_name: Result<types::Name, String>,
@@ -7513,7 +7513,7 @@ pub mod builder {
     ///Builder for [`ClientIpPoolsExt::ip_pool_range_remove`]
     ///
     ///[`ClientIpPoolsExt::ip_pool_range_remove`]: super::ClientIpPoolsExt::ip_pool_range_remove
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct IpPoolRangeRemove<'a> {
         client: &'a super::Client,
         pool_name: Result<types::Name, String>,
@@ -7582,7 +7582,7 @@ pub mod builder {
     ///Builder for [`ClientHiddenExt::spoof_login`]
     ///
     ///[`ClientHiddenExt::spoof_login`]: super::ClientHiddenExt::spoof_login
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SpoofLogin<'a> {
         client: &'a super::Client,
         body: Result<types::SpoofLoginBody, String>,
@@ -7624,7 +7624,7 @@ pub mod builder {
     ///Builder for [`ClientLoginExt::login`]
     ///
     ///[`ClientLoginExt::login`]: super::ClientLoginExt::login
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct Login<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -7773,7 +7773,7 @@ pub mod builder {
     ///Builder for [`ClientHiddenExt::logout`]
     ///
     ///[`ClientHiddenExt::logout`]: super::ClientHiddenExt::logout
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct Logout<'a> {
         client: &'a super::Client,
     }
@@ -7800,7 +7800,7 @@ pub mod builder {
     ///Builder for [`ClientOrganizationsExt::organization_list`]
     ///
     ///[`ClientOrganizationsExt::organization_list`]: super::ClientOrganizationsExt::organization_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct OrganizationList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -7939,7 +7939,7 @@ pub mod builder {
     ///Builder for [`ClientOrganizationsExt::organization_create`]
     ///
     ///[`ClientOrganizationsExt::organization_create`]: super::ClientOrganizationsExt::organization_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct OrganizationCreate<'a> {
         client: &'a super::Client,
         body: Result<types::OrganizationCreate, String>,
@@ -7987,7 +7987,7 @@ pub mod builder {
     ///Builder for [`ClientOrganizationsExt::organization_view`]
     ///
     ///[`ClientOrganizationsExt::organization_view`]: super::ClientOrganizationsExt::organization_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct OrganizationView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8042,7 +8042,7 @@ pub mod builder {
     ///Builder for [`ClientOrganizationsExt::organization_update`]
     ///
     ///[`ClientOrganizationsExt::organization_update`]: super::ClientOrganizationsExt::organization_update
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct OrganizationUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8111,7 +8111,7 @@ pub mod builder {
     ///Builder for [`ClientOrganizationsExt::organization_delete`]
     ///
     ///[`ClientOrganizationsExt::organization_delete`]: super::ClientOrganizationsExt::organization_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct OrganizationDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8166,7 +8166,7 @@ pub mod builder {
     ///Builder for [`ClientOrganizationsExt::organization_policy_view`]
     ///
     ///[`ClientOrganizationsExt::organization_policy_view`]: super::ClientOrganizationsExt::organization_policy_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct OrganizationPolicyView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8223,7 +8223,7 @@ pub mod builder {
     ///Builder for [`ClientOrganizationsExt::organization_policy_update`]
     ///
     ///[`ClientOrganizationsExt::organization_policy_update`]: super::ClientOrganizationsExt::organization_policy_update
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct OrganizationPolicyUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8294,7 +8294,7 @@ pub mod builder {
     ///Builder for [`ClientProjectsExt::project_list`]
     ///
     ///[`ClientProjectsExt::project_list`]: super::ClientProjectsExt::project_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ProjectList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8453,7 +8453,7 @@ pub mod builder {
     ///Builder for [`ClientProjectsExt::project_create`]
     ///
     ///[`ClientProjectsExt::project_create`]: super::ClientProjectsExt::project_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ProjectCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8523,7 +8523,7 @@ pub mod builder {
     ///Builder for [`ClientProjectsExt::project_view`]
     ///
     ///[`ClientProjectsExt::project_view`]: super::ClientProjectsExt::project_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ProjectView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8594,7 +8594,7 @@ pub mod builder {
     ///Builder for [`ClientProjectsExt::project_update`]
     ///
     ///[`ClientProjectsExt::project_update`]: super::ClientProjectsExt::project_update
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ProjectUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8679,7 +8679,7 @@ pub mod builder {
     ///Builder for [`ClientProjectsExt::project_delete`]
     ///
     ///[`ClientProjectsExt::project_delete`]: super::ClientProjectsExt::project_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ProjectDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8750,7 +8750,7 @@ pub mod builder {
     ///Builder for [`ClientDisksExt::disk_list`]
     ///
     ///[`ClientDisksExt::disk_list`]: super::ClientDisksExt::disk_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct DiskList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8924,7 +8924,7 @@ pub mod builder {
     ///Builder for [`ClientDisksExt::disk_create`]
     ///
     ///[`ClientDisksExt::disk_create`]: super::ClientDisksExt::disk_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct DiskCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9009,7 +9009,7 @@ pub mod builder {
     ///Builder for [`ClientDisksExt::disk_view`]
     ///
     ///[`ClientDisksExt::disk_view`]: super::ClientDisksExt::disk_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct DiskView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9096,7 +9096,7 @@ pub mod builder {
     ///Builder for [`ClientDisksExt::disk_delete`]
     ///
     ///[`ClientDisksExt::disk_delete`]: super::ClientDisksExt::disk_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct DiskDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9183,7 +9183,7 @@ pub mod builder {
     ///Builder for [`ClientDisksExt::disk_metrics_list`]
     ///
     ///[`ClientDisksExt::disk_metrics_list`]: super::ClientDisksExt::disk_metrics_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct DiskMetricsList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9403,7 +9403,7 @@ pub mod builder {
     ///Builder for [`ClientImagesExt::image_list`]
     ///
     ///[`ClientImagesExt::image_list`]: super::ClientImagesExt::image_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ImageList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9577,7 +9577,7 @@ pub mod builder {
     ///Builder for [`ClientImagesExt::image_create`]
     ///
     ///[`ClientImagesExt::image_create`]: super::ClientImagesExt::image_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ImageCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9662,7 +9662,7 @@ pub mod builder {
     ///Builder for [`ClientImagesExt::image_view`]
     ///
     ///[`ClientImagesExt::image_view`]: super::ClientImagesExt::image_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ImageView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9749,7 +9749,7 @@ pub mod builder {
     ///Builder for [`ClientImagesExt::image_delete`]
     ///
     ///[`ClientImagesExt::image_delete`]: super::ClientImagesExt::image_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ImageDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9836,7 +9836,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_list`]
     ///
     ///[`ClientInstancesExt::instance_list`]: super::ClientInstancesExt::instance_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10012,7 +10012,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_create`]
     ///
     ///[`ClientInstancesExt::instance_create`]: super::ClientInstancesExt::instance_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10098,7 +10098,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_view`]
     ///
     ///[`ClientInstancesExt::instance_view`]: super::ClientInstancesExt::instance_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10185,7 +10185,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_delete`]
     ///
     ///[`ClientInstancesExt::instance_delete`]: super::ClientInstancesExt::instance_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10272,7 +10272,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_disk_list`]
     ///
     ///[`ClientInstancesExt::instance_disk_list`]: super::ClientInstancesExt::instance_disk_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceDiskList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10463,7 +10463,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_disk_attach`]
     ///
     ///[`ClientInstancesExt::instance_disk_attach`]: super::ClientInstancesExt::instance_disk_attach
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceDiskAttach<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10564,7 +10564,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_disk_detach`]
     ///
     ///[`ClientInstancesExt::instance_disk_detach`]: super::ClientInstancesExt::instance_disk_detach
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceDiskDetach<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10665,7 +10665,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_external_ip_list`]
     ///
     ///[`ClientInstancesExt::instance_external_ip_list`]: super::ClientInstancesExt::instance_external_ip_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceExternalIpList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10754,7 +10754,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_migrate`]
     ///
     ///[`ClientInstancesExt::instance_migrate`]: super::ClientInstancesExt::instance_migrate
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceMigrate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10855,7 +10855,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_network_interface_list`]
     ///
     ///[`ClientInstancesExt::instance_network_interface_list`]: super::ClientInstancesExt::instance_network_interface_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceNetworkInterfaceList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11047,7 +11047,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_network_interface_create`]
     ///
     ///[`ClientInstancesExt::instance_network_interface_create`]: super::ClientInstancesExt::instance_network_interface_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceNetworkInterfaceCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11150,7 +11150,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_network_interface_view`]
     ///
     ///[`ClientInstancesExt::instance_network_interface_view`]: super::ClientInstancesExt::instance_network_interface_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceNetworkInterfaceView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11254,7 +11254,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_network_interface_update`]
     ///
     ///[`ClientInstancesExt::instance_network_interface_update`]: super::ClientInstancesExt::instance_network_interface_update
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceNetworkInterfaceUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11372,7 +11372,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_network_interface_delete`]
     ///
     ///[`ClientInstancesExt::instance_network_interface_delete`]: super::ClientInstancesExt::instance_network_interface_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceNetworkInterfaceDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11474,7 +11474,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_reboot`]
     ///
     ///[`ClientInstancesExt::instance_reboot`]: super::ClientInstancesExt::instance_reboot
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceReboot<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11561,7 +11561,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_serial_console`]
     ///
     ///[`ClientInstancesExt::instance_serial_console`]: super::ClientInstancesExt::instance_serial_console
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceSerialConsole<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11705,7 +11705,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_start`]
     ///
     ///[`ClientInstancesExt::instance_start`]: super::ClientInstancesExt::instance_start
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceStart<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11792,7 +11792,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_stop`]
     ///
     ///[`ClientInstancesExt::instance_stop`]: super::ClientInstancesExt::instance_stop
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceStop<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11879,7 +11879,7 @@ pub mod builder {
     ///Builder for [`ClientProjectsExt::project_policy_view`]
     ///
     ///[`ClientProjectsExt::project_policy_view`]: super::ClientProjectsExt::project_policy_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ProjectPolicyView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11952,7 +11952,7 @@ pub mod builder {
     ///Builder for [`ClientProjectsExt::project_policy_update`]
     ///
     ///[`ClientProjectsExt::project_policy_update`]: super::ClientProjectsExt::project_policy_update
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ProjectPolicyUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12039,7 +12039,7 @@ pub mod builder {
     ///Builder for [`ClientSnapshotsExt::snapshot_list`]
     ///
     ///[`ClientSnapshotsExt::snapshot_list`]: super::ClientSnapshotsExt::snapshot_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SnapshotList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12215,7 +12215,7 @@ pub mod builder {
     ///Builder for [`ClientSnapshotsExt::snapshot_create`]
     ///
     ///[`ClientSnapshotsExt::snapshot_create`]: super::ClientSnapshotsExt::snapshot_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SnapshotCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12301,7 +12301,7 @@ pub mod builder {
     ///Builder for [`ClientSnapshotsExt::snapshot_view`]
     ///
     ///[`ClientSnapshotsExt::snapshot_view`]: super::ClientSnapshotsExt::snapshot_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SnapshotView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12388,7 +12388,7 @@ pub mod builder {
     ///Builder for [`ClientSnapshotsExt::snapshot_delete`]
     ///
     ///[`ClientSnapshotsExt::snapshot_delete`]: super::ClientSnapshotsExt::snapshot_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SnapshotDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12475,7 +12475,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_list`]
     ///
     ///[`ClientVpcsExt::vpc_list`]: super::ClientVpcsExt::vpc_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12649,7 +12649,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_create`]
     ///
     ///[`ClientVpcsExt::vpc_create`]: super::ClientVpcsExt::vpc_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12734,7 +12734,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_view`]
     ///
     ///[`ClientVpcsExt::vpc_view`]: super::ClientVpcsExt::vpc_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12821,7 +12821,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_update`]
     ///
     ///[`ClientVpcsExt::vpc_update`]: super::ClientVpcsExt::vpc_update
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12922,7 +12922,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_delete`]
     ///
     ///[`ClientVpcsExt::vpc_delete`]: super::ClientVpcsExt::vpc_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13009,7 +13009,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_firewall_rules_view`]
     ///
     ///[`ClientVpcsExt::vpc_firewall_rules_view`]: super::ClientVpcsExt::vpc_firewall_rules_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcFirewallRulesView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13098,7 +13098,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_firewall_rules_update`]
     ///
     ///[`ClientVpcsExt::vpc_firewall_rules_update`]: super::ClientVpcsExt::vpc_firewall_rules_update
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcFirewallRulesUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13201,7 +13201,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_router_list`]
     ///
     ///[`ClientVpcsExt::vpc_router_list`]: super::ClientVpcsExt::vpc_router_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcRouterList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13392,7 +13392,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_router_create`]
     ///
     ///[`ClientVpcsExt::vpc_router_create`]: super::ClientVpcsExt::vpc_router_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcRouterCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13493,7 +13493,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_router_view`]
     ///
     ///[`ClientVpcsExt::vpc_router_view`]: super::ClientVpcsExt::vpc_router_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcRouterView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13595,7 +13595,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_router_update`]
     ///
     ///[`ClientVpcsExt::vpc_router_update`]: super::ClientVpcsExt::vpc_router_update
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcRouterUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13711,7 +13711,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_router_delete`]
     ///
     ///[`ClientVpcsExt::vpc_router_delete`]: super::ClientVpcsExt::vpc_router_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcRouterDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13813,7 +13813,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_router_route_list`]
     ///
     ///[`ClientVpcsExt::vpc_router_route_list`]: super::ClientVpcsExt::vpc_router_route_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcRouterRouteList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14019,7 +14019,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_router_route_create`]
     ///
     ///[`ClientVpcsExt::vpc_router_route_create`]: super::ClientVpcsExt::vpc_router_route_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcRouterRouteCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14135,7 +14135,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_router_route_view`]
     ///
     ///[`ClientVpcsExt::vpc_router_route_view`]: super::ClientVpcsExt::vpc_router_route_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcRouterRouteView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14252,7 +14252,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_router_route_update`]
     ///
     ///[`ClientVpcsExt::vpc_router_route_update`]: super::ClientVpcsExt::vpc_router_route_update
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcRouterRouteUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14383,7 +14383,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_router_route_delete`]
     ///
     ///[`ClientVpcsExt::vpc_router_route_delete`]: super::ClientVpcsExt::vpc_router_route_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcRouterRouteDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14500,7 +14500,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_subnet_list`]
     ///
     ///[`ClientVpcsExt::vpc_subnet_list`]: super::ClientVpcsExt::vpc_subnet_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcSubnetList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14691,7 +14691,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_subnet_create`]
     ///
     ///[`ClientVpcsExt::vpc_subnet_create`]: super::ClientVpcsExt::vpc_subnet_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcSubnetCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14792,7 +14792,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_subnet_view`]
     ///
     ///[`ClientVpcsExt::vpc_subnet_view`]: super::ClientVpcsExt::vpc_subnet_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcSubnetView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14894,7 +14894,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_subnet_update`]
     ///
     ///[`ClientVpcsExt::vpc_subnet_update`]: super::ClientVpcsExt::vpc_subnet_update
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcSubnetUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -15010,7 +15010,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_subnet_delete`]
     ///
     ///[`ClientVpcsExt::vpc_subnet_delete`]: super::ClientVpcsExt::vpc_subnet_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcSubnetDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -15112,7 +15112,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_subnet_list_network_interfaces`]
     ///
     ///[`ClientVpcsExt::vpc_subnet_list_network_interfaces`]: super::ClientVpcsExt::vpc_subnet_list_network_interfaces
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcSubnetListNetworkInterfaces<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -15319,7 +15319,7 @@ pub mod builder {
     ///Builder for [`ClientPolicyExt::policy_view`]
     ///
     ///[`ClientPolicyExt::policy_view`]: super::ClientPolicyExt::policy_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct PolicyView<'a> {
         client: &'a super::Client,
     }
@@ -15354,7 +15354,7 @@ pub mod builder {
     ///Builder for [`ClientPolicyExt::policy_update`]
     ///
     ///[`ClientPolicyExt::policy_update`]: super::ClientPolicyExt::policy_update
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct PolicyUpdate<'a> {
         client: &'a super::Client,
         body: Result<types::FleetRolePolicy, String>,
@@ -15404,7 +15404,7 @@ pub mod builder {
     ///Builder for [`ClientRolesExt::role_list`]
     ///
     ///[`ClientRolesExt::role_list`]: super::ClientRolesExt::role_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct RoleList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -15525,7 +15525,7 @@ pub mod builder {
     ///Builder for [`ClientRolesExt::role_view`]
     ///
     ///[`ClientRolesExt::role_view`]: super::ClientRolesExt::role_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct RoleView<'a> {
         client: &'a super::Client,
         role_name: Result<String, String>,
@@ -15577,7 +15577,7 @@ pub mod builder {
     ///Builder for [`ClientSagasExt::saga_list`]
     ///
     ///[`ClientSagasExt::saga_list`]: super::ClientSagasExt::saga_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SagaList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -15716,7 +15716,7 @@ pub mod builder {
     ///Builder for [`ClientSagasExt::saga_view`]
     ///
     ///[`ClientSagasExt::saga_view`]: super::ClientSagasExt::saga_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SagaView<'a> {
         client: &'a super::Client,
         saga_id: Result<uuid::Uuid, String>,
@@ -15768,7 +15768,7 @@ pub mod builder {
     ///Builder for [`ClientHiddenExt::session_me`]
     ///
     ///[`ClientHiddenExt::session_me`]: super::ClientHiddenExt::session_me
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SessionMe<'a> {
         client: &'a super::Client,
     }
@@ -15801,7 +15801,7 @@ pub mod builder {
     ///Builder for [`ClientSessionExt::session_sshkey_list`]
     ///
     ///[`ClientSessionExt::session_sshkey_list`]: super::ClientSessionExt::session_sshkey_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SessionSshkeyList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -15940,7 +15940,7 @@ pub mod builder {
     ///Builder for [`ClientSessionExt::session_sshkey_create`]
     ///
     ///[`ClientSessionExt::session_sshkey_create`]: super::ClientSessionExt::session_sshkey_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SessionSshkeyCreate<'a> {
         client: &'a super::Client,
         body: Result<types::SshKeyCreate, String>,
@@ -15988,7 +15988,7 @@ pub mod builder {
     ///Builder for [`ClientSessionExt::session_sshkey_view`]
     ///
     ///[`ClientSessionExt::session_sshkey_view`]: super::ClientSessionExt::session_sshkey_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SessionSshkeyView<'a> {
         client: &'a super::Client,
         ssh_key_name: Result<types::Name, String>,
@@ -16043,7 +16043,7 @@ pub mod builder {
     ///Builder for [`ClientSessionExt::session_sshkey_delete`]
     ///
     ///[`ClientSessionExt::session_sshkey_delete`]: super::ClientSessionExt::session_sshkey_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SessionSshkeyDelete<'a> {
         client: &'a super::Client,
         ssh_key_name: Result<types::Name, String>,
@@ -16098,7 +16098,7 @@ pub mod builder {
     ///Builder for [`ClientSilosExt::silo_list`]
     ///
     ///[`ClientSilosExt::silo_list`]: super::ClientSilosExt::silo_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SiloList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -16237,7 +16237,7 @@ pub mod builder {
     ///Builder for [`ClientSilosExt::silo_create`]
     ///
     ///[`ClientSilosExt::silo_create`]: super::ClientSilosExt::silo_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SiloCreate<'a> {
         client: &'a super::Client,
         body: Result<types::SiloCreate, String>,
@@ -16285,7 +16285,7 @@ pub mod builder {
     ///Builder for [`ClientSilosExt::silo_view`]
     ///
     ///[`ClientSilosExt::silo_view`]: super::ClientSilosExt::silo_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SiloView<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -16337,7 +16337,7 @@ pub mod builder {
     ///Builder for [`ClientSilosExt::silo_delete`]
     ///
     ///[`ClientSilosExt::silo_delete`]: super::ClientSilosExt::silo_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SiloDelete<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -16389,7 +16389,7 @@ pub mod builder {
     ///Builder for [`ClientSilosExt::silo_identity_provider_list`]
     ///
     ///[`ClientSilosExt::silo_identity_provider_list`]: super::ClientSilosExt::silo_identity_provider_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SiloIdentityProviderList<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -16547,7 +16547,7 @@ pub mod builder {
     ///Builder for [`ClientSilosExt::silo_policy_view`]
     ///
     ///[`ClientSilosExt::silo_policy_view`]: super::ClientSilosExt::silo_policy_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SiloPolicyView<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -16601,7 +16601,7 @@ pub mod builder {
     ///Builder for [`ClientSilosExt::silo_policy_update`]
     ///
     ///[`ClientSilosExt::silo_policy_update`]: super::ClientSilosExt::silo_policy_update
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SiloPolicyUpdate<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -16672,7 +16672,7 @@ pub mod builder {
     ///Builder for [`ClientSilosExt::silo_identity_provider_create`]
     ///
     ///[`ClientSilosExt::silo_identity_provider_create`]: super::ClientSilosExt::silo_identity_provider_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SiloIdentityProviderCreate<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -16744,7 +16744,7 @@ pub mod builder {
     ///Builder for [`ClientSilosExt::silo_identity_provider_view`]
     ///
     ///[`ClientSilosExt::silo_identity_provider_view`]: super::ClientSilosExt::silo_identity_provider_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SiloIdentityProviderView<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -16817,7 +16817,7 @@ pub mod builder {
     ///Builder for [`ClientSystemExt::system_user_list`]
     ///
     ///[`ClientSystemExt::system_user_list`]: super::ClientSystemExt::system_user_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SystemUserList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -16956,7 +16956,7 @@ pub mod builder {
     ///Builder for [`ClientSystemExt::system_user_view`]
     ///
     ///[`ClientSystemExt::system_user_view`]: super::ClientSystemExt::system_user_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SystemUserView<'a> {
         client: &'a super::Client,
         user_name: Result<types::Name, String>,
@@ -17008,7 +17008,7 @@ pub mod builder {
     ///Builder for [`ClientMetricsExt::timeseries_schema_get`]
     ///
     ///[`ClientMetricsExt::timeseries_schema_get`]: super::ClientMetricsExt::timeseries_schema_get
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct TimeseriesSchemaGet<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -17130,7 +17130,7 @@ pub mod builder {
     ///Builder for [`ClientUpdatesExt::updates_refresh`]
     ///
     ///[`ClientUpdatesExt::updates_refresh`]: super::ClientUpdatesExt::updates_refresh
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct UpdatesRefresh<'a> {
         client: &'a super::Client,
     }
@@ -17163,7 +17163,7 @@ pub mod builder {
     ///Builder for [`ClientSilosExt::user_list`]
     ///
     ///[`ClientSilosExt::user_list`]: super::ClientSilosExt::user_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct UserList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,

--- a/progenitor-impl/tests/output/nexus-builder-tagged.out
+++ b/progenitor-impl/tests/output/nexus-builder-tagged.out
@@ -5513,7 +5513,7 @@ pub mod builder {
     ///Builder for [`ClientDisksExt::disk_view_by_id`]
     ///
     ///[`ClientDisksExt::disk_view_by_id`]: super::ClientDisksExt::disk_view_by_id
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct DiskViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5565,7 +5565,7 @@ pub mod builder {
     ///Builder for [`ClientImagesGlobalExt::image_global_view_by_id`]
     ///
     ///[`ClientImagesGlobalExt::image_global_view_by_id`]: super::ClientImagesGlobalExt::image_global_view_by_id
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ImageGlobalViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5617,7 +5617,7 @@ pub mod builder {
     ///Builder for [`ClientImagesExt::image_view_by_id`]
     ///
     ///[`ClientImagesExt::image_view_by_id`]: super::ClientImagesExt::image_view_by_id
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ImageViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5669,7 +5669,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_view_by_id`]
     ///
     ///[`ClientInstancesExt::instance_view_by_id`]: super::ClientInstancesExt::instance_view_by_id
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5722,7 +5722,7 @@ pub mod builder {
     /// [`ClientInstancesExt::instance_network_interface_view_by_id`]
     ///
     ///[`ClientInstancesExt::instance_network_interface_view_by_id`]: super::ClientInstancesExt::instance_network_interface_view_by_id
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5776,7 +5776,7 @@ pub mod builder {
     ///Builder for [`ClientOrganizationsExt::organization_view_by_id`]
     ///
     ///[`ClientOrganizationsExt::organization_view_by_id`]: super::ClientOrganizationsExt::organization_view_by_id
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct OrganizationViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5828,7 +5828,7 @@ pub mod builder {
     ///Builder for [`ClientProjectsExt::project_view_by_id`]
     ///
     ///[`ClientProjectsExt::project_view_by_id`]: super::ClientProjectsExt::project_view_by_id
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ProjectViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5880,7 +5880,7 @@ pub mod builder {
     ///Builder for [`ClientSnapshotsExt::snapshot_view_by_id`]
     ///
     ///[`ClientSnapshotsExt::snapshot_view_by_id`]: super::ClientSnapshotsExt::snapshot_view_by_id
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SnapshotViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5932,7 +5932,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_router_route_view_by_id`]
     ///
     ///[`ClientVpcsExt::vpc_router_route_view_by_id`]: super::ClientVpcsExt::vpc_router_route_view_by_id
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcRouterRouteViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5984,7 +5984,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_router_view_by_id`]
     ///
     ///[`ClientVpcsExt::vpc_router_view_by_id`]: super::ClientVpcsExt::vpc_router_view_by_id
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcRouterViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -6036,7 +6036,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_subnet_view_by_id`]
     ///
     ///[`ClientVpcsExt::vpc_subnet_view_by_id`]: super::ClientVpcsExt::vpc_subnet_view_by_id
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcSubnetViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -6088,7 +6088,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_view_by_id`]
     ///
     ///[`ClientVpcsExt::vpc_view_by_id`]: super::ClientVpcsExt::vpc_view_by_id
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -6140,7 +6140,7 @@ pub mod builder {
     ///Builder for [`ClientHiddenExt::device_auth_request`]
     ///
     ///[`ClientHiddenExt::device_auth_request`]: super::ClientHiddenExt::device_auth_request
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct DeviceAuthRequest<'a> {
         client: &'a super::Client,
         body: Result<types::DeviceAuthRequest, String>,
@@ -6182,7 +6182,7 @@ pub mod builder {
     ///Builder for [`ClientHiddenExt::device_auth_confirm`]
     ///
     ///[`ClientHiddenExt::device_auth_confirm`]: super::ClientHiddenExt::device_auth_confirm
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct DeviceAuthConfirm<'a> {
         client: &'a super::Client,
         body: Result<types::DeviceAuthVerify, String>,
@@ -6230,7 +6230,7 @@ pub mod builder {
     ///Builder for [`ClientHiddenExt::device_access_token`]
     ///
     ///[`ClientHiddenExt::device_access_token`]: super::ClientHiddenExt::device_access_token
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct DeviceAccessToken<'a> {
         client: &'a super::Client,
         body: Result<types::DeviceAccessTokenRequest, String>,
@@ -6272,7 +6272,7 @@ pub mod builder {
     ///Builder for [`ClientHardwareExt::rack_list`]
     ///
     ///[`ClientHardwareExt::rack_list`]: super::ClientHardwareExt::rack_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct RackList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -6411,7 +6411,7 @@ pub mod builder {
     ///Builder for [`ClientHardwareExt::rack_view`]
     ///
     ///[`ClientHardwareExt::rack_view`]: super::ClientHardwareExt::rack_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct RackView<'a> {
         client: &'a super::Client,
         rack_id: Result<uuid::Uuid, String>,
@@ -6463,7 +6463,7 @@ pub mod builder {
     ///Builder for [`ClientHardwareExt::sled_list`]
     ///
     ///[`ClientHardwareExt::sled_list`]: super::ClientHardwareExt::sled_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SledList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -6602,7 +6602,7 @@ pub mod builder {
     ///Builder for [`ClientHardwareExt::sled_view`]
     ///
     ///[`ClientHardwareExt::sled_view`]: super::ClientHardwareExt::sled_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SledView<'a> {
         client: &'a super::Client,
         sled_id: Result<uuid::Uuid, String>,
@@ -6654,7 +6654,7 @@ pub mod builder {
     ///Builder for [`ClientImagesGlobalExt::image_global_list`]
     ///
     ///[`ClientImagesGlobalExt::image_global_list`]: super::ClientImagesGlobalExt::image_global_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ImageGlobalList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -6793,7 +6793,7 @@ pub mod builder {
     ///Builder for [`ClientImagesGlobalExt::image_global_create`]
     ///
     ///[`ClientImagesGlobalExt::image_global_create`]: super::ClientImagesGlobalExt::image_global_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ImageGlobalCreate<'a> {
         client: &'a super::Client,
         body: Result<types::GlobalImageCreate, String>,
@@ -6841,7 +6841,7 @@ pub mod builder {
     ///Builder for [`ClientImagesGlobalExt::image_global_view`]
     ///
     ///[`ClientImagesGlobalExt::image_global_view`]: super::ClientImagesGlobalExt::image_global_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ImageGlobalView<'a> {
         client: &'a super::Client,
         image_name: Result<types::Name, String>,
@@ -6893,7 +6893,7 @@ pub mod builder {
     ///Builder for [`ClientImagesGlobalExt::image_global_delete`]
     ///
     ///[`ClientImagesGlobalExt::image_global_delete`]: super::ClientImagesGlobalExt::image_global_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ImageGlobalDelete<'a> {
         client: &'a super::Client,
         image_name: Result<types::Name, String>,
@@ -6945,7 +6945,7 @@ pub mod builder {
     ///Builder for [`ClientIpPoolsExt::ip_pool_list`]
     ///
     ///[`ClientIpPoolsExt::ip_pool_list`]: super::ClientIpPoolsExt::ip_pool_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct IpPoolList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -7084,7 +7084,7 @@ pub mod builder {
     ///Builder for [`ClientIpPoolsExt::ip_pool_create`]
     ///
     ///[`ClientIpPoolsExt::ip_pool_create`]: super::ClientIpPoolsExt::ip_pool_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct IpPoolCreate<'a> {
         client: &'a super::Client,
         body: Result<types::IpPoolCreate, String>,
@@ -7132,7 +7132,7 @@ pub mod builder {
     ///Builder for [`ClientIpPoolsExt::ip_pool_view`]
     ///
     ///[`ClientIpPoolsExt::ip_pool_view`]: super::ClientIpPoolsExt::ip_pool_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct IpPoolView<'a> {
         client: &'a super::Client,
         pool_name: Result<types::Name, String>,
@@ -7184,7 +7184,7 @@ pub mod builder {
     ///Builder for [`ClientIpPoolsExt::ip_pool_update`]
     ///
     ///[`ClientIpPoolsExt::ip_pool_update`]: super::ClientIpPoolsExt::ip_pool_update
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct IpPoolUpdate<'a> {
         client: &'a super::Client,
         pool_name: Result<types::Name, String>,
@@ -7253,7 +7253,7 @@ pub mod builder {
     ///Builder for [`ClientIpPoolsExt::ip_pool_delete`]
     ///
     ///[`ClientIpPoolsExt::ip_pool_delete`]: super::ClientIpPoolsExt::ip_pool_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct IpPoolDelete<'a> {
         client: &'a super::Client,
         pool_name: Result<types::Name, String>,
@@ -7305,7 +7305,7 @@ pub mod builder {
     ///Builder for [`ClientIpPoolsExt::ip_pool_range_list`]
     ///
     ///[`ClientIpPoolsExt::ip_pool_range_list`]: super::ClientIpPoolsExt::ip_pool_range_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct IpPoolRangeList<'a> {
         client: &'a super::Client,
         pool_name: Result<types::Name, String>,
@@ -7444,7 +7444,7 @@ pub mod builder {
     ///Builder for [`ClientIpPoolsExt::ip_pool_range_add`]
     ///
     ///[`ClientIpPoolsExt::ip_pool_range_add`]: super::ClientIpPoolsExt::ip_pool_range_add
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct IpPoolRangeAdd<'a> {
         client: &'a super::Client,
         pool_name: Result<types::Name, String>,
@@ -7513,7 +7513,7 @@ pub mod builder {
     ///Builder for [`ClientIpPoolsExt::ip_pool_range_remove`]
     ///
     ///[`ClientIpPoolsExt::ip_pool_range_remove`]: super::ClientIpPoolsExt::ip_pool_range_remove
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct IpPoolRangeRemove<'a> {
         client: &'a super::Client,
         pool_name: Result<types::Name, String>,
@@ -7582,7 +7582,7 @@ pub mod builder {
     ///Builder for [`ClientHiddenExt::spoof_login`]
     ///
     ///[`ClientHiddenExt::spoof_login`]: super::ClientHiddenExt::spoof_login
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SpoofLogin<'a> {
         client: &'a super::Client,
         body: Result<types::SpoofLoginBody, String>,
@@ -7624,7 +7624,7 @@ pub mod builder {
     ///Builder for [`ClientLoginExt::login`]
     ///
     ///[`ClientLoginExt::login`]: super::ClientLoginExt::login
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct Login<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -7688,6 +7688,7 @@ pub mod builder {
     ///Builder for [`ClientLoginExt::consume_credentials`]
     ///
     ///[`ClientLoginExt::consume_credentials`]: super::ClientLoginExt::consume_credentials
+    #[derive(Debug)]
     pub struct ConsumeCredentials<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -7773,7 +7774,7 @@ pub mod builder {
     ///Builder for [`ClientHiddenExt::logout`]
     ///
     ///[`ClientHiddenExt::logout`]: super::ClientHiddenExt::logout
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct Logout<'a> {
         client: &'a super::Client,
     }
@@ -7800,7 +7801,7 @@ pub mod builder {
     ///Builder for [`ClientOrganizationsExt::organization_list`]
     ///
     ///[`ClientOrganizationsExt::organization_list`]: super::ClientOrganizationsExt::organization_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct OrganizationList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -7939,7 +7940,7 @@ pub mod builder {
     ///Builder for [`ClientOrganizationsExt::organization_create`]
     ///
     ///[`ClientOrganizationsExt::organization_create`]: super::ClientOrganizationsExt::organization_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct OrganizationCreate<'a> {
         client: &'a super::Client,
         body: Result<types::OrganizationCreate, String>,
@@ -7987,7 +7988,7 @@ pub mod builder {
     ///Builder for [`ClientOrganizationsExt::organization_view`]
     ///
     ///[`ClientOrganizationsExt::organization_view`]: super::ClientOrganizationsExt::organization_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct OrganizationView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8042,7 +8043,7 @@ pub mod builder {
     ///Builder for [`ClientOrganizationsExt::organization_update`]
     ///
     ///[`ClientOrganizationsExt::organization_update`]: super::ClientOrganizationsExt::organization_update
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct OrganizationUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8111,7 +8112,7 @@ pub mod builder {
     ///Builder for [`ClientOrganizationsExt::organization_delete`]
     ///
     ///[`ClientOrganizationsExt::organization_delete`]: super::ClientOrganizationsExt::organization_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct OrganizationDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8166,7 +8167,7 @@ pub mod builder {
     ///Builder for [`ClientOrganizationsExt::organization_policy_view`]
     ///
     ///[`ClientOrganizationsExt::organization_policy_view`]: super::ClientOrganizationsExt::organization_policy_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct OrganizationPolicyView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8223,7 +8224,7 @@ pub mod builder {
     ///Builder for [`ClientOrganizationsExt::organization_policy_update`]
     ///
     ///[`ClientOrganizationsExt::organization_policy_update`]: super::ClientOrganizationsExt::organization_policy_update
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct OrganizationPolicyUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8294,7 +8295,7 @@ pub mod builder {
     ///Builder for [`ClientProjectsExt::project_list`]
     ///
     ///[`ClientProjectsExt::project_list`]: super::ClientProjectsExt::project_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ProjectList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8453,7 +8454,7 @@ pub mod builder {
     ///Builder for [`ClientProjectsExt::project_create`]
     ///
     ///[`ClientProjectsExt::project_create`]: super::ClientProjectsExt::project_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ProjectCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8523,7 +8524,7 @@ pub mod builder {
     ///Builder for [`ClientProjectsExt::project_view`]
     ///
     ///[`ClientProjectsExt::project_view`]: super::ClientProjectsExt::project_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ProjectView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8594,7 +8595,7 @@ pub mod builder {
     ///Builder for [`ClientProjectsExt::project_update`]
     ///
     ///[`ClientProjectsExt::project_update`]: super::ClientProjectsExt::project_update
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ProjectUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8679,7 +8680,7 @@ pub mod builder {
     ///Builder for [`ClientProjectsExt::project_delete`]
     ///
     ///[`ClientProjectsExt::project_delete`]: super::ClientProjectsExt::project_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ProjectDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8750,7 +8751,7 @@ pub mod builder {
     ///Builder for [`ClientDisksExt::disk_list`]
     ///
     ///[`ClientDisksExt::disk_list`]: super::ClientDisksExt::disk_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct DiskList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8924,7 +8925,7 @@ pub mod builder {
     ///Builder for [`ClientDisksExt::disk_create`]
     ///
     ///[`ClientDisksExt::disk_create`]: super::ClientDisksExt::disk_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct DiskCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9009,7 +9010,7 @@ pub mod builder {
     ///Builder for [`ClientDisksExt::disk_view`]
     ///
     ///[`ClientDisksExt::disk_view`]: super::ClientDisksExt::disk_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct DiskView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9096,7 +9097,7 @@ pub mod builder {
     ///Builder for [`ClientDisksExt::disk_delete`]
     ///
     ///[`ClientDisksExt::disk_delete`]: super::ClientDisksExt::disk_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct DiskDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9183,7 +9184,7 @@ pub mod builder {
     ///Builder for [`ClientDisksExt::disk_metrics_list`]
     ///
     ///[`ClientDisksExt::disk_metrics_list`]: super::ClientDisksExt::disk_metrics_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct DiskMetricsList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9403,7 +9404,7 @@ pub mod builder {
     ///Builder for [`ClientImagesExt::image_list`]
     ///
     ///[`ClientImagesExt::image_list`]: super::ClientImagesExt::image_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ImageList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9577,7 +9578,7 @@ pub mod builder {
     ///Builder for [`ClientImagesExt::image_create`]
     ///
     ///[`ClientImagesExt::image_create`]: super::ClientImagesExt::image_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ImageCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9662,7 +9663,7 @@ pub mod builder {
     ///Builder for [`ClientImagesExt::image_view`]
     ///
     ///[`ClientImagesExt::image_view`]: super::ClientImagesExt::image_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ImageView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9749,7 +9750,7 @@ pub mod builder {
     ///Builder for [`ClientImagesExt::image_delete`]
     ///
     ///[`ClientImagesExt::image_delete`]: super::ClientImagesExt::image_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ImageDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9836,7 +9837,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_list`]
     ///
     ///[`ClientInstancesExt::instance_list`]: super::ClientInstancesExt::instance_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10012,7 +10013,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_create`]
     ///
     ///[`ClientInstancesExt::instance_create`]: super::ClientInstancesExt::instance_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10098,7 +10099,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_view`]
     ///
     ///[`ClientInstancesExt::instance_view`]: super::ClientInstancesExt::instance_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10185,7 +10186,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_delete`]
     ///
     ///[`ClientInstancesExt::instance_delete`]: super::ClientInstancesExt::instance_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10272,7 +10273,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_disk_list`]
     ///
     ///[`ClientInstancesExt::instance_disk_list`]: super::ClientInstancesExt::instance_disk_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceDiskList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10463,7 +10464,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_disk_attach`]
     ///
     ///[`ClientInstancesExt::instance_disk_attach`]: super::ClientInstancesExt::instance_disk_attach
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceDiskAttach<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10564,7 +10565,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_disk_detach`]
     ///
     ///[`ClientInstancesExt::instance_disk_detach`]: super::ClientInstancesExt::instance_disk_detach
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceDiskDetach<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10665,7 +10666,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_external_ip_list`]
     ///
     ///[`ClientInstancesExt::instance_external_ip_list`]: super::ClientInstancesExt::instance_external_ip_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceExternalIpList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10754,7 +10755,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_migrate`]
     ///
     ///[`ClientInstancesExt::instance_migrate`]: super::ClientInstancesExt::instance_migrate
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceMigrate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10855,7 +10856,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_network_interface_list`]
     ///
     ///[`ClientInstancesExt::instance_network_interface_list`]: super::ClientInstancesExt::instance_network_interface_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11047,7 +11048,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_network_interface_create`]
     ///
     ///[`ClientInstancesExt::instance_network_interface_create`]: super::ClientInstancesExt::instance_network_interface_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11150,7 +11151,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_network_interface_view`]
     ///
     ///[`ClientInstancesExt::instance_network_interface_view`]: super::ClientInstancesExt::instance_network_interface_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11254,7 +11255,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_network_interface_update`]
     ///
     ///[`ClientInstancesExt::instance_network_interface_update`]: super::ClientInstancesExt::instance_network_interface_update
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11372,7 +11373,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_network_interface_delete`]
     ///
     ///[`ClientInstancesExt::instance_network_interface_delete`]: super::ClientInstancesExt::instance_network_interface_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11474,7 +11475,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_reboot`]
     ///
     ///[`ClientInstancesExt::instance_reboot`]: super::ClientInstancesExt::instance_reboot
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceReboot<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11561,7 +11562,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_serial_console`]
     ///
     ///[`ClientInstancesExt::instance_serial_console`]: super::ClientInstancesExt::instance_serial_console
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceSerialConsole<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11705,7 +11706,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_start`]
     ///
     ///[`ClientInstancesExt::instance_start`]: super::ClientInstancesExt::instance_start
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceStart<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11792,7 +11793,7 @@ pub mod builder {
     ///Builder for [`ClientInstancesExt::instance_stop`]
     ///
     ///[`ClientInstancesExt::instance_stop`]: super::ClientInstancesExt::instance_stop
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceStop<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11879,7 +11880,7 @@ pub mod builder {
     ///Builder for [`ClientProjectsExt::project_policy_view`]
     ///
     ///[`ClientProjectsExt::project_policy_view`]: super::ClientProjectsExt::project_policy_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ProjectPolicyView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11952,7 +11953,7 @@ pub mod builder {
     ///Builder for [`ClientProjectsExt::project_policy_update`]
     ///
     ///[`ClientProjectsExt::project_policy_update`]: super::ClientProjectsExt::project_policy_update
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ProjectPolicyUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12039,7 +12040,7 @@ pub mod builder {
     ///Builder for [`ClientSnapshotsExt::snapshot_list`]
     ///
     ///[`ClientSnapshotsExt::snapshot_list`]: super::ClientSnapshotsExt::snapshot_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SnapshotList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12215,7 +12216,7 @@ pub mod builder {
     ///Builder for [`ClientSnapshotsExt::snapshot_create`]
     ///
     ///[`ClientSnapshotsExt::snapshot_create`]: super::ClientSnapshotsExt::snapshot_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SnapshotCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12301,7 +12302,7 @@ pub mod builder {
     ///Builder for [`ClientSnapshotsExt::snapshot_view`]
     ///
     ///[`ClientSnapshotsExt::snapshot_view`]: super::ClientSnapshotsExt::snapshot_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SnapshotView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12388,7 +12389,7 @@ pub mod builder {
     ///Builder for [`ClientSnapshotsExt::snapshot_delete`]
     ///
     ///[`ClientSnapshotsExt::snapshot_delete`]: super::ClientSnapshotsExt::snapshot_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SnapshotDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12475,7 +12476,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_list`]
     ///
     ///[`ClientVpcsExt::vpc_list`]: super::ClientVpcsExt::vpc_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12649,7 +12650,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_create`]
     ///
     ///[`ClientVpcsExt::vpc_create`]: super::ClientVpcsExt::vpc_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12734,7 +12735,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_view`]
     ///
     ///[`ClientVpcsExt::vpc_view`]: super::ClientVpcsExt::vpc_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12821,7 +12822,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_update`]
     ///
     ///[`ClientVpcsExt::vpc_update`]: super::ClientVpcsExt::vpc_update
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12922,7 +12923,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_delete`]
     ///
     ///[`ClientVpcsExt::vpc_delete`]: super::ClientVpcsExt::vpc_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13009,7 +13010,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_firewall_rules_view`]
     ///
     ///[`ClientVpcsExt::vpc_firewall_rules_view`]: super::ClientVpcsExt::vpc_firewall_rules_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcFirewallRulesView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13098,7 +13099,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_firewall_rules_update`]
     ///
     ///[`ClientVpcsExt::vpc_firewall_rules_update`]: super::ClientVpcsExt::vpc_firewall_rules_update
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcFirewallRulesUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13201,7 +13202,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_router_list`]
     ///
     ///[`ClientVpcsExt::vpc_router_list`]: super::ClientVpcsExt::vpc_router_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcRouterList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13392,7 +13393,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_router_create`]
     ///
     ///[`ClientVpcsExt::vpc_router_create`]: super::ClientVpcsExt::vpc_router_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcRouterCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13493,7 +13494,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_router_view`]
     ///
     ///[`ClientVpcsExt::vpc_router_view`]: super::ClientVpcsExt::vpc_router_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcRouterView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13595,7 +13596,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_router_update`]
     ///
     ///[`ClientVpcsExt::vpc_router_update`]: super::ClientVpcsExt::vpc_router_update
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcRouterUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13711,7 +13712,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_router_delete`]
     ///
     ///[`ClientVpcsExt::vpc_router_delete`]: super::ClientVpcsExt::vpc_router_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcRouterDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13813,7 +13814,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_router_route_list`]
     ///
     ///[`ClientVpcsExt::vpc_router_route_list`]: super::ClientVpcsExt::vpc_router_route_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcRouterRouteList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14019,7 +14020,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_router_route_create`]
     ///
     ///[`ClientVpcsExt::vpc_router_route_create`]: super::ClientVpcsExt::vpc_router_route_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcRouterRouteCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14135,7 +14136,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_router_route_view`]
     ///
     ///[`ClientVpcsExt::vpc_router_route_view`]: super::ClientVpcsExt::vpc_router_route_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcRouterRouteView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14252,7 +14253,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_router_route_update`]
     ///
     ///[`ClientVpcsExt::vpc_router_route_update`]: super::ClientVpcsExt::vpc_router_route_update
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcRouterRouteUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14383,7 +14384,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_router_route_delete`]
     ///
     ///[`ClientVpcsExt::vpc_router_route_delete`]: super::ClientVpcsExt::vpc_router_route_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcRouterRouteDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14500,7 +14501,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_subnet_list`]
     ///
     ///[`ClientVpcsExt::vpc_subnet_list`]: super::ClientVpcsExt::vpc_subnet_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcSubnetList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14691,7 +14692,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_subnet_create`]
     ///
     ///[`ClientVpcsExt::vpc_subnet_create`]: super::ClientVpcsExt::vpc_subnet_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcSubnetCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14792,7 +14793,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_subnet_view`]
     ///
     ///[`ClientVpcsExt::vpc_subnet_view`]: super::ClientVpcsExt::vpc_subnet_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcSubnetView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14894,7 +14895,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_subnet_update`]
     ///
     ///[`ClientVpcsExt::vpc_subnet_update`]: super::ClientVpcsExt::vpc_subnet_update
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcSubnetUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -15010,7 +15011,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_subnet_delete`]
     ///
     ///[`ClientVpcsExt::vpc_subnet_delete`]: super::ClientVpcsExt::vpc_subnet_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcSubnetDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -15112,7 +15113,7 @@ pub mod builder {
     ///Builder for [`ClientVpcsExt::vpc_subnet_list_network_interfaces`]
     ///
     ///[`ClientVpcsExt::vpc_subnet_list_network_interfaces`]: super::ClientVpcsExt::vpc_subnet_list_network_interfaces
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcSubnetListNetworkInterfaces<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -15319,7 +15320,7 @@ pub mod builder {
     ///Builder for [`ClientPolicyExt::policy_view`]
     ///
     ///[`ClientPolicyExt::policy_view`]: super::ClientPolicyExt::policy_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct PolicyView<'a> {
         client: &'a super::Client,
     }
@@ -15354,7 +15355,7 @@ pub mod builder {
     ///Builder for [`ClientPolicyExt::policy_update`]
     ///
     ///[`ClientPolicyExt::policy_update`]: super::ClientPolicyExt::policy_update
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct PolicyUpdate<'a> {
         client: &'a super::Client,
         body: Result<types::FleetRolePolicy, String>,
@@ -15404,7 +15405,7 @@ pub mod builder {
     ///Builder for [`ClientRolesExt::role_list`]
     ///
     ///[`ClientRolesExt::role_list`]: super::ClientRolesExt::role_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct RoleList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -15525,7 +15526,7 @@ pub mod builder {
     ///Builder for [`ClientRolesExt::role_view`]
     ///
     ///[`ClientRolesExt::role_view`]: super::ClientRolesExt::role_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct RoleView<'a> {
         client: &'a super::Client,
         role_name: Result<String, String>,
@@ -15577,7 +15578,7 @@ pub mod builder {
     ///Builder for [`ClientSagasExt::saga_list`]
     ///
     ///[`ClientSagasExt::saga_list`]: super::ClientSagasExt::saga_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SagaList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -15716,7 +15717,7 @@ pub mod builder {
     ///Builder for [`ClientSagasExt::saga_view`]
     ///
     ///[`ClientSagasExt::saga_view`]: super::ClientSagasExt::saga_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SagaView<'a> {
         client: &'a super::Client,
         saga_id: Result<uuid::Uuid, String>,
@@ -15768,7 +15769,7 @@ pub mod builder {
     ///Builder for [`ClientHiddenExt::session_me`]
     ///
     ///[`ClientHiddenExt::session_me`]: super::ClientHiddenExt::session_me
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SessionMe<'a> {
         client: &'a super::Client,
     }
@@ -15801,7 +15802,7 @@ pub mod builder {
     ///Builder for [`ClientSessionExt::session_sshkey_list`]
     ///
     ///[`ClientSessionExt::session_sshkey_list`]: super::ClientSessionExt::session_sshkey_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SessionSshkeyList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -15940,7 +15941,7 @@ pub mod builder {
     ///Builder for [`ClientSessionExt::session_sshkey_create`]
     ///
     ///[`ClientSessionExt::session_sshkey_create`]: super::ClientSessionExt::session_sshkey_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SessionSshkeyCreate<'a> {
         client: &'a super::Client,
         body: Result<types::SshKeyCreate, String>,
@@ -15988,7 +15989,7 @@ pub mod builder {
     ///Builder for [`ClientSessionExt::session_sshkey_view`]
     ///
     ///[`ClientSessionExt::session_sshkey_view`]: super::ClientSessionExt::session_sshkey_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SessionSshkeyView<'a> {
         client: &'a super::Client,
         ssh_key_name: Result<types::Name, String>,
@@ -16043,7 +16044,7 @@ pub mod builder {
     ///Builder for [`ClientSessionExt::session_sshkey_delete`]
     ///
     ///[`ClientSessionExt::session_sshkey_delete`]: super::ClientSessionExt::session_sshkey_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SessionSshkeyDelete<'a> {
         client: &'a super::Client,
         ssh_key_name: Result<types::Name, String>,
@@ -16098,7 +16099,7 @@ pub mod builder {
     ///Builder for [`ClientSilosExt::silo_list`]
     ///
     ///[`ClientSilosExt::silo_list`]: super::ClientSilosExt::silo_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SiloList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -16237,7 +16238,7 @@ pub mod builder {
     ///Builder for [`ClientSilosExt::silo_create`]
     ///
     ///[`ClientSilosExt::silo_create`]: super::ClientSilosExt::silo_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SiloCreate<'a> {
         client: &'a super::Client,
         body: Result<types::SiloCreate, String>,
@@ -16285,7 +16286,7 @@ pub mod builder {
     ///Builder for [`ClientSilosExt::silo_view`]
     ///
     ///[`ClientSilosExt::silo_view`]: super::ClientSilosExt::silo_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SiloView<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -16337,7 +16338,7 @@ pub mod builder {
     ///Builder for [`ClientSilosExt::silo_delete`]
     ///
     ///[`ClientSilosExt::silo_delete`]: super::ClientSilosExt::silo_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SiloDelete<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -16389,7 +16390,7 @@ pub mod builder {
     ///Builder for [`ClientSilosExt::silo_identity_provider_list`]
     ///
     ///[`ClientSilosExt::silo_identity_provider_list`]: super::ClientSilosExt::silo_identity_provider_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SiloIdentityProviderList<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -16547,7 +16548,7 @@ pub mod builder {
     ///Builder for [`ClientSilosExt::silo_policy_view`]
     ///
     ///[`ClientSilosExt::silo_policy_view`]: super::ClientSilosExt::silo_policy_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SiloPolicyView<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -16601,7 +16602,7 @@ pub mod builder {
     ///Builder for [`ClientSilosExt::silo_policy_update`]
     ///
     ///[`ClientSilosExt::silo_policy_update`]: super::ClientSilosExt::silo_policy_update
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SiloPolicyUpdate<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -16672,7 +16673,7 @@ pub mod builder {
     ///Builder for [`ClientSilosExt::silo_identity_provider_create`]
     ///
     ///[`ClientSilosExt::silo_identity_provider_create`]: super::ClientSilosExt::silo_identity_provider_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SiloIdentityProviderCreate<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -16744,7 +16745,7 @@ pub mod builder {
     ///Builder for [`ClientSilosExt::silo_identity_provider_view`]
     ///
     ///[`ClientSilosExt::silo_identity_provider_view`]: super::ClientSilosExt::silo_identity_provider_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SiloIdentityProviderView<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -16817,7 +16818,7 @@ pub mod builder {
     ///Builder for [`ClientSystemExt::system_user_list`]
     ///
     ///[`ClientSystemExt::system_user_list`]: super::ClientSystemExt::system_user_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SystemUserList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -16956,7 +16957,7 @@ pub mod builder {
     ///Builder for [`ClientSystemExt::system_user_view`]
     ///
     ///[`ClientSystemExt::system_user_view`]: super::ClientSystemExt::system_user_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SystemUserView<'a> {
         client: &'a super::Client,
         user_name: Result<types::Name, String>,
@@ -17008,7 +17009,7 @@ pub mod builder {
     ///Builder for [`ClientMetricsExt::timeseries_schema_get`]
     ///
     ///[`ClientMetricsExt::timeseries_schema_get`]: super::ClientMetricsExt::timeseries_schema_get
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct TimeseriesSchemaGet<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -17130,7 +17131,7 @@ pub mod builder {
     ///Builder for [`ClientUpdatesExt::updates_refresh`]
     ///
     ///[`ClientUpdatesExt::updates_refresh`]: super::ClientUpdatesExt::updates_refresh
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct UpdatesRefresh<'a> {
         client: &'a super::Client,
     }
@@ -17163,7 +17164,7 @@ pub mod builder {
     ///Builder for [`ClientSilosExt::user_list`]
     ///
     ///[`ClientSilosExt::user_list`]: super::ClientSilosExt::user_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct UserList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,

--- a/progenitor-impl/tests/output/nexus-builder.out
+++ b/progenitor-impl/tests/output/nexus-builder.out
@@ -5335,7 +5335,7 @@ pub mod builder {
     ///Builder for [`Client::disk_view_by_id`]
     ///
     ///[`Client::disk_view_by_id`]: super::Client::disk_view_by_id
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct DiskViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5387,7 +5387,7 @@ pub mod builder {
     ///Builder for [`Client::image_global_view_by_id`]
     ///
     ///[`Client::image_global_view_by_id`]: super::Client::image_global_view_by_id
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ImageGlobalViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5439,7 +5439,7 @@ pub mod builder {
     ///Builder for [`Client::image_view_by_id`]
     ///
     ///[`Client::image_view_by_id`]: super::Client::image_view_by_id
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ImageViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5491,7 +5491,7 @@ pub mod builder {
     ///Builder for [`Client::instance_view_by_id`]
     ///
     ///[`Client::instance_view_by_id`]: super::Client::instance_view_by_id
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5543,7 +5543,7 @@ pub mod builder {
     ///Builder for [`Client::instance_network_interface_view_by_id`]
     ///
     ///[`Client::instance_network_interface_view_by_id`]: super::Client::instance_network_interface_view_by_id
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5597,7 +5597,7 @@ pub mod builder {
     ///Builder for [`Client::organization_view_by_id`]
     ///
     ///[`Client::organization_view_by_id`]: super::Client::organization_view_by_id
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct OrganizationViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5649,7 +5649,7 @@ pub mod builder {
     ///Builder for [`Client::project_view_by_id`]
     ///
     ///[`Client::project_view_by_id`]: super::Client::project_view_by_id
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ProjectViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5701,7 +5701,7 @@ pub mod builder {
     ///Builder for [`Client::snapshot_view_by_id`]
     ///
     ///[`Client::snapshot_view_by_id`]: super::Client::snapshot_view_by_id
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SnapshotViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5753,7 +5753,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_router_route_view_by_id`]
     ///
     ///[`Client::vpc_router_route_view_by_id`]: super::Client::vpc_router_route_view_by_id
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcRouterRouteViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5805,7 +5805,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_router_view_by_id`]
     ///
     ///[`Client::vpc_router_view_by_id`]: super::Client::vpc_router_view_by_id
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcRouterViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5857,7 +5857,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_subnet_view_by_id`]
     ///
     ///[`Client::vpc_subnet_view_by_id`]: super::Client::vpc_subnet_view_by_id
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcSubnetViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5909,7 +5909,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_view_by_id`]
     ///
     ///[`Client::vpc_view_by_id`]: super::Client::vpc_view_by_id
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5961,7 +5961,7 @@ pub mod builder {
     ///Builder for [`Client::device_auth_request`]
     ///
     ///[`Client::device_auth_request`]: super::Client::device_auth_request
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct DeviceAuthRequest<'a> {
         client: &'a super::Client,
         body: Result<types::DeviceAuthRequest, String>,
@@ -6003,7 +6003,7 @@ pub mod builder {
     ///Builder for [`Client::device_auth_confirm`]
     ///
     ///[`Client::device_auth_confirm`]: super::Client::device_auth_confirm
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct DeviceAuthConfirm<'a> {
         client: &'a super::Client,
         body: Result<types::DeviceAuthVerify, String>,
@@ -6051,7 +6051,7 @@ pub mod builder {
     ///Builder for [`Client::device_access_token`]
     ///
     ///[`Client::device_access_token`]: super::Client::device_access_token
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct DeviceAccessToken<'a> {
         client: &'a super::Client,
         body: Result<types::DeviceAccessTokenRequest, String>,
@@ -6093,7 +6093,7 @@ pub mod builder {
     ///Builder for [`Client::rack_list`]
     ///
     ///[`Client::rack_list`]: super::Client::rack_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct RackList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -6232,7 +6232,7 @@ pub mod builder {
     ///Builder for [`Client::rack_view`]
     ///
     ///[`Client::rack_view`]: super::Client::rack_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct RackView<'a> {
         client: &'a super::Client,
         rack_id: Result<uuid::Uuid, String>,
@@ -6284,7 +6284,7 @@ pub mod builder {
     ///Builder for [`Client::sled_list`]
     ///
     ///[`Client::sled_list`]: super::Client::sled_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SledList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -6423,7 +6423,7 @@ pub mod builder {
     ///Builder for [`Client::sled_view`]
     ///
     ///[`Client::sled_view`]: super::Client::sled_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SledView<'a> {
         client: &'a super::Client,
         sled_id: Result<uuid::Uuid, String>,
@@ -6475,7 +6475,7 @@ pub mod builder {
     ///Builder for [`Client::image_global_list`]
     ///
     ///[`Client::image_global_list`]: super::Client::image_global_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ImageGlobalList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -6614,7 +6614,7 @@ pub mod builder {
     ///Builder for [`Client::image_global_create`]
     ///
     ///[`Client::image_global_create`]: super::Client::image_global_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ImageGlobalCreate<'a> {
         client: &'a super::Client,
         body: Result<types::GlobalImageCreate, String>,
@@ -6662,7 +6662,7 @@ pub mod builder {
     ///Builder for [`Client::image_global_view`]
     ///
     ///[`Client::image_global_view`]: super::Client::image_global_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ImageGlobalView<'a> {
         client: &'a super::Client,
         image_name: Result<types::Name, String>,
@@ -6714,7 +6714,7 @@ pub mod builder {
     ///Builder for [`Client::image_global_delete`]
     ///
     ///[`Client::image_global_delete`]: super::Client::image_global_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ImageGlobalDelete<'a> {
         client: &'a super::Client,
         image_name: Result<types::Name, String>,
@@ -6766,7 +6766,7 @@ pub mod builder {
     ///Builder for [`Client::ip_pool_list`]
     ///
     ///[`Client::ip_pool_list`]: super::Client::ip_pool_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct IpPoolList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -6905,7 +6905,7 @@ pub mod builder {
     ///Builder for [`Client::ip_pool_create`]
     ///
     ///[`Client::ip_pool_create`]: super::Client::ip_pool_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct IpPoolCreate<'a> {
         client: &'a super::Client,
         body: Result<types::IpPoolCreate, String>,
@@ -6953,7 +6953,7 @@ pub mod builder {
     ///Builder for [`Client::ip_pool_view`]
     ///
     ///[`Client::ip_pool_view`]: super::Client::ip_pool_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct IpPoolView<'a> {
         client: &'a super::Client,
         pool_name: Result<types::Name, String>,
@@ -7005,7 +7005,7 @@ pub mod builder {
     ///Builder for [`Client::ip_pool_update`]
     ///
     ///[`Client::ip_pool_update`]: super::Client::ip_pool_update
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct IpPoolUpdate<'a> {
         client: &'a super::Client,
         pool_name: Result<types::Name, String>,
@@ -7074,7 +7074,7 @@ pub mod builder {
     ///Builder for [`Client::ip_pool_delete`]
     ///
     ///[`Client::ip_pool_delete`]: super::Client::ip_pool_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct IpPoolDelete<'a> {
         client: &'a super::Client,
         pool_name: Result<types::Name, String>,
@@ -7126,7 +7126,7 @@ pub mod builder {
     ///Builder for [`Client::ip_pool_range_list`]
     ///
     ///[`Client::ip_pool_range_list`]: super::Client::ip_pool_range_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct IpPoolRangeList<'a> {
         client: &'a super::Client,
         pool_name: Result<types::Name, String>,
@@ -7265,7 +7265,7 @@ pub mod builder {
     ///Builder for [`Client::ip_pool_range_add`]
     ///
     ///[`Client::ip_pool_range_add`]: super::Client::ip_pool_range_add
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct IpPoolRangeAdd<'a> {
         client: &'a super::Client,
         pool_name: Result<types::Name, String>,
@@ -7334,7 +7334,7 @@ pub mod builder {
     ///Builder for [`Client::ip_pool_range_remove`]
     ///
     ///[`Client::ip_pool_range_remove`]: super::Client::ip_pool_range_remove
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct IpPoolRangeRemove<'a> {
         client: &'a super::Client,
         pool_name: Result<types::Name, String>,
@@ -7403,7 +7403,7 @@ pub mod builder {
     ///Builder for [`Client::spoof_login`]
     ///
     ///[`Client::spoof_login`]: super::Client::spoof_login
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SpoofLogin<'a> {
         client: &'a super::Client,
         body: Result<types::SpoofLoginBody, String>,
@@ -7445,7 +7445,7 @@ pub mod builder {
     ///Builder for [`Client::login`]
     ///
     ///[`Client::login`]: super::Client::login
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct Login<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -7509,6 +7509,7 @@ pub mod builder {
     ///Builder for [`Client::consume_credentials`]
     ///
     ///[`Client::consume_credentials`]: super::Client::consume_credentials
+    #[derive(Debug)]
     pub struct ConsumeCredentials<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -7594,7 +7595,7 @@ pub mod builder {
     ///Builder for [`Client::logout`]
     ///
     ///[`Client::logout`]: super::Client::logout
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct Logout<'a> {
         client: &'a super::Client,
     }
@@ -7621,7 +7622,7 @@ pub mod builder {
     ///Builder for [`Client::organization_list`]
     ///
     ///[`Client::organization_list`]: super::Client::organization_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct OrganizationList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -7760,7 +7761,7 @@ pub mod builder {
     ///Builder for [`Client::organization_create`]
     ///
     ///[`Client::organization_create`]: super::Client::organization_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct OrganizationCreate<'a> {
         client: &'a super::Client,
         body: Result<types::OrganizationCreate, String>,
@@ -7808,7 +7809,7 @@ pub mod builder {
     ///Builder for [`Client::organization_view`]
     ///
     ///[`Client::organization_view`]: super::Client::organization_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct OrganizationView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -7863,7 +7864,7 @@ pub mod builder {
     ///Builder for [`Client::organization_update`]
     ///
     ///[`Client::organization_update`]: super::Client::organization_update
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct OrganizationUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -7932,7 +7933,7 @@ pub mod builder {
     ///Builder for [`Client::organization_delete`]
     ///
     ///[`Client::organization_delete`]: super::Client::organization_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct OrganizationDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -7987,7 +7988,7 @@ pub mod builder {
     ///Builder for [`Client::organization_policy_view`]
     ///
     ///[`Client::organization_policy_view`]: super::Client::organization_policy_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct OrganizationPolicyView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8044,7 +8045,7 @@ pub mod builder {
     ///Builder for [`Client::organization_policy_update`]
     ///
     ///[`Client::organization_policy_update`]: super::Client::organization_policy_update
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct OrganizationPolicyUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8115,7 +8116,7 @@ pub mod builder {
     ///Builder for [`Client::project_list`]
     ///
     ///[`Client::project_list`]: super::Client::project_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ProjectList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8274,7 +8275,7 @@ pub mod builder {
     ///Builder for [`Client::project_create`]
     ///
     ///[`Client::project_create`]: super::Client::project_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ProjectCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8344,7 +8345,7 @@ pub mod builder {
     ///Builder for [`Client::project_view`]
     ///
     ///[`Client::project_view`]: super::Client::project_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ProjectView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8415,7 +8416,7 @@ pub mod builder {
     ///Builder for [`Client::project_update`]
     ///
     ///[`Client::project_update`]: super::Client::project_update
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ProjectUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8500,7 +8501,7 @@ pub mod builder {
     ///Builder for [`Client::project_delete`]
     ///
     ///[`Client::project_delete`]: super::Client::project_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ProjectDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8571,7 +8572,7 @@ pub mod builder {
     ///Builder for [`Client::disk_list`]
     ///
     ///[`Client::disk_list`]: super::Client::disk_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct DiskList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8745,7 +8746,7 @@ pub mod builder {
     ///Builder for [`Client::disk_create`]
     ///
     ///[`Client::disk_create`]: super::Client::disk_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct DiskCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8830,7 +8831,7 @@ pub mod builder {
     ///Builder for [`Client::disk_view`]
     ///
     ///[`Client::disk_view`]: super::Client::disk_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct DiskView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8917,7 +8918,7 @@ pub mod builder {
     ///Builder for [`Client::disk_delete`]
     ///
     ///[`Client::disk_delete`]: super::Client::disk_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct DiskDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9004,7 +9005,7 @@ pub mod builder {
     ///Builder for [`Client::disk_metrics_list`]
     ///
     ///[`Client::disk_metrics_list`]: super::Client::disk_metrics_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct DiskMetricsList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9224,7 +9225,7 @@ pub mod builder {
     ///Builder for [`Client::image_list`]
     ///
     ///[`Client::image_list`]: super::Client::image_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ImageList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9398,7 +9399,7 @@ pub mod builder {
     ///Builder for [`Client::image_create`]
     ///
     ///[`Client::image_create`]: super::Client::image_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ImageCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9483,7 +9484,7 @@ pub mod builder {
     ///Builder for [`Client::image_view`]
     ///
     ///[`Client::image_view`]: super::Client::image_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ImageView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9570,7 +9571,7 @@ pub mod builder {
     ///Builder for [`Client::image_delete`]
     ///
     ///[`Client::image_delete`]: super::Client::image_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ImageDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9657,7 +9658,7 @@ pub mod builder {
     ///Builder for [`Client::instance_list`]
     ///
     ///[`Client::instance_list`]: super::Client::instance_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9833,7 +9834,7 @@ pub mod builder {
     ///Builder for [`Client::instance_create`]
     ///
     ///[`Client::instance_create`]: super::Client::instance_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9919,7 +9920,7 @@ pub mod builder {
     ///Builder for [`Client::instance_view`]
     ///
     ///[`Client::instance_view`]: super::Client::instance_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10006,7 +10007,7 @@ pub mod builder {
     ///Builder for [`Client::instance_delete`]
     ///
     ///[`Client::instance_delete`]: super::Client::instance_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10093,7 +10094,7 @@ pub mod builder {
     ///Builder for [`Client::instance_disk_list`]
     ///
     ///[`Client::instance_disk_list`]: super::Client::instance_disk_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceDiskList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10284,7 +10285,7 @@ pub mod builder {
     ///Builder for [`Client::instance_disk_attach`]
     ///
     ///[`Client::instance_disk_attach`]: super::Client::instance_disk_attach
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceDiskAttach<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10385,7 +10386,7 @@ pub mod builder {
     ///Builder for [`Client::instance_disk_detach`]
     ///
     ///[`Client::instance_disk_detach`]: super::Client::instance_disk_detach
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceDiskDetach<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10486,7 +10487,7 @@ pub mod builder {
     ///Builder for [`Client::instance_external_ip_list`]
     ///
     ///[`Client::instance_external_ip_list`]: super::Client::instance_external_ip_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceExternalIpList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10575,7 +10576,7 @@ pub mod builder {
     ///Builder for [`Client::instance_migrate`]
     ///
     ///[`Client::instance_migrate`]: super::Client::instance_migrate
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceMigrate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10676,7 +10677,7 @@ pub mod builder {
     ///Builder for [`Client::instance_network_interface_list`]
     ///
     ///[`Client::instance_network_interface_list`]: super::Client::instance_network_interface_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10868,7 +10869,7 @@ pub mod builder {
     ///Builder for [`Client::instance_network_interface_create`]
     ///
     ///[`Client::instance_network_interface_create`]: super::Client::instance_network_interface_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10971,7 +10972,7 @@ pub mod builder {
     ///Builder for [`Client::instance_network_interface_view`]
     ///
     ///[`Client::instance_network_interface_view`]: super::Client::instance_network_interface_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11075,7 +11076,7 @@ pub mod builder {
     ///Builder for [`Client::instance_network_interface_update`]
     ///
     ///[`Client::instance_network_interface_update`]: super::Client::instance_network_interface_update
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11193,7 +11194,7 @@ pub mod builder {
     ///Builder for [`Client::instance_network_interface_delete`]
     ///
     ///[`Client::instance_network_interface_delete`]: super::Client::instance_network_interface_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11295,7 +11296,7 @@ pub mod builder {
     ///Builder for [`Client::instance_reboot`]
     ///
     ///[`Client::instance_reboot`]: super::Client::instance_reboot
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceReboot<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11382,7 +11383,7 @@ pub mod builder {
     ///Builder for [`Client::instance_serial_console`]
     ///
     ///[`Client::instance_serial_console`]: super::Client::instance_serial_console
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceSerialConsole<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11526,7 +11527,7 @@ pub mod builder {
     ///Builder for [`Client::instance_start`]
     ///
     ///[`Client::instance_start`]: super::Client::instance_start
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceStart<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11613,7 +11614,7 @@ pub mod builder {
     ///Builder for [`Client::instance_stop`]
     ///
     ///[`Client::instance_stop`]: super::Client::instance_stop
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct InstanceStop<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11700,7 +11701,7 @@ pub mod builder {
     ///Builder for [`Client::project_policy_view`]
     ///
     ///[`Client::project_policy_view`]: super::Client::project_policy_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ProjectPolicyView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11773,7 +11774,7 @@ pub mod builder {
     ///Builder for [`Client::project_policy_update`]
     ///
     ///[`Client::project_policy_update`]: super::Client::project_policy_update
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct ProjectPolicyUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11860,7 +11861,7 @@ pub mod builder {
     ///Builder for [`Client::snapshot_list`]
     ///
     ///[`Client::snapshot_list`]: super::Client::snapshot_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SnapshotList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12036,7 +12037,7 @@ pub mod builder {
     ///Builder for [`Client::snapshot_create`]
     ///
     ///[`Client::snapshot_create`]: super::Client::snapshot_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SnapshotCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12122,7 +12123,7 @@ pub mod builder {
     ///Builder for [`Client::snapshot_view`]
     ///
     ///[`Client::snapshot_view`]: super::Client::snapshot_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SnapshotView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12209,7 +12210,7 @@ pub mod builder {
     ///Builder for [`Client::snapshot_delete`]
     ///
     ///[`Client::snapshot_delete`]: super::Client::snapshot_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SnapshotDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12296,7 +12297,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_list`]
     ///
     ///[`Client::vpc_list`]: super::Client::vpc_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12470,7 +12471,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_create`]
     ///
     ///[`Client::vpc_create`]: super::Client::vpc_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12555,7 +12556,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_view`]
     ///
     ///[`Client::vpc_view`]: super::Client::vpc_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12642,7 +12643,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_update`]
     ///
     ///[`Client::vpc_update`]: super::Client::vpc_update
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12743,7 +12744,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_delete`]
     ///
     ///[`Client::vpc_delete`]: super::Client::vpc_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12830,7 +12831,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_firewall_rules_view`]
     ///
     ///[`Client::vpc_firewall_rules_view`]: super::Client::vpc_firewall_rules_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcFirewallRulesView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12919,7 +12920,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_firewall_rules_update`]
     ///
     ///[`Client::vpc_firewall_rules_update`]: super::Client::vpc_firewall_rules_update
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcFirewallRulesUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13022,7 +13023,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_router_list`]
     ///
     ///[`Client::vpc_router_list`]: super::Client::vpc_router_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcRouterList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13213,7 +13214,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_router_create`]
     ///
     ///[`Client::vpc_router_create`]: super::Client::vpc_router_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcRouterCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13314,7 +13315,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_router_view`]
     ///
     ///[`Client::vpc_router_view`]: super::Client::vpc_router_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcRouterView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13416,7 +13417,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_router_update`]
     ///
     ///[`Client::vpc_router_update`]: super::Client::vpc_router_update
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcRouterUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13532,7 +13533,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_router_delete`]
     ///
     ///[`Client::vpc_router_delete`]: super::Client::vpc_router_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcRouterDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13634,7 +13635,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_router_route_list`]
     ///
     ///[`Client::vpc_router_route_list`]: super::Client::vpc_router_route_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcRouterRouteList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13840,7 +13841,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_router_route_create`]
     ///
     ///[`Client::vpc_router_route_create`]: super::Client::vpc_router_route_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcRouterRouteCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13956,7 +13957,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_router_route_view`]
     ///
     ///[`Client::vpc_router_route_view`]: super::Client::vpc_router_route_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcRouterRouteView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14073,7 +14074,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_router_route_update`]
     ///
     ///[`Client::vpc_router_route_update`]: super::Client::vpc_router_route_update
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcRouterRouteUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14204,7 +14205,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_router_route_delete`]
     ///
     ///[`Client::vpc_router_route_delete`]: super::Client::vpc_router_route_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcRouterRouteDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14321,7 +14322,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_subnet_list`]
     ///
     ///[`Client::vpc_subnet_list`]: super::Client::vpc_subnet_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcSubnetList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14512,7 +14513,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_subnet_create`]
     ///
     ///[`Client::vpc_subnet_create`]: super::Client::vpc_subnet_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcSubnetCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14613,7 +14614,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_subnet_view`]
     ///
     ///[`Client::vpc_subnet_view`]: super::Client::vpc_subnet_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcSubnetView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14715,7 +14716,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_subnet_update`]
     ///
     ///[`Client::vpc_subnet_update`]: super::Client::vpc_subnet_update
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcSubnetUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14831,7 +14832,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_subnet_delete`]
     ///
     ///[`Client::vpc_subnet_delete`]: super::Client::vpc_subnet_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcSubnetDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14933,7 +14934,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_subnet_list_network_interfaces`]
     ///
     ///[`Client::vpc_subnet_list_network_interfaces`]: super::Client::vpc_subnet_list_network_interfaces
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct VpcSubnetListNetworkInterfaces<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -15140,7 +15141,7 @@ pub mod builder {
     ///Builder for [`Client::policy_view`]
     ///
     ///[`Client::policy_view`]: super::Client::policy_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct PolicyView<'a> {
         client: &'a super::Client,
     }
@@ -15175,7 +15176,7 @@ pub mod builder {
     ///Builder for [`Client::policy_update`]
     ///
     ///[`Client::policy_update`]: super::Client::policy_update
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct PolicyUpdate<'a> {
         client: &'a super::Client,
         body: Result<types::FleetRolePolicy, String>,
@@ -15225,7 +15226,7 @@ pub mod builder {
     ///Builder for [`Client::role_list`]
     ///
     ///[`Client::role_list`]: super::Client::role_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct RoleList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -15346,7 +15347,7 @@ pub mod builder {
     ///Builder for [`Client::role_view`]
     ///
     ///[`Client::role_view`]: super::Client::role_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct RoleView<'a> {
         client: &'a super::Client,
         role_name: Result<String, String>,
@@ -15398,7 +15399,7 @@ pub mod builder {
     ///Builder for [`Client::saga_list`]
     ///
     ///[`Client::saga_list`]: super::Client::saga_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SagaList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -15537,7 +15538,7 @@ pub mod builder {
     ///Builder for [`Client::saga_view`]
     ///
     ///[`Client::saga_view`]: super::Client::saga_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SagaView<'a> {
         client: &'a super::Client,
         saga_id: Result<uuid::Uuid, String>,
@@ -15589,7 +15590,7 @@ pub mod builder {
     ///Builder for [`Client::session_me`]
     ///
     ///[`Client::session_me`]: super::Client::session_me
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SessionMe<'a> {
         client: &'a super::Client,
     }
@@ -15622,7 +15623,7 @@ pub mod builder {
     ///Builder for [`Client::session_sshkey_list`]
     ///
     ///[`Client::session_sshkey_list`]: super::Client::session_sshkey_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SessionSshkeyList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -15761,7 +15762,7 @@ pub mod builder {
     ///Builder for [`Client::session_sshkey_create`]
     ///
     ///[`Client::session_sshkey_create`]: super::Client::session_sshkey_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SessionSshkeyCreate<'a> {
         client: &'a super::Client,
         body: Result<types::SshKeyCreate, String>,
@@ -15809,7 +15810,7 @@ pub mod builder {
     ///Builder for [`Client::session_sshkey_view`]
     ///
     ///[`Client::session_sshkey_view`]: super::Client::session_sshkey_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SessionSshkeyView<'a> {
         client: &'a super::Client,
         ssh_key_name: Result<types::Name, String>,
@@ -15864,7 +15865,7 @@ pub mod builder {
     ///Builder for [`Client::session_sshkey_delete`]
     ///
     ///[`Client::session_sshkey_delete`]: super::Client::session_sshkey_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SessionSshkeyDelete<'a> {
         client: &'a super::Client,
         ssh_key_name: Result<types::Name, String>,
@@ -15919,7 +15920,7 @@ pub mod builder {
     ///Builder for [`Client::silo_list`]
     ///
     ///[`Client::silo_list`]: super::Client::silo_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SiloList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -16058,7 +16059,7 @@ pub mod builder {
     ///Builder for [`Client::silo_create`]
     ///
     ///[`Client::silo_create`]: super::Client::silo_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SiloCreate<'a> {
         client: &'a super::Client,
         body: Result<types::SiloCreate, String>,
@@ -16106,7 +16107,7 @@ pub mod builder {
     ///Builder for [`Client::silo_view`]
     ///
     ///[`Client::silo_view`]: super::Client::silo_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SiloView<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -16158,7 +16159,7 @@ pub mod builder {
     ///Builder for [`Client::silo_delete`]
     ///
     ///[`Client::silo_delete`]: super::Client::silo_delete
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SiloDelete<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -16210,7 +16211,7 @@ pub mod builder {
     ///Builder for [`Client::silo_identity_provider_list`]
     ///
     ///[`Client::silo_identity_provider_list`]: super::Client::silo_identity_provider_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SiloIdentityProviderList<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -16368,7 +16369,7 @@ pub mod builder {
     ///Builder for [`Client::silo_policy_view`]
     ///
     ///[`Client::silo_policy_view`]: super::Client::silo_policy_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SiloPolicyView<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -16422,7 +16423,7 @@ pub mod builder {
     ///Builder for [`Client::silo_policy_update`]
     ///
     ///[`Client::silo_policy_update`]: super::Client::silo_policy_update
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SiloPolicyUpdate<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -16493,7 +16494,7 @@ pub mod builder {
     ///Builder for [`Client::silo_identity_provider_create`]
     ///
     ///[`Client::silo_identity_provider_create`]: super::Client::silo_identity_provider_create
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SiloIdentityProviderCreate<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -16565,7 +16566,7 @@ pub mod builder {
     ///Builder for [`Client::silo_identity_provider_view`]
     ///
     ///[`Client::silo_identity_provider_view`]: super::Client::silo_identity_provider_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SiloIdentityProviderView<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -16638,7 +16639,7 @@ pub mod builder {
     ///Builder for [`Client::system_user_list`]
     ///
     ///[`Client::system_user_list`]: super::Client::system_user_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SystemUserList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -16777,7 +16778,7 @@ pub mod builder {
     ///Builder for [`Client::system_user_view`]
     ///
     ///[`Client::system_user_view`]: super::Client::system_user_view
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct SystemUserView<'a> {
         client: &'a super::Client,
         user_name: Result<types::Name, String>,
@@ -16829,7 +16830,7 @@ pub mod builder {
     ///Builder for [`Client::timeseries_schema_get`]
     ///
     ///[`Client::timeseries_schema_get`]: super::Client::timeseries_schema_get
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct TimeseriesSchemaGet<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -16951,7 +16952,7 @@ pub mod builder {
     ///Builder for [`Client::updates_refresh`]
     ///
     ///[`Client::updates_refresh`]: super::Client::updates_refresh
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct UpdatesRefresh<'a> {
         client: &'a super::Client,
     }
@@ -16984,7 +16985,7 @@ pub mod builder {
     ///Builder for [`Client::user_list`]
     ///
     ///[`Client::user_list`]: super::Client::user_list
-    #[derive(Clone, Debug)]
+    #[derive(Debug, Clone)]
     pub struct UserList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,

--- a/progenitor-impl/tests/output/nexus-builder.out
+++ b/progenitor-impl/tests/output/nexus-builder.out
@@ -2929,7 +2929,7 @@ pub mod types {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
@@ -5335,7 +5335,7 @@ pub mod builder {
     ///Builder for [`Client::disk_view_by_id`]
     ///
     ///[`Client::disk_view_by_id`]: super::Client::disk_view_by_id
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct DiskViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5387,7 +5387,7 @@ pub mod builder {
     ///Builder for [`Client::image_global_view_by_id`]
     ///
     ///[`Client::image_global_view_by_id`]: super::Client::image_global_view_by_id
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ImageGlobalViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5439,7 +5439,7 @@ pub mod builder {
     ///Builder for [`Client::image_view_by_id`]
     ///
     ///[`Client::image_view_by_id`]: super::Client::image_view_by_id
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ImageViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5491,7 +5491,7 @@ pub mod builder {
     ///Builder for [`Client::instance_view_by_id`]
     ///
     ///[`Client::instance_view_by_id`]: super::Client::instance_view_by_id
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5543,7 +5543,7 @@ pub mod builder {
     ///Builder for [`Client::instance_network_interface_view_by_id`]
     ///
     ///[`Client::instance_network_interface_view_by_id`]: super::Client::instance_network_interface_view_by_id
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceNetworkInterfaceViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5597,7 +5597,7 @@ pub mod builder {
     ///Builder for [`Client::organization_view_by_id`]
     ///
     ///[`Client::organization_view_by_id`]: super::Client::organization_view_by_id
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct OrganizationViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5649,7 +5649,7 @@ pub mod builder {
     ///Builder for [`Client::project_view_by_id`]
     ///
     ///[`Client::project_view_by_id`]: super::Client::project_view_by_id
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ProjectViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5701,7 +5701,7 @@ pub mod builder {
     ///Builder for [`Client::snapshot_view_by_id`]
     ///
     ///[`Client::snapshot_view_by_id`]: super::Client::snapshot_view_by_id
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SnapshotViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5753,7 +5753,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_router_route_view_by_id`]
     ///
     ///[`Client::vpc_router_route_view_by_id`]: super::Client::vpc_router_route_view_by_id
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcRouterRouteViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5805,7 +5805,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_router_view_by_id`]
     ///
     ///[`Client::vpc_router_view_by_id`]: super::Client::vpc_router_view_by_id
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcRouterViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5857,7 +5857,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_subnet_view_by_id`]
     ///
     ///[`Client::vpc_subnet_view_by_id`]: super::Client::vpc_subnet_view_by_id
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcSubnetViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5909,7 +5909,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_view_by_id`]
     ///
     ///[`Client::vpc_view_by_id`]: super::Client::vpc_view_by_id
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcViewById<'a> {
         client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
@@ -5961,7 +5961,7 @@ pub mod builder {
     ///Builder for [`Client::device_auth_request`]
     ///
     ///[`Client::device_auth_request`]: super::Client::device_auth_request
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct DeviceAuthRequest<'a> {
         client: &'a super::Client,
         body: Result<types::DeviceAuthRequest, String>,
@@ -6003,7 +6003,7 @@ pub mod builder {
     ///Builder for [`Client::device_auth_confirm`]
     ///
     ///[`Client::device_auth_confirm`]: super::Client::device_auth_confirm
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct DeviceAuthConfirm<'a> {
         client: &'a super::Client,
         body: Result<types::DeviceAuthVerify, String>,
@@ -6051,7 +6051,7 @@ pub mod builder {
     ///Builder for [`Client::device_access_token`]
     ///
     ///[`Client::device_access_token`]: super::Client::device_access_token
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct DeviceAccessToken<'a> {
         client: &'a super::Client,
         body: Result<types::DeviceAccessTokenRequest, String>,
@@ -6093,7 +6093,7 @@ pub mod builder {
     ///Builder for [`Client::rack_list`]
     ///
     ///[`Client::rack_list`]: super::Client::rack_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct RackList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -6232,7 +6232,7 @@ pub mod builder {
     ///Builder for [`Client::rack_view`]
     ///
     ///[`Client::rack_view`]: super::Client::rack_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct RackView<'a> {
         client: &'a super::Client,
         rack_id: Result<uuid::Uuid, String>,
@@ -6284,7 +6284,7 @@ pub mod builder {
     ///Builder for [`Client::sled_list`]
     ///
     ///[`Client::sled_list`]: super::Client::sled_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SledList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -6423,7 +6423,7 @@ pub mod builder {
     ///Builder for [`Client::sled_view`]
     ///
     ///[`Client::sled_view`]: super::Client::sled_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SledView<'a> {
         client: &'a super::Client,
         sled_id: Result<uuid::Uuid, String>,
@@ -6475,7 +6475,7 @@ pub mod builder {
     ///Builder for [`Client::image_global_list`]
     ///
     ///[`Client::image_global_list`]: super::Client::image_global_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ImageGlobalList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -6614,7 +6614,7 @@ pub mod builder {
     ///Builder for [`Client::image_global_create`]
     ///
     ///[`Client::image_global_create`]: super::Client::image_global_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ImageGlobalCreate<'a> {
         client: &'a super::Client,
         body: Result<types::GlobalImageCreate, String>,
@@ -6662,7 +6662,7 @@ pub mod builder {
     ///Builder for [`Client::image_global_view`]
     ///
     ///[`Client::image_global_view`]: super::Client::image_global_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ImageGlobalView<'a> {
         client: &'a super::Client,
         image_name: Result<types::Name, String>,
@@ -6714,7 +6714,7 @@ pub mod builder {
     ///Builder for [`Client::image_global_delete`]
     ///
     ///[`Client::image_global_delete`]: super::Client::image_global_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ImageGlobalDelete<'a> {
         client: &'a super::Client,
         image_name: Result<types::Name, String>,
@@ -6766,7 +6766,7 @@ pub mod builder {
     ///Builder for [`Client::ip_pool_list`]
     ///
     ///[`Client::ip_pool_list`]: super::Client::ip_pool_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct IpPoolList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -6905,7 +6905,7 @@ pub mod builder {
     ///Builder for [`Client::ip_pool_create`]
     ///
     ///[`Client::ip_pool_create`]: super::Client::ip_pool_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct IpPoolCreate<'a> {
         client: &'a super::Client,
         body: Result<types::IpPoolCreate, String>,
@@ -6953,7 +6953,7 @@ pub mod builder {
     ///Builder for [`Client::ip_pool_view`]
     ///
     ///[`Client::ip_pool_view`]: super::Client::ip_pool_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct IpPoolView<'a> {
         client: &'a super::Client,
         pool_name: Result<types::Name, String>,
@@ -7005,7 +7005,7 @@ pub mod builder {
     ///Builder for [`Client::ip_pool_update`]
     ///
     ///[`Client::ip_pool_update`]: super::Client::ip_pool_update
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct IpPoolUpdate<'a> {
         client: &'a super::Client,
         pool_name: Result<types::Name, String>,
@@ -7074,7 +7074,7 @@ pub mod builder {
     ///Builder for [`Client::ip_pool_delete`]
     ///
     ///[`Client::ip_pool_delete`]: super::Client::ip_pool_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct IpPoolDelete<'a> {
         client: &'a super::Client,
         pool_name: Result<types::Name, String>,
@@ -7126,7 +7126,7 @@ pub mod builder {
     ///Builder for [`Client::ip_pool_range_list`]
     ///
     ///[`Client::ip_pool_range_list`]: super::Client::ip_pool_range_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct IpPoolRangeList<'a> {
         client: &'a super::Client,
         pool_name: Result<types::Name, String>,
@@ -7265,7 +7265,7 @@ pub mod builder {
     ///Builder for [`Client::ip_pool_range_add`]
     ///
     ///[`Client::ip_pool_range_add`]: super::Client::ip_pool_range_add
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct IpPoolRangeAdd<'a> {
         client: &'a super::Client,
         pool_name: Result<types::Name, String>,
@@ -7334,7 +7334,7 @@ pub mod builder {
     ///Builder for [`Client::ip_pool_range_remove`]
     ///
     ///[`Client::ip_pool_range_remove`]: super::Client::ip_pool_range_remove
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct IpPoolRangeRemove<'a> {
         client: &'a super::Client,
         pool_name: Result<types::Name, String>,
@@ -7403,7 +7403,7 @@ pub mod builder {
     ///Builder for [`Client::spoof_login`]
     ///
     ///[`Client::spoof_login`]: super::Client::spoof_login
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SpoofLogin<'a> {
         client: &'a super::Client,
         body: Result<types::SpoofLoginBody, String>,
@@ -7445,7 +7445,7 @@ pub mod builder {
     ///Builder for [`Client::login`]
     ///
     ///[`Client::login`]: super::Client::login
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct Login<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -7594,7 +7594,7 @@ pub mod builder {
     ///Builder for [`Client::logout`]
     ///
     ///[`Client::logout`]: super::Client::logout
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct Logout<'a> {
         client: &'a super::Client,
     }
@@ -7621,7 +7621,7 @@ pub mod builder {
     ///Builder for [`Client::organization_list`]
     ///
     ///[`Client::organization_list`]: super::Client::organization_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct OrganizationList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -7760,7 +7760,7 @@ pub mod builder {
     ///Builder for [`Client::organization_create`]
     ///
     ///[`Client::organization_create`]: super::Client::organization_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct OrganizationCreate<'a> {
         client: &'a super::Client,
         body: Result<types::OrganizationCreate, String>,
@@ -7808,7 +7808,7 @@ pub mod builder {
     ///Builder for [`Client::organization_view`]
     ///
     ///[`Client::organization_view`]: super::Client::organization_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct OrganizationView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -7863,7 +7863,7 @@ pub mod builder {
     ///Builder for [`Client::organization_update`]
     ///
     ///[`Client::organization_update`]: super::Client::organization_update
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct OrganizationUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -7932,7 +7932,7 @@ pub mod builder {
     ///Builder for [`Client::organization_delete`]
     ///
     ///[`Client::organization_delete`]: super::Client::organization_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct OrganizationDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -7987,7 +7987,7 @@ pub mod builder {
     ///Builder for [`Client::organization_policy_view`]
     ///
     ///[`Client::organization_policy_view`]: super::Client::organization_policy_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct OrganizationPolicyView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8044,7 +8044,7 @@ pub mod builder {
     ///Builder for [`Client::organization_policy_update`]
     ///
     ///[`Client::organization_policy_update`]: super::Client::organization_policy_update
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct OrganizationPolicyUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8115,7 +8115,7 @@ pub mod builder {
     ///Builder for [`Client::project_list`]
     ///
     ///[`Client::project_list`]: super::Client::project_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ProjectList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8274,7 +8274,7 @@ pub mod builder {
     ///Builder for [`Client::project_create`]
     ///
     ///[`Client::project_create`]: super::Client::project_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ProjectCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8344,7 +8344,7 @@ pub mod builder {
     ///Builder for [`Client::project_view`]
     ///
     ///[`Client::project_view`]: super::Client::project_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ProjectView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8415,7 +8415,7 @@ pub mod builder {
     ///Builder for [`Client::project_update`]
     ///
     ///[`Client::project_update`]: super::Client::project_update
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ProjectUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8500,7 +8500,7 @@ pub mod builder {
     ///Builder for [`Client::project_delete`]
     ///
     ///[`Client::project_delete`]: super::Client::project_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ProjectDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8571,7 +8571,7 @@ pub mod builder {
     ///Builder for [`Client::disk_list`]
     ///
     ///[`Client::disk_list`]: super::Client::disk_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct DiskList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8745,7 +8745,7 @@ pub mod builder {
     ///Builder for [`Client::disk_create`]
     ///
     ///[`Client::disk_create`]: super::Client::disk_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct DiskCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8830,7 +8830,7 @@ pub mod builder {
     ///Builder for [`Client::disk_view`]
     ///
     ///[`Client::disk_view`]: super::Client::disk_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct DiskView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -8917,7 +8917,7 @@ pub mod builder {
     ///Builder for [`Client::disk_delete`]
     ///
     ///[`Client::disk_delete`]: super::Client::disk_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct DiskDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9004,7 +9004,7 @@ pub mod builder {
     ///Builder for [`Client::disk_metrics_list`]
     ///
     ///[`Client::disk_metrics_list`]: super::Client::disk_metrics_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct DiskMetricsList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9224,7 +9224,7 @@ pub mod builder {
     ///Builder for [`Client::image_list`]
     ///
     ///[`Client::image_list`]: super::Client::image_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ImageList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9398,7 +9398,7 @@ pub mod builder {
     ///Builder for [`Client::image_create`]
     ///
     ///[`Client::image_create`]: super::Client::image_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ImageCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9483,7 +9483,7 @@ pub mod builder {
     ///Builder for [`Client::image_view`]
     ///
     ///[`Client::image_view`]: super::Client::image_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ImageView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9570,7 +9570,7 @@ pub mod builder {
     ///Builder for [`Client::image_delete`]
     ///
     ///[`Client::image_delete`]: super::Client::image_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ImageDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9657,7 +9657,7 @@ pub mod builder {
     ///Builder for [`Client::instance_list`]
     ///
     ///[`Client::instance_list`]: super::Client::instance_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9833,7 +9833,7 @@ pub mod builder {
     ///Builder for [`Client::instance_create`]
     ///
     ///[`Client::instance_create`]: super::Client::instance_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -9919,7 +9919,7 @@ pub mod builder {
     ///Builder for [`Client::instance_view`]
     ///
     ///[`Client::instance_view`]: super::Client::instance_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10006,7 +10006,7 @@ pub mod builder {
     ///Builder for [`Client::instance_delete`]
     ///
     ///[`Client::instance_delete`]: super::Client::instance_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10093,7 +10093,7 @@ pub mod builder {
     ///Builder for [`Client::instance_disk_list`]
     ///
     ///[`Client::instance_disk_list`]: super::Client::instance_disk_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceDiskList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10284,7 +10284,7 @@ pub mod builder {
     ///Builder for [`Client::instance_disk_attach`]
     ///
     ///[`Client::instance_disk_attach`]: super::Client::instance_disk_attach
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceDiskAttach<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10385,7 +10385,7 @@ pub mod builder {
     ///Builder for [`Client::instance_disk_detach`]
     ///
     ///[`Client::instance_disk_detach`]: super::Client::instance_disk_detach
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceDiskDetach<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10486,7 +10486,7 @@ pub mod builder {
     ///Builder for [`Client::instance_external_ip_list`]
     ///
     ///[`Client::instance_external_ip_list`]: super::Client::instance_external_ip_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceExternalIpList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10575,7 +10575,7 @@ pub mod builder {
     ///Builder for [`Client::instance_migrate`]
     ///
     ///[`Client::instance_migrate`]: super::Client::instance_migrate
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceMigrate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10676,7 +10676,7 @@ pub mod builder {
     ///Builder for [`Client::instance_network_interface_list`]
     ///
     ///[`Client::instance_network_interface_list`]: super::Client::instance_network_interface_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceNetworkInterfaceList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10868,7 +10868,7 @@ pub mod builder {
     ///Builder for [`Client::instance_network_interface_create`]
     ///
     ///[`Client::instance_network_interface_create`]: super::Client::instance_network_interface_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceNetworkInterfaceCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -10971,7 +10971,7 @@ pub mod builder {
     ///Builder for [`Client::instance_network_interface_view`]
     ///
     ///[`Client::instance_network_interface_view`]: super::Client::instance_network_interface_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceNetworkInterfaceView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11075,7 +11075,7 @@ pub mod builder {
     ///Builder for [`Client::instance_network_interface_update`]
     ///
     ///[`Client::instance_network_interface_update`]: super::Client::instance_network_interface_update
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceNetworkInterfaceUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11193,7 +11193,7 @@ pub mod builder {
     ///Builder for [`Client::instance_network_interface_delete`]
     ///
     ///[`Client::instance_network_interface_delete`]: super::Client::instance_network_interface_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceNetworkInterfaceDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11295,7 +11295,7 @@ pub mod builder {
     ///Builder for [`Client::instance_reboot`]
     ///
     ///[`Client::instance_reboot`]: super::Client::instance_reboot
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceReboot<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11382,7 +11382,7 @@ pub mod builder {
     ///Builder for [`Client::instance_serial_console`]
     ///
     ///[`Client::instance_serial_console`]: super::Client::instance_serial_console
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceSerialConsole<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11526,7 +11526,7 @@ pub mod builder {
     ///Builder for [`Client::instance_start`]
     ///
     ///[`Client::instance_start`]: super::Client::instance_start
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceStart<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11613,7 +11613,7 @@ pub mod builder {
     ///Builder for [`Client::instance_stop`]
     ///
     ///[`Client::instance_stop`]: super::Client::instance_stop
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct InstanceStop<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11700,7 +11700,7 @@ pub mod builder {
     ///Builder for [`Client::project_policy_view`]
     ///
     ///[`Client::project_policy_view`]: super::Client::project_policy_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ProjectPolicyView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11773,7 +11773,7 @@ pub mod builder {
     ///Builder for [`Client::project_policy_update`]
     ///
     ///[`Client::project_policy_update`]: super::Client::project_policy_update
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct ProjectPolicyUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -11860,7 +11860,7 @@ pub mod builder {
     ///Builder for [`Client::snapshot_list`]
     ///
     ///[`Client::snapshot_list`]: super::Client::snapshot_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SnapshotList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12036,7 +12036,7 @@ pub mod builder {
     ///Builder for [`Client::snapshot_create`]
     ///
     ///[`Client::snapshot_create`]: super::Client::snapshot_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SnapshotCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12122,7 +12122,7 @@ pub mod builder {
     ///Builder for [`Client::snapshot_view`]
     ///
     ///[`Client::snapshot_view`]: super::Client::snapshot_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SnapshotView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12209,7 +12209,7 @@ pub mod builder {
     ///Builder for [`Client::snapshot_delete`]
     ///
     ///[`Client::snapshot_delete`]: super::Client::snapshot_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SnapshotDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12296,7 +12296,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_list`]
     ///
     ///[`Client::vpc_list`]: super::Client::vpc_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12470,7 +12470,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_create`]
     ///
     ///[`Client::vpc_create`]: super::Client::vpc_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12555,7 +12555,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_view`]
     ///
     ///[`Client::vpc_view`]: super::Client::vpc_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12642,7 +12642,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_update`]
     ///
     ///[`Client::vpc_update`]: super::Client::vpc_update
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12743,7 +12743,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_delete`]
     ///
     ///[`Client::vpc_delete`]: super::Client::vpc_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12830,7 +12830,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_firewall_rules_view`]
     ///
     ///[`Client::vpc_firewall_rules_view`]: super::Client::vpc_firewall_rules_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcFirewallRulesView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -12919,7 +12919,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_firewall_rules_update`]
     ///
     ///[`Client::vpc_firewall_rules_update`]: super::Client::vpc_firewall_rules_update
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcFirewallRulesUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13022,7 +13022,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_router_list`]
     ///
     ///[`Client::vpc_router_list`]: super::Client::vpc_router_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcRouterList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13213,7 +13213,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_router_create`]
     ///
     ///[`Client::vpc_router_create`]: super::Client::vpc_router_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcRouterCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13314,7 +13314,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_router_view`]
     ///
     ///[`Client::vpc_router_view`]: super::Client::vpc_router_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcRouterView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13416,7 +13416,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_router_update`]
     ///
     ///[`Client::vpc_router_update`]: super::Client::vpc_router_update
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcRouterUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13532,7 +13532,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_router_delete`]
     ///
     ///[`Client::vpc_router_delete`]: super::Client::vpc_router_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcRouterDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13634,7 +13634,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_router_route_list`]
     ///
     ///[`Client::vpc_router_route_list`]: super::Client::vpc_router_route_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcRouterRouteList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13840,7 +13840,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_router_route_create`]
     ///
     ///[`Client::vpc_router_route_create`]: super::Client::vpc_router_route_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcRouterRouteCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -13956,7 +13956,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_router_route_view`]
     ///
     ///[`Client::vpc_router_route_view`]: super::Client::vpc_router_route_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcRouterRouteView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14073,7 +14073,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_router_route_update`]
     ///
     ///[`Client::vpc_router_route_update`]: super::Client::vpc_router_route_update
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcRouterRouteUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14204,7 +14204,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_router_route_delete`]
     ///
     ///[`Client::vpc_router_route_delete`]: super::Client::vpc_router_route_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcRouterRouteDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14321,7 +14321,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_subnet_list`]
     ///
     ///[`Client::vpc_subnet_list`]: super::Client::vpc_subnet_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcSubnetList<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14512,7 +14512,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_subnet_create`]
     ///
     ///[`Client::vpc_subnet_create`]: super::Client::vpc_subnet_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcSubnetCreate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14613,7 +14613,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_subnet_view`]
     ///
     ///[`Client::vpc_subnet_view`]: super::Client::vpc_subnet_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcSubnetView<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14715,7 +14715,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_subnet_update`]
     ///
     ///[`Client::vpc_subnet_update`]: super::Client::vpc_subnet_update
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcSubnetUpdate<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14831,7 +14831,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_subnet_delete`]
     ///
     ///[`Client::vpc_subnet_delete`]: super::Client::vpc_subnet_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcSubnetDelete<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -14933,7 +14933,7 @@ pub mod builder {
     ///Builder for [`Client::vpc_subnet_list_network_interfaces`]
     ///
     ///[`Client::vpc_subnet_list_network_interfaces`]: super::Client::vpc_subnet_list_network_interfaces
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct VpcSubnetListNetworkInterfaces<'a> {
         client: &'a super::Client,
         organization_name: Result<types::Name, String>,
@@ -15140,7 +15140,7 @@ pub mod builder {
     ///Builder for [`Client::policy_view`]
     ///
     ///[`Client::policy_view`]: super::Client::policy_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct PolicyView<'a> {
         client: &'a super::Client,
     }
@@ -15175,7 +15175,7 @@ pub mod builder {
     ///Builder for [`Client::policy_update`]
     ///
     ///[`Client::policy_update`]: super::Client::policy_update
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct PolicyUpdate<'a> {
         client: &'a super::Client,
         body: Result<types::FleetRolePolicy, String>,
@@ -15225,7 +15225,7 @@ pub mod builder {
     ///Builder for [`Client::role_list`]
     ///
     ///[`Client::role_list`]: super::Client::role_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct RoleList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -15346,7 +15346,7 @@ pub mod builder {
     ///Builder for [`Client::role_view`]
     ///
     ///[`Client::role_view`]: super::Client::role_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct RoleView<'a> {
         client: &'a super::Client,
         role_name: Result<String, String>,
@@ -15398,7 +15398,7 @@ pub mod builder {
     ///Builder for [`Client::saga_list`]
     ///
     ///[`Client::saga_list`]: super::Client::saga_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SagaList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -15537,7 +15537,7 @@ pub mod builder {
     ///Builder for [`Client::saga_view`]
     ///
     ///[`Client::saga_view`]: super::Client::saga_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SagaView<'a> {
         client: &'a super::Client,
         saga_id: Result<uuid::Uuid, String>,
@@ -15589,7 +15589,7 @@ pub mod builder {
     ///Builder for [`Client::session_me`]
     ///
     ///[`Client::session_me`]: super::Client::session_me
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SessionMe<'a> {
         client: &'a super::Client,
     }
@@ -15622,7 +15622,7 @@ pub mod builder {
     ///Builder for [`Client::session_sshkey_list`]
     ///
     ///[`Client::session_sshkey_list`]: super::Client::session_sshkey_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SessionSshkeyList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -15761,7 +15761,7 @@ pub mod builder {
     ///Builder for [`Client::session_sshkey_create`]
     ///
     ///[`Client::session_sshkey_create`]: super::Client::session_sshkey_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SessionSshkeyCreate<'a> {
         client: &'a super::Client,
         body: Result<types::SshKeyCreate, String>,
@@ -15809,7 +15809,7 @@ pub mod builder {
     ///Builder for [`Client::session_sshkey_view`]
     ///
     ///[`Client::session_sshkey_view`]: super::Client::session_sshkey_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SessionSshkeyView<'a> {
         client: &'a super::Client,
         ssh_key_name: Result<types::Name, String>,
@@ -15864,7 +15864,7 @@ pub mod builder {
     ///Builder for [`Client::session_sshkey_delete`]
     ///
     ///[`Client::session_sshkey_delete`]: super::Client::session_sshkey_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SessionSshkeyDelete<'a> {
         client: &'a super::Client,
         ssh_key_name: Result<types::Name, String>,
@@ -15919,7 +15919,7 @@ pub mod builder {
     ///Builder for [`Client::silo_list`]
     ///
     ///[`Client::silo_list`]: super::Client::silo_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SiloList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -16058,7 +16058,7 @@ pub mod builder {
     ///Builder for [`Client::silo_create`]
     ///
     ///[`Client::silo_create`]: super::Client::silo_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SiloCreate<'a> {
         client: &'a super::Client,
         body: Result<types::SiloCreate, String>,
@@ -16106,7 +16106,7 @@ pub mod builder {
     ///Builder for [`Client::silo_view`]
     ///
     ///[`Client::silo_view`]: super::Client::silo_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SiloView<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -16158,7 +16158,7 @@ pub mod builder {
     ///Builder for [`Client::silo_delete`]
     ///
     ///[`Client::silo_delete`]: super::Client::silo_delete
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SiloDelete<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -16210,7 +16210,7 @@ pub mod builder {
     ///Builder for [`Client::silo_identity_provider_list`]
     ///
     ///[`Client::silo_identity_provider_list`]: super::Client::silo_identity_provider_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SiloIdentityProviderList<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -16368,7 +16368,7 @@ pub mod builder {
     ///Builder for [`Client::silo_policy_view`]
     ///
     ///[`Client::silo_policy_view`]: super::Client::silo_policy_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SiloPolicyView<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -16422,7 +16422,7 @@ pub mod builder {
     ///Builder for [`Client::silo_policy_update`]
     ///
     ///[`Client::silo_policy_update`]: super::Client::silo_policy_update
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SiloPolicyUpdate<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -16493,7 +16493,7 @@ pub mod builder {
     ///Builder for [`Client::silo_identity_provider_create`]
     ///
     ///[`Client::silo_identity_provider_create`]: super::Client::silo_identity_provider_create
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SiloIdentityProviderCreate<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -16565,7 +16565,7 @@ pub mod builder {
     ///Builder for [`Client::silo_identity_provider_view`]
     ///
     ///[`Client::silo_identity_provider_view`]: super::Client::silo_identity_provider_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SiloIdentityProviderView<'a> {
         client: &'a super::Client,
         silo_name: Result<types::Name, String>,
@@ -16638,7 +16638,7 @@ pub mod builder {
     ///Builder for [`Client::system_user_list`]
     ///
     ///[`Client::system_user_list`]: super::Client::system_user_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SystemUserList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -16777,7 +16777,7 @@ pub mod builder {
     ///Builder for [`Client::system_user_view`]
     ///
     ///[`Client::system_user_view`]: super::Client::system_user_view
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct SystemUserView<'a> {
         client: &'a super::Client,
         user_name: Result<types::Name, String>,
@@ -16829,7 +16829,7 @@ pub mod builder {
     ///Builder for [`Client::timeseries_schema_get`]
     ///
     ///[`Client::timeseries_schema_get`]: super::Client::timeseries_schema_get
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct TimeseriesSchemaGet<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -16951,7 +16951,7 @@ pub mod builder {
     ///Builder for [`Client::updates_refresh`]
     ///
     ///[`Client::updates_refresh`]: super::Client::updates_refresh
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct UpdatesRefresh<'a> {
         client: &'a super::Client,
     }
@@ -16984,7 +16984,7 @@ pub mod builder {
     ///Builder for [`Client::user_list`]
     ///
     ///[`Client::user_list`]: super::Client::user_list
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct UserList<'a> {
         client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,

--- a/progenitor-impl/tests/output/nexus-positional.out
+++ b/progenitor-impl/tests/output/nexus-positional.out
@@ -2885,7 +2885,7 @@ pub mod types {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,

--- a/progenitor-impl/tests/output/test_default_params.out
+++ b/progenitor-impl/tests/output/test_default_params.out
@@ -34,7 +34,7 @@ pub mod types {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,

--- a/progenitor-impl/tests/output/test_freeform_response.out
+++ b/progenitor-impl/tests/output/test_freeform_response.out
@@ -15,7 +15,7 @@ pub mod types {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,

--- a/progenitor-impl/tests/output/test_renamed_parameters.out
+++ b/progenitor-impl/tests/output/test_renamed_parameters.out
@@ -15,7 +15,7 @@ pub mod types {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,


### PR DESCRIPTION
In order to get a verbose mode working in the CLI, all client types need to derive `Debug`.

I'm not sure this is the approach you're looking for @ahl , happy to change this PR if it's not.