### PR TITLE
feat: support header parameters

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,6 +15,8 @@
 
 https://github.com/oxidecomputer/progenitor/compare/v0.2.0\...HEAD[Full list of commits]
 
+* Add support for header parameters (#210)
+
 == 0.2.0 (released 2022-09-11)
 
 https://github.com/oxidecomputer/progenitor/compare/v0.1.1\...v0.2.0[Full list of commits]

--- a/example-build/src/main.rs
+++ b/example-build/src/main.rs
@@ -5,8 +5,11 @@ include!(concat!(env!("OUT_DIR"), "/codegen.rs"));
 
 fn main() {
     let client = Client::new("https://foo/bar");
-    let _ = client.enrol(&types::EnrolBody {
-        host: "".to_string(),
-        key: "".to_string(),
-    });
+    let _ = client.enrol(
+        "auth-token",
+        &types::EnrolBody {
+            host: "".to_string(),
+            key: "".to_string(),
+        },
+    );
 }

--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -286,6 +286,12 @@ impl<E> From<reqwest::Error> for Error<E> {
     }
 }
 
+impl<E> From<reqwest::header::InvalidHeaderValue> for Error<E> {
+    fn from(e: reqwest::header::InvalidHeaderValue) -> Self {
+        Self::InvalidRequest(e.to_string())
+    }
+}
+
 impl<E> std::fmt::Display for Error<E>
 where
     ResponseValue<E>: ErrorFormat,

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -261,6 +261,8 @@ impl Generator {
             pub use progenitor_client::{ByteStream, Error, ResponseValue};
             #[allow(unused_imports)]
             use progenitor_client::{encode_path, RequestBuilderExt};
+            #[allow(unused_imports)]
+            use reqwest::header::{HeaderMap, HeaderValue};
 
             pub mod types {
                 use serde::{Deserialize, Serialize};
@@ -366,6 +368,8 @@ impl Generator {
                     encode_path,
                     ByteStream,
                     Error,
+                    HeaderMap,
+                    HeaderValue,
                     RequestBuilderExt,
                     ResponseValue,
                 };
@@ -403,6 +407,8 @@ impl Generator {
                     encode_path,
                     ByteStream,
                     Error,
+                    HeaderMap,
+                    HeaderValue,
                     RequestBuilderExt,
                     ResponseValue,
                 };

--- a/progenitor-impl/tests/output/buildomat-builder-tagged.out
+++ b/progenitor-impl/tests/output/buildomat-builder-tagged.out
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
+#[allow(unused_imports)]
+use reqwest::header::{HeaderMap, HeaderValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -1500,7 +1502,9 @@ impl Client {
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]
-    use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    use super::{
+        encode_path, ByteStream, Error, HeaderMap, HeaderValue, RequestBuilderExt, ResponseValue,
+    };
     ///Builder for [`Client::control_hold`]
     ///
     ///[`Client::control_hold`]: super::Client::control_hold
@@ -1724,7 +1728,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(1usize);
             if let Some(v) = &minseq {
                 query.push(("minseq", v.to_string()));
             }

--- a/progenitor-impl/tests/output/buildomat-builder.out
+++ b/progenitor-impl/tests/output/buildomat-builder.out
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
+#[allow(unused_imports)]
+use reqwest::header::{HeaderMap, HeaderValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -1500,7 +1502,9 @@ impl Client {
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]
-    use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    use super::{
+        encode_path, ByteStream, Error, HeaderMap, HeaderValue, RequestBuilderExt, ResponseValue,
+    };
     ///Builder for [`Client::control_hold`]
     ///
     ///[`Client::control_hold`]: super::Client::control_hold
@@ -1724,7 +1728,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(1usize);
             if let Some(v) = &minseq {
                 query.push(("minseq", v.to_string()));
             }

--- a/progenitor-impl/tests/output/buildomat-positional.out
+++ b/progenitor-impl/tests/output/buildomat-positional.out
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
+#[allow(unused_imports)]
+use reqwest::header::{HeaderMap, HeaderValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -249,7 +251,7 @@ impl Client {
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(1usize);
         if let Some(v) = &minseq {
             query.push(("minseq", v.to_string()));
         }

--- a/progenitor-impl/tests/output/keeper-builder-tagged.out
+++ b/progenitor-impl/tests/output/keeper-builder-tagged.out
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
+#[allow(unused_imports)]
+use reqwest::header::{HeaderMap, HeaderValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -762,8 +764,14 @@ impl Client {
 
 impl Client {
     ///Sends a `POST` request to `/enrol`
+    ///
+    ///Arguments:
+    /// - `authorization`: Authorization header (bearer token)
+    /// - `body`
+    ///
     ///```ignore
     /// let response = client.enrol()
+    ///    .authorization(authorization)
     ///    .body(body)
     ///    .send()
     ///    .await;
@@ -773,8 +781,13 @@ impl Client {
     }
 
     ///Sends a `GET` request to `/global/jobs`
+    ///
+    ///Arguments:
+    /// - `authorization`: Authorization header (bearer token)
+    ///
     ///```ignore
     /// let response = client.global_jobs()
+    ///    .authorization(authorization)
     ///    .send()
     ///    .await;
     /// ```
@@ -783,8 +796,13 @@ impl Client {
     }
 
     ///Sends a `GET` request to `/ping`
+    ///
+    ///Arguments:
+    /// - `authorization`: Authorization header (bearer token)
+    ///
     ///```ignore
     /// let response = client.ping()
+    ///    .authorization(authorization)
     ///    .send()
     ///    .await;
     /// ```
@@ -793,8 +811,14 @@ impl Client {
     }
 
     ///Sends a `POST` request to `/report/finish`
+    ///
+    ///Arguments:
+    /// - `authorization`: Authorization header (bearer token)
+    /// - `body`
+    ///
     ///```ignore
     /// let response = client.report_finish()
+    ///    .authorization(authorization)
     ///    .body(body)
     ///    .send()
     ///    .await;
@@ -804,8 +828,14 @@ impl Client {
     }
 
     ///Sends a `POST` request to `/report/output`
+    ///
+    ///Arguments:
+    /// - `authorization`: Authorization header (bearer token)
+    /// - `body`
+    ///
     ///```ignore
     /// let response = client.report_output()
+    ///    .authorization(authorization)
     ///    .body(body)
     ///    .send()
     ///    .await;
@@ -815,8 +845,14 @@ impl Client {
     }
 
     ///Sends a `POST` request to `/report/start`
+    ///
+    ///Arguments:
+    /// - `authorization`: Authorization header (bearer token)
+    /// - `body`
+    ///
     ///```ignore
     /// let response = client.report_start()
+    ///    .authorization(authorization)
     ///    .body(body)
     ///    .send()
     ///    .await;
@@ -829,13 +865,16 @@ impl Client {
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]
-    use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    use super::{
+        encode_path, ByteStream, Error, HeaderMap, HeaderValue, RequestBuilderExt, ResponseValue,
+    };
     ///Builder for [`Client::enrol`]
     ///
     ///[`Client::enrol`]: super::Client::enrol
     #[derive(Debug, Clone)]
     pub struct Enrol<'a> {
         client: &'a super::Client,
+        authorization: Result<String, String>,
         body: Result<types::EnrolBody, String>,
     }
 
@@ -843,8 +882,19 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
+                authorization: Err("authorization was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
+        }
+
+        pub fn authorization<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<String>,
+        {
+            self.authorization = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for authorization failed".to_string());
+            self
         }
 
         pub fn body<V>(mut self, value: V) -> Self
@@ -859,10 +909,22 @@ pub mod builder {
 
         ///Sends a `POST` request to `/enrol`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self { client, body } = self;
+            let Self {
+                client,
+                authorization,
+                body,
+            } = self;
+            let authorization = authorization.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/enrol", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let mut header_map = HeaderMap::with_capacity(1usize);
+            header_map.append("Authorization", HeaderValue::try_from(authorization)?);
+            let request = client
+                .client
+                .post(url)
+                .json(&body)
+                .headers(header_map)
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -878,18 +940,38 @@ pub mod builder {
     #[derive(Debug, Clone)]
     pub struct GlobalJobs<'a> {
         client: &'a super::Client,
+        authorization: Result<String, String>,
     }
 
     impl<'a> GlobalJobs<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                client,
+                authorization: Err("authorization was not initialized".to_string()),
+            }
+        }
+
+        pub fn authorization<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<String>,
+        {
+            self.authorization = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for authorization failed".to_string());
+            self
         }
 
         ///Sends a `GET` request to `/global/jobs`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalJobsResult>, Error<()>> {
-            let Self { client } = self;
+            let Self {
+                client,
+                authorization,
+            } = self;
+            let authorization = authorization.map_err(Error::InvalidRequest)?;
             let url = format!("{}/global/jobs", client.baseurl,);
-            let request = client.client.get(url).build()?;
+            let mut header_map = HeaderMap::with_capacity(1usize);
+            header_map.append("Authorization", HeaderValue::try_from(authorization)?);
+            let request = client.client.get(url).headers(header_map).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -905,18 +987,38 @@ pub mod builder {
     #[derive(Debug, Clone)]
     pub struct Ping<'a> {
         client: &'a super::Client,
+        authorization: Result<String, String>,
     }
 
     impl<'a> Ping<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                client,
+                authorization: Err("authorization was not initialized".to_string()),
+            }
+        }
+
+        pub fn authorization<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<String>,
+        {
+            self.authorization = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for authorization failed".to_string());
+            self
         }
 
         ///Sends a `GET` request to `/ping`
         pub async fn send(self) -> Result<ResponseValue<types::PingResult>, Error<()>> {
-            let Self { client } = self;
+            let Self {
+                client,
+                authorization,
+            } = self;
+            let authorization = authorization.map_err(Error::InvalidRequest)?;
             let url = format!("{}/ping", client.baseurl,);
-            let request = client.client.get(url).build()?;
+            let mut header_map = HeaderMap::with_capacity(1usize);
+            header_map.append("Authorization", HeaderValue::try_from(authorization)?);
+            let request = client.client.get(url).headers(header_map).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -932,6 +1034,7 @@ pub mod builder {
     #[derive(Debug, Clone)]
     pub struct ReportFinish<'a> {
         client: &'a super::Client,
+        authorization: Result<String, String>,
         body: Result<types::ReportFinishBody, String>,
     }
 
@@ -939,8 +1042,19 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
+                authorization: Err("authorization was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
+        }
+
+        pub fn authorization<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<String>,
+        {
+            self.authorization = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for authorization failed".to_string());
+            self
         }
 
         pub fn body<V>(mut self, value: V) -> Self
@@ -955,10 +1069,22 @@ pub mod builder {
 
         ///Sends a `POST` request to `/report/finish`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
-            let Self { client, body } = self;
+            let Self {
+                client,
+                authorization,
+                body,
+            } = self;
+            let authorization = authorization.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/report/finish", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let mut header_map = HeaderMap::with_capacity(1usize);
+            header_map.append("Authorization", HeaderValue::try_from(authorization)?);
+            let request = client
+                .client
+                .post(url)
+                .json(&body)
+                .headers(header_map)
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -974,6 +1100,7 @@ pub mod builder {
     #[derive(Debug, Clone)]
     pub struct ReportOutput<'a> {
         client: &'a super::Client,
+        authorization: Result<String, String>,
         body: Result<types::ReportOutputBody, String>,
     }
 
@@ -981,8 +1108,19 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
+                authorization: Err("authorization was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
+        }
+
+        pub fn authorization<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<String>,
+        {
+            self.authorization = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for authorization failed".to_string());
+            self
         }
 
         pub fn body<V>(mut self, value: V) -> Self
@@ -997,10 +1135,22 @@ pub mod builder {
 
         ///Sends a `POST` request to `/report/output`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
-            let Self { client, body } = self;
+            let Self {
+                client,
+                authorization,
+                body,
+            } = self;
+            let authorization = authorization.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/report/output", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let mut header_map = HeaderMap::with_capacity(1usize);
+            header_map.append("Authorization", HeaderValue::try_from(authorization)?);
+            let request = client
+                .client
+                .post(url)
+                .json(&body)
+                .headers(header_map)
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1016,6 +1166,7 @@ pub mod builder {
     #[derive(Debug, Clone)]
     pub struct ReportStart<'a> {
         client: &'a super::Client,
+        authorization: Result<String, String>,
         body: Result<types::ReportStartBody, String>,
     }
 
@@ -1023,8 +1174,19 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
+                authorization: Err("authorization was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
+        }
+
+        pub fn authorization<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<String>,
+        {
+            self.authorization = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for authorization failed".to_string());
+            self
         }
 
         pub fn body<V>(mut self, value: V) -> Self
@@ -1039,10 +1201,22 @@ pub mod builder {
 
         ///Sends a `POST` request to `/report/start`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
-            let Self { client, body } = self;
+            let Self {
+                client,
+                authorization,
+                body,
+            } = self;
+            let authorization = authorization.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/report/start", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let mut header_map = HeaderMap::with_capacity(1usize);
+            header_map.append("Authorization", HeaderValue::try_from(authorization)?);
+            let request = client
+                .client
+                .post(url)
+                .json(&body)
+                .headers(header_map)
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {

--- a/progenitor-impl/tests/output/keeper-builder.out
+++ b/progenitor-impl/tests/output/keeper-builder.out
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
+#[allow(unused_imports)]
+use reqwest::header::{HeaderMap, HeaderValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -762,8 +764,14 @@ impl Client {
 
 impl Client {
     ///Sends a `POST` request to `/enrol`
+    ///
+    ///Arguments:
+    /// - `authorization`: Authorization header (bearer token)
+    /// - `body`
+    ///
     ///```ignore
     /// let response = client.enrol()
+    ///    .authorization(authorization)
     ///    .body(body)
     ///    .send()
     ///    .await;
@@ -773,8 +781,13 @@ impl Client {
     }
 
     ///Sends a `GET` request to `/global/jobs`
+    ///
+    ///Arguments:
+    /// - `authorization`: Authorization header (bearer token)
+    ///
     ///```ignore
     /// let response = client.global_jobs()
+    ///    .authorization(authorization)
     ///    .send()
     ///    .await;
     /// ```
@@ -783,8 +796,13 @@ impl Client {
     }
 
     ///Sends a `GET` request to `/ping`
+    ///
+    ///Arguments:
+    /// - `authorization`: Authorization header (bearer token)
+    ///
     ///```ignore
     /// let response = client.ping()
+    ///    .authorization(authorization)
     ///    .send()
     ///    .await;
     /// ```
@@ -793,8 +811,14 @@ impl Client {
     }
 
     ///Sends a `POST` request to `/report/finish`
+    ///
+    ///Arguments:
+    /// - `authorization`: Authorization header (bearer token)
+    /// - `body`
+    ///
     ///```ignore
     /// let response = client.report_finish()
+    ///    .authorization(authorization)
     ///    .body(body)
     ///    .send()
     ///    .await;
@@ -804,8 +828,14 @@ impl Client {
     }
 
     ///Sends a `POST` request to `/report/output`
+    ///
+    ///Arguments:
+    /// - `authorization`: Authorization header (bearer token)
+    /// - `body`
+    ///
     ///```ignore
     /// let response = client.report_output()
+    ///    .authorization(authorization)
     ///    .body(body)
     ///    .send()
     ///    .await;
@@ -815,8 +845,14 @@ impl Client {
     }
 
     ///Sends a `POST` request to `/report/start`
+    ///
+    ///Arguments:
+    /// - `authorization`: Authorization header (bearer token)
+    /// - `body`
+    ///
     ///```ignore
     /// let response = client.report_start()
+    ///    .authorization(authorization)
     ///    .body(body)
     ///    .send()
     ///    .await;
@@ -829,13 +865,16 @@ impl Client {
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]
-    use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    use super::{
+        encode_path, ByteStream, Error, HeaderMap, HeaderValue, RequestBuilderExt, ResponseValue,
+    };
     ///Builder for [`Client::enrol`]
     ///
     ///[`Client::enrol`]: super::Client::enrol
     #[derive(Debug, Clone)]
     pub struct Enrol<'a> {
         client: &'a super::Client,
+        authorization: Result<String, String>,
         body: Result<types::EnrolBody, String>,
     }
 
@@ -843,8 +882,19 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
+                authorization: Err("authorization was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
+        }
+
+        pub fn authorization<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<String>,
+        {
+            self.authorization = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for authorization failed".to_string());
+            self
         }
 
         pub fn body<V>(mut self, value: V) -> Self
@@ -859,10 +909,22 @@ pub mod builder {
 
         ///Sends a `POST` request to `/enrol`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self { client, body } = self;
+            let Self {
+                client,
+                authorization,
+                body,
+            } = self;
+            let authorization = authorization.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/enrol", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let mut header_map = HeaderMap::with_capacity(1usize);
+            header_map.append("Authorization", HeaderValue::try_from(authorization)?);
+            let request = client
+                .client
+                .post(url)
+                .json(&body)
+                .headers(header_map)
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -878,18 +940,38 @@ pub mod builder {
     #[derive(Debug, Clone)]
     pub struct GlobalJobs<'a> {
         client: &'a super::Client,
+        authorization: Result<String, String>,
     }
 
     impl<'a> GlobalJobs<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                client,
+                authorization: Err("authorization was not initialized".to_string()),
+            }
+        }
+
+        pub fn authorization<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<String>,
+        {
+            self.authorization = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for authorization failed".to_string());
+            self
         }
 
         ///Sends a `GET` request to `/global/jobs`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalJobsResult>, Error<()>> {
-            let Self { client } = self;
+            let Self {
+                client,
+                authorization,
+            } = self;
+            let authorization = authorization.map_err(Error::InvalidRequest)?;
             let url = format!("{}/global/jobs", client.baseurl,);
-            let request = client.client.get(url).build()?;
+            let mut header_map = HeaderMap::with_capacity(1usize);
+            header_map.append("Authorization", HeaderValue::try_from(authorization)?);
+            let request = client.client.get(url).headers(header_map).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -905,18 +987,38 @@ pub mod builder {
     #[derive(Debug, Clone)]
     pub struct Ping<'a> {
         client: &'a super::Client,
+        authorization: Result<String, String>,
     }
 
     impl<'a> Ping<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                client,
+                authorization: Err("authorization was not initialized".to_string()),
+            }
+        }
+
+        pub fn authorization<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<String>,
+        {
+            self.authorization = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for authorization failed".to_string());
+            self
         }
 
         ///Sends a `GET` request to `/ping`
         pub async fn send(self) -> Result<ResponseValue<types::PingResult>, Error<()>> {
-            let Self { client } = self;
+            let Self {
+                client,
+                authorization,
+            } = self;
+            let authorization = authorization.map_err(Error::InvalidRequest)?;
             let url = format!("{}/ping", client.baseurl,);
-            let request = client.client.get(url).build()?;
+            let mut header_map = HeaderMap::with_capacity(1usize);
+            header_map.append("Authorization", HeaderValue::try_from(authorization)?);
+            let request = client.client.get(url).headers(header_map).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -932,6 +1034,7 @@ pub mod builder {
     #[derive(Debug, Clone)]
     pub struct ReportFinish<'a> {
         client: &'a super::Client,
+        authorization: Result<String, String>,
         body: Result<types::ReportFinishBody, String>,
     }
 
@@ -939,8 +1042,19 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
+                authorization: Err("authorization was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
+        }
+
+        pub fn authorization<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<String>,
+        {
+            self.authorization = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for authorization failed".to_string());
+            self
         }
 
         pub fn body<V>(mut self, value: V) -> Self
@@ -955,10 +1069,22 @@ pub mod builder {
 
         ///Sends a `POST` request to `/report/finish`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
-            let Self { client, body } = self;
+            let Self {
+                client,
+                authorization,
+                body,
+            } = self;
+            let authorization = authorization.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/report/finish", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let mut header_map = HeaderMap::with_capacity(1usize);
+            header_map.append("Authorization", HeaderValue::try_from(authorization)?);
+            let request = client
+                .client
+                .post(url)
+                .json(&body)
+                .headers(header_map)
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -974,6 +1100,7 @@ pub mod builder {
     #[derive(Debug, Clone)]
     pub struct ReportOutput<'a> {
         client: &'a super::Client,
+        authorization: Result<String, String>,
         body: Result<types::ReportOutputBody, String>,
     }
 
@@ -981,8 +1108,19 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
+                authorization: Err("authorization was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
+        }
+
+        pub fn authorization<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<String>,
+        {
+            self.authorization = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for authorization failed".to_string());
+            self
         }
 
         pub fn body<V>(mut self, value: V) -> Self
@@ -997,10 +1135,22 @@ pub mod builder {
 
         ///Sends a `POST` request to `/report/output`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
-            let Self { client, body } = self;
+            let Self {
+                client,
+                authorization,
+                body,
+            } = self;
+            let authorization = authorization.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/report/output", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let mut header_map = HeaderMap::with_capacity(1usize);
+            header_map.append("Authorization", HeaderValue::try_from(authorization)?);
+            let request = client
+                .client
+                .post(url)
+                .json(&body)
+                .headers(header_map)
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1016,6 +1166,7 @@ pub mod builder {
     #[derive(Debug, Clone)]
     pub struct ReportStart<'a> {
         client: &'a super::Client,
+        authorization: Result<String, String>,
         body: Result<types::ReportStartBody, String>,
     }
 
@@ -1023,8 +1174,19 @@ pub mod builder {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
+                authorization: Err("authorization was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
+        }
+
+        pub fn authorization<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<String>,
+        {
+            self.authorization = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for authorization failed".to_string());
+            self
         }
 
         pub fn body<V>(mut self, value: V) -> Self
@@ -1039,10 +1201,22 @@ pub mod builder {
 
         ///Sends a `POST` request to `/report/start`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
-            let Self { client, body } = self;
+            let Self {
+                client,
+                authorization,
+                body,
+            } = self;
+            let authorization = authorization.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/report/start", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let mut header_map = HeaderMap::with_capacity(1usize);
+            header_map.append("Authorization", HeaderValue::try_from(authorization)?);
+            let request = client
+                .client
+                .post(url)
+                .json(&body)
+                .headers(header_map)
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {

--- a/progenitor-impl/tests/output/keeper-positional.out
+++ b/progenitor-impl/tests/output/keeper-positional.out
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
+#[allow(unused_imports)]
+use reqwest::header::{HeaderMap, HeaderValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -110,12 +112,24 @@ impl Client {
 
 impl Client {
     ///Sends a `POST` request to `/enrol`
+    ///
+    ///Arguments:
+    /// - `authorization`: Authorization header (bearer token)
+    /// - `body`
     pub async fn enrol<'a>(
         &'a self,
+        authorization: &'a str,
         body: &'a types::EnrolBody,
     ) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/enrol", self.baseurl,);
-        let request = self.client.post(url).json(&body).build()?;
+        let mut header_map = HeaderMap::with_capacity(1usize);
+        header_map.append("Authorization", HeaderValue::try_from(authorization)?);
+        let request = self
+            .client
+            .post(url)
+            .json(&body)
+            .headers(header_map)
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -125,11 +139,17 @@ impl Client {
     }
 
     ///Sends a `GET` request to `/global/jobs`
+    ///
+    ///Arguments:
+    /// - `authorization`: Authorization header (bearer token)
     pub async fn global_jobs<'a>(
         &'a self,
+        authorization: &'a str,
     ) -> Result<ResponseValue<types::GlobalJobsResult>, Error<()>> {
         let url = format!("{}/global/jobs", self.baseurl,);
-        let request = self.client.get(url).build()?;
+        let mut header_map = HeaderMap::with_capacity(1usize);
+        header_map.append("Authorization", HeaderValue::try_from(authorization)?);
+        let request = self.client.get(url).headers(header_map).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -139,9 +159,17 @@ impl Client {
     }
 
     ///Sends a `GET` request to `/ping`
-    pub async fn ping<'a>(&'a self) -> Result<ResponseValue<types::PingResult>, Error<()>> {
+    ///
+    ///Arguments:
+    /// - `authorization`: Authorization header (bearer token)
+    pub async fn ping<'a>(
+        &'a self,
+        authorization: &'a str,
+    ) -> Result<ResponseValue<types::PingResult>, Error<()>> {
         let url = format!("{}/ping", self.baseurl,);
-        let request = self.client.get(url).build()?;
+        let mut header_map = HeaderMap::with_capacity(1usize);
+        header_map.append("Authorization", HeaderValue::try_from(authorization)?);
+        let request = self.client.get(url).headers(header_map).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -151,12 +179,24 @@ impl Client {
     }
 
     ///Sends a `POST` request to `/report/finish`
+    ///
+    ///Arguments:
+    /// - `authorization`: Authorization header (bearer token)
+    /// - `body`
     pub async fn report_finish<'a>(
         &'a self,
+        authorization: &'a str,
         body: &'a types::ReportFinishBody,
     ) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
         let url = format!("{}/report/finish", self.baseurl,);
-        let request = self.client.post(url).json(&body).build()?;
+        let mut header_map = HeaderMap::with_capacity(1usize);
+        header_map.append("Authorization", HeaderValue::try_from(authorization)?);
+        let request = self
+            .client
+            .post(url)
+            .json(&body)
+            .headers(header_map)
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -166,12 +206,24 @@ impl Client {
     }
 
     ///Sends a `POST` request to `/report/output`
+    ///
+    ///Arguments:
+    /// - `authorization`: Authorization header (bearer token)
+    /// - `body`
     pub async fn report_output<'a>(
         &'a self,
+        authorization: &'a str,
         body: &'a types::ReportOutputBody,
     ) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
         let url = format!("{}/report/output", self.baseurl,);
-        let request = self.client.post(url).json(&body).build()?;
+        let mut header_map = HeaderMap::with_capacity(1usize);
+        header_map.append("Authorization", HeaderValue::try_from(authorization)?);
+        let request = self
+            .client
+            .post(url)
+            .json(&body)
+            .headers(header_map)
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -181,12 +233,24 @@ impl Client {
     }
 
     ///Sends a `POST` request to `/report/start`
+    ///
+    ///Arguments:
+    /// - `authorization`: Authorization header (bearer token)
+    /// - `body`
     pub async fn report_start<'a>(
         &'a self,
+        authorization: &'a str,
         body: &'a types::ReportStartBody,
     ) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
         let url = format!("{}/report/start", self.baseurl,);
-        let request = self.client.post(url).json(&body).build()?;
+        let mut header_map = HeaderMap::with_capacity(1usize);
+        header_map.append("Authorization", HeaderValue::try_from(authorization)?);
+        let request = self
+            .client
+            .post(url)
+            .json(&body)
+            .headers(header_map)
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {

--- a/progenitor-impl/tests/output/nexus-builder-tagged.out
+++ b/progenitor-impl/tests/output/nexus-builder-tagged.out
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
+#[allow(unused_imports)]
+use reqwest::header::{HeaderMap, HeaderValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -13682,7 +13684,9 @@ impl ClientVpcsExt for Client {
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]
-    use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    use super::{
+        encode_path, ByteStream, Error, HeaderMap, HeaderValue, RequestBuilderExt, ResponseValue,
+    };
     ///Builder for [`ClientDisksExt::disk_view_by_id`]
     ///
     ///[`ClientDisksExt::disk_view_by_id`]: super::ClientDisksExt::disk_view_by_id
@@ -14508,7 +14512,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/hardware/racks", client.baseurl,);
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -14699,7 +14703,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/hardware/sleds", client.baseurl,);
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -14890,7 +14894,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/images", client.baseurl,);
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -15181,7 +15185,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/ip-pools", client.baseurl,);
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -15545,7 +15549,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -16037,7 +16041,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/organizations", client.baseurl,);
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -16550,7 +16554,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -17021,7 +17025,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -17495,7 +17499,7 @@ pub mod builder {
                 encode_path(&disk_name.to_string()),
                 encode_path(&metric_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(4usize);
             if let Some(v) = &end_time {
                 query.push(("end_time", v.to_string()));
             }
@@ -17674,7 +17678,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -18108,7 +18112,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -18559,7 +18563,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -19143,7 +19147,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -19850,7 +19854,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &from_start {
                 query.push(("from_start", v.to_string()));
             }
@@ -20311,7 +20315,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -20746,7 +20750,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -21488,7 +21492,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -22115,7 +22119,7 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -22787,7 +22791,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -23415,7 +23419,7 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -23627,7 +23631,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/roles", client.baseurl,);
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -23814,7 +23818,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/sagas", client.baseurl,);
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -24038,7 +24042,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/sshkeys", client.baseurl,);
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -24335,7 +24339,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/silos", client.baseurl,);
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -24645,7 +24649,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -25054,7 +25058,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/user", client.baseurl,);
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -25232,7 +25236,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/timeseries/schema", client.baseurl,);
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -25400,7 +25404,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/users", client.baseurl,);
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }

--- a/progenitor-impl/tests/output/nexus-builder.out
+++ b/progenitor-impl/tests/output/nexus-builder.out
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
+#[allow(unused_imports)]
+use reqwest::header::{HeaderMap, HeaderValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -13502,7 +13504,9 @@ impl Client {
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]
-    use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    use super::{
+        encode_path, ByteStream, Error, HeaderMap, HeaderValue, RequestBuilderExt, ResponseValue,
+    };
     ///Builder for [`Client::disk_view_by_id`]
     ///
     ///[`Client::disk_view_by_id`]: super::Client::disk_view_by_id
@@ -14327,7 +14331,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/hardware/racks", client.baseurl,);
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -14518,7 +14522,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/hardware/sleds", client.baseurl,);
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -14709,7 +14713,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/images", client.baseurl,);
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -15000,7 +15004,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/ip-pools", client.baseurl,);
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -15364,7 +15368,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -15856,7 +15860,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/organizations", client.baseurl,);
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -16369,7 +16373,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -16840,7 +16844,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -17314,7 +17318,7 @@ pub mod builder {
                 encode_path(&disk_name.to_string()),
                 encode_path(&metric_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(4usize);
             if let Some(v) = &end_time {
                 query.push(("end_time", v.to_string()));
             }
@@ -17493,7 +17497,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -17927,7 +17931,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -18378,7 +18382,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -18962,7 +18966,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -19669,7 +19673,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &from_start {
                 query.push(("from_start", v.to_string()));
             }
@@ -20130,7 +20134,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -20565,7 +20569,7 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -21307,7 +21311,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -21934,7 +21938,7 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -22606,7 +22610,7 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -23234,7 +23238,7 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -23446,7 +23450,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/roles", client.baseurl,);
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -23633,7 +23637,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/sagas", client.baseurl,);
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -23857,7 +23861,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/sshkeys", client.baseurl,);
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -24154,7 +24158,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/silos", client.baseurl,);
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -24464,7 +24468,7 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -24873,7 +24877,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/user", client.baseurl,);
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -25051,7 +25055,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/timeseries/schema", client.baseurl,);
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }
@@ -25219,7 +25223,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/users", client.baseurl,);
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 query.push(("limit", v.to_string()));
             }

--- a/progenitor-impl/tests/output/nexus-positional.out
+++ b/progenitor-impl/tests/output/nexus-positional.out
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
+#[allow(unused_imports)]
+use reqwest::header::{HeaderMap, HeaderValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -3396,7 +3398,7 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::RackResultsPage>, Error<types::Error>> {
         let url = format!("{}/hardware/racks", self.baseurl,);
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
             query.push(("limit", v.to_string()));
         }
@@ -3512,7 +3514,7 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SledResultsPage>, Error<types::Error>> {
         let url = format!("{}/hardware/sleds", self.baseurl,);
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
             query.push(("limit", v.to_string()));
         }
@@ -3631,7 +3633,7 @@ impl Client {
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::GlobalImageResultsPage>, Error<types::Error>> {
         let url = format!("{}/images", self.baseurl,);
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
             query.push(("limit", v.to_string()));
         }
@@ -3807,7 +3809,7 @@ impl Client {
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::IpPoolResultsPage>, Error<types::Error>> {
         let url = format!("{}/ip-pools", self.baseurl,);
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
             query.push(("limit", v.to_string()));
         }
@@ -4004,7 +4006,7 @@ impl Client {
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(2usize);
         if let Some(v) = &limit {
             query.push(("limit", v.to_string()));
         }
@@ -4234,7 +4236,7 @@ impl Client {
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
         let url = format!("{}/organizations", self.baseurl,);
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
             query.push(("limit", v.to_string()));
         }
@@ -4504,7 +4506,7 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
             query.push(("limit", v.to_string()));
         }
@@ -4739,7 +4741,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
             query.push(("limit", v.to_string()));
         }
@@ -4957,7 +4959,7 @@ impl Client {
             encode_path(&disk_name.to_string()),
             encode_path(&metric_name.to_string()),
         );
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(4usize);
         if let Some(v) = &end_time {
             query.push(("end_time", v.to_string()));
         }
@@ -5090,7 +5092,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
             query.push(("limit", v.to_string()));
         }
@@ -5310,7 +5312,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
             query.push(("limit", v.to_string()));
         }
@@ -5524,7 +5526,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
             query.push(("limit", v.to_string()));
         }
@@ -5777,7 +5779,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
             query.push(("limit", v.to_string()));
         }
@@ -6084,7 +6086,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &from_start {
             query.push(("from_start", v.to_string()));
         }
@@ -6274,7 +6276,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
             query.push(("limit", v.to_string()));
         }
@@ -6484,7 +6486,7 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
             query.push(("limit", v.to_string()));
         }
@@ -6798,7 +6800,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
             query.push(("limit", v.to_string()));
         }
@@ -7063,7 +7065,7 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
             query.push(("limit", v.to_string()));
         }
@@ -7338,7 +7340,7 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
             query.push(("limit", v.to_string()));
         }
@@ -7603,7 +7605,7 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&subnet_name.to_string()),
         );
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
             query.push(("limit", v.to_string()));
         }
@@ -7759,7 +7761,7 @@ impl Client {
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::RoleResultsPage>, Error<types::Error>> {
         let url = format!("{}/roles", self.baseurl,);
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(2usize);
         if let Some(v) = &limit {
             query.push(("limit", v.to_string()));
         }
@@ -7869,7 +7871,7 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SagaResultsPage>, Error<types::Error>> {
         let url = format!("{}/sagas", self.baseurl,);
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
             query.push(("limit", v.to_string()));
         }
@@ -8004,7 +8006,7 @@ impl Client {
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::SshKeyResultsPage>, Error<types::Error>> {
         let url = format!("{}/session/me/sshkeys", self.baseurl,);
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
             query.push(("limit", v.to_string()));
         }
@@ -8165,7 +8167,7 @@ impl Client {
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::SiloResultsPage>, Error<types::Error>> {
         let url = format!("{}/silos", self.baseurl,);
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
             query.push(("limit", v.to_string()));
         }
@@ -8338,7 +8340,7 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
             query.push(("limit", v.to_string()));
         }
@@ -8555,7 +8557,7 @@ impl Client {
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::UserBuiltinResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/user", self.baseurl,);
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
             query.push(("limit", v.to_string()));
         }
@@ -8670,7 +8672,7 @@ impl Client {
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::TimeseriesSchemaResultsPage>, Error<types::Error>> {
         let url = format!("{}/timeseries/schema", self.baseurl,);
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(2usize);
         if let Some(v) = &limit {
             query.push(("limit", v.to_string()));
         }
@@ -8771,7 +8773,7 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
         let url = format!("{}/users", self.baseurl,);
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
             query.push(("limit", v.to_string()));
         }

--- a/progenitor-impl/tests/output/param-overrides-builder-tagged.out
+++ b/progenitor-impl/tests/output/param-overrides-builder-tagged.out
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
+#[allow(unused_imports)]
+use reqwest::header::{HeaderMap, HeaderValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -66,7 +68,9 @@ impl Client {
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]
-    use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    use super::{
+        encode_path, ByteStream, Error, HeaderMap, HeaderValue, RequestBuilderExt, ResponseValue,
+    };
     ///Builder for [`Client::key_get`]
     ///
     ///[`Client::key_get`]: super::Client::key_get
@@ -118,7 +122,7 @@ pub mod builder {
             let key = key.map_err(Error::InvalidRequest)?;
             let unique_key = unique_key.map_err(Error::InvalidRequest)?;
             let url = format!("{}/key", client.baseurl,);
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &key {
                 query.push(("key", v.to_string()));
             }

--- a/progenitor-impl/tests/output/param-overrides-builder.out
+++ b/progenitor-impl/tests/output/param-overrides-builder.out
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
+#[allow(unused_imports)]
+use reqwest::header::{HeaderMap, HeaderValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -66,7 +68,9 @@ impl Client {
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]
-    use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    use super::{
+        encode_path, ByteStream, Error, HeaderMap, HeaderValue, RequestBuilderExt, ResponseValue,
+    };
     ///Builder for [`Client::key_get`]
     ///
     ///[`Client::key_get`]: super::Client::key_get
@@ -118,7 +122,7 @@ pub mod builder {
             let key = key.map_err(Error::InvalidRequest)?;
             let unique_key = unique_key.map_err(Error::InvalidRequest)?;
             let url = format!("{}/key", client.baseurl,);
-            let mut query = Vec::new();
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &key {
                 query.push(("key", v.to_string()));
             }

--- a/progenitor-impl/tests/output/param-overrides-positional.out
+++ b/progenitor-impl/tests/output/param-overrides-positional.out
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
+#[allow(unused_imports)]
+use reqwest::header::{HeaderMap, HeaderValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -56,7 +58,7 @@ impl Client {
         unique_key: Option<&'a str>,
     ) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/key", self.baseurl,);
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(2usize);
         if let Some(v) = &key {
             query.push(("key", v.to_string()));
         }

--- a/progenitor-impl/tests/output/propolis-server-builder-tagged.out
+++ b/progenitor-impl/tests/output/propolis-server-builder-tagged.out
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
+#[allow(unused_imports)]
+use reqwest::header::{HeaderMap, HeaderValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -1615,7 +1617,9 @@ impl Client {
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]
-    use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    use super::{
+        encode_path, ByteStream, Error, HeaderMap, HeaderValue, RequestBuilderExt, ResponseValue,
+    };
     ///Builder for [`Client::instance_get`]
     ///
     ///[`Client::instance_get`]: super::Client::instance_get

--- a/progenitor-impl/tests/output/propolis-server-builder.out
+++ b/progenitor-impl/tests/output/propolis-server-builder.out
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
+#[allow(unused_imports)]
+use reqwest::header::{HeaderMap, HeaderValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -1621,7 +1623,9 @@ impl Client {
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]
-    use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    use super::{
+        encode_path, ByteStream, Error, HeaderMap, HeaderValue, RequestBuilderExt, ResponseValue,
+    };
     ///Builder for [`Client::instance_get`]
     ///
     ///[`Client::instance_get`]: super::Client::instance_get

--- a/progenitor-impl/tests/output/propolis-server-positional.out
+++ b/progenitor-impl/tests/output/propolis-server-positional.out
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
+#[allow(unused_imports)]
+use reqwest::header::{HeaderMap, HeaderValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/test_default_params_builder.out
+++ b/progenitor-impl/tests/output/test_default_params_builder.out
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
+#[allow(unused_imports)]
+use reqwest::header::{HeaderMap, HeaderValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -236,7 +238,9 @@ impl Client {
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]
-    use super::{encode_path, ByteStream, Error, RequestBuilderExt, ResponseValue};
+    use super::{
+        encode_path, ByteStream, Error, HeaderMap, HeaderValue, RequestBuilderExt, ResponseValue,
+    };
     ///Builder for [`Client::default_params`]
     ///
     ///[`Client::default_params`]: super::Client::default_params

--- a/progenitor-impl/tests/output/test_default_params_positional.out
+++ b/progenitor-impl/tests/output/test_default_params_positional.out
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
+#[allow(unused_imports)]
+use reqwest::header::{HeaderMap, HeaderValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/test_freeform_response.out
+++ b/progenitor-impl/tests/output/test_freeform_response.out
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
+#[allow(unused_imports)]
+use reqwest::header::{HeaderMap, HeaderValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/test_renamed_parameters.out
+++ b/progenitor-impl/tests/output/test_renamed_parameters.out
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
+#[allow(unused_imports)]
+use reqwest::header::{HeaderMap, HeaderValue};
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -66,7 +68,7 @@ impl Client {
             encode_path(&type_.to_string()),
             encode_path(&trait_.to_string()),
         );
-        let mut query = Vec::new();
+        let mut query = Vec::with_capacity(3usize);
         query.push(("if", if_.to_string()));
         query.push(("in", in_.to_string()));
         query.push(("use", use_.to_string()));

--- a/progenitor-impl/tests/test_output.rs
+++ b/progenitor-impl/tests/test_output.rs
@@ -51,6 +51,7 @@ fn verify_apis(openapi_file: &str) {
             .with_tag(TagStyle::Separate),
     );
     let output = generator.generate_text_normalize_comments(&spec).unwrap();
+    println!("{output}");
     expectorate::assert_contents(
         format!("tests/output/{}-builder-tagged.out", openapi_file),
         &output,

--- a/progenitor/tests/build_keeper.rs
+++ b/progenitor/tests/build_keeper.rs
@@ -4,10 +4,13 @@ mod positional {
     progenitor::generate_api!("../sample_openapi/keeper.json");
 
     fn _ignore() {
-        let _ = Client::new("").enrol(&types::EnrolBody {
-            host: "".to_string(),
-            key: "".to_string(),
-        });
+        let _ = Client::new("").enrol(
+            "auth token",
+            &types::EnrolBody {
+                host: "".to_string(),
+                key: "".to_string(),
+            },
+        );
     }
 }
 
@@ -21,6 +24,7 @@ mod builder_untagged {
     fn _ignore() {
         let _ = Client::new("")
             .enrol()
+            .authorization("")
             .body(types::EnrolBody {
                 host: "".to_string(),
                 key: "".to_string(),
@@ -39,6 +43,7 @@ mod builder_tagged {
     fn _ignore() {
         let _ = Client::new("")
             .enrol()
+            .authorization("")
             .body(types::EnrolBody {
                 host: "".to_string(),
                 key: "".to_string(),

--- a/sample_openapi/keeper.json
+++ b/sample_openapi/keeper.json
@@ -13,6 +13,18 @@
     "/enrol": {
       "post": {
         "operationId": "enrol",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "schema": {
+              "type": "string"
+            },
+            "in": "header",
+            "description": "Authorization header (bearer token)",
+            "required": true,
+            "deprecated": false
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -46,6 +58,18 @@
     "/global/jobs": {
       "get": {
         "operationId": "global_jobs",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "schema": {
+              "type": "string"
+            },
+            "in": "header",
+            "description": "Authorization header (bearer token)",
+            "required": true,
+            "deprecated": false
+          }
+        ],
         "responses": {
           "201": {
             "description": "successful creation",
@@ -75,6 +99,18 @@
     "/ping": {
       "get": {
         "operationId": "ping",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "schema": {
+              "type": "string"
+            },
+            "in": "header",
+            "description": "Authorization header (bearer token)",
+            "required": true,
+            "deprecated": false
+          }
+        ],
         "responses": {
           "201": {
             "description": "successful creation",
@@ -105,6 +141,18 @@
     "/report/finish": {
       "post": {
         "operationId": "report_finish",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "schema": {
+              "type": "string"
+            },
+            "in": "header",
+            "description": "Authorization header (bearer token)",
+            "required": true,
+            "deprecated": false
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -165,6 +213,18 @@
     "/report/output": {
       "post": {
         "operationId": "report_output",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "schema": {
+              "type": "string"
+            },
+            "in": "header",
+            "description": "Authorization header (bearer token)",
+            "required": true,
+            "deprecated": false
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -214,6 +274,18 @@
     "/report/start": {
       "post": {
         "operationId": "report_start",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "schema": {
+              "type": "string"
+            },
+            "in": "header",
+            "description": "Authorization header (bearer token)",
+            "required": true,
+            "deprecated": false
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {


### PR DESCRIPTION
Closes #255
Base support for Header parameters.

And small additional change: use `Vec::with_capacity` instead of `Vec::new`

All current tests passes, but it would be nice to add some test with `header` params (I tested it on my own examples). 
I've not found `Header` in `dropshot` to write "specific-test". So we can choose any public openapi spec to add. (Upd: see https://github.com/oxidecomputer/progenitor/pull/210#issuecomment-1298794146)