### PR TITLE
Add generated crate metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ For example:
 
 This will produce a package in the specified directory.
 
+Options `--license` and `--registry-name` may also be used to improve metadata
+before publishing the static crate.
+
 The output will use the published `progenitor-client` crate by default
 if progenitor was built from a released version.  However, when using progenitor
 built from the repository, the `progenitor-client` will be inlined into the

--- a/progenitor/src/main.rs
+++ b/progenitor/src/main.rs
@@ -36,6 +36,12 @@ struct Args {
     /// Target Rust crate version
     #[clap(short = 'v', long)]
     version: String,
+    /// Target Rust crate registry
+    #[clap(long)]
+    registry_name: Option<String>,
+    /// Target crate license
+    #[clap(long, default_value = "SPECIFY A LICENSE BEFORE PUBLISHING")]
+    license_name: String,
 
     /// SDK interface style
     #[clap(value_enum, long, default_value_t = InterfaceArg::Positional)]
@@ -132,18 +138,28 @@ fn main() -> Result<()> {
             let mut toml = root.clone();
             toml.push("Cargo.toml");
 
-            let tomlout = format!(
+            let mut tomlout = format!(
                 "[package]\n\
                 name = \"{}\"\n\
                 version = \"{}\"\n\
-                edition = \"2021\"\n\
-                \n\
+                edition = \"2021\"\n\"
+                license = \"{}\"\n",
+                name, version, &args.license_name,
+            );
+            if let Some(registry_name) = args.registry_name {
+                tomlout.extend(
+                    format!("publish = [\"{}\"]\n", registry_name).chars(),
+                );
+            }
+            tomlout.extend(
+                format!(
+                    "\n\
                 [dependencies]\n\
                 {}\n\
                 \n",
-                name,
-                version,
-                dependencies(builder, args.include_client).join("\n"),
+                    dependencies(builder, args.include_client).join("\n"),
+                )
+                .chars(),
             );
 
             save(&toml, tomlout.as_str())?;


### PR DESCRIPTION
This adds a CLI arg for the crate registry to publish to, and a hardcoded `license` value which at least makes people think about licensing.
Ideally some other approach is found to make the crate metadata more easily customised without resorting to lots of CLI args.