### PR TITLE
WIP: use reqwest-middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,6 +356,7 @@ dependencies = [
  "progenitor-client",
  "rand",
  "reqwest",
+ "reqwest-middleware",
  "serde",
  "serde_json",
  "uuid",
@@ -368,6 +369,7 @@ dependencies = [
  "chrono",
  "progenitor",
  "reqwest",
+ "reqwest-middleware",
  "schemars",
  "serde",
  "uuid",
@@ -795,6 +797,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,6 +1054,7 @@ dependencies = [
  "rand",
  "regress",
  "reqwest",
+ "reqwest-middleware",
  "schemars",
  "serde",
  "serde_json",
@@ -1056,6 +1069,7 @@ dependencies = [
  "futures-core",
  "percent-encoding",
  "reqwest",
+ "reqwest-middleware",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -1213,6 +1227,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding",
@@ -1229,6 +1244,21 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1c03e9011a8c59716ad13115550469e081e2e9892656b0ba6a47c907921894"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest",
+ "serde",
+ "task-local-extensions",
+ "thiserror",
 ]
 
 [[package]]
@@ -1592,6 +1622,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
+name = "task-local-extensions"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4167afbec18ae012de40f8cf1b9bf48420abb390678c34821caa07d924941cc4"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1894,6 +1933,15 @@ name = "ucd-trie"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/example-build/Cargo.toml
+++ b/example-build/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 chrono = { version = "0.4", features = ["serde"] }
 progenitor-client = { path = "../progenitor-client" }
 reqwest = { version = "0.11.12", features = ["json", "stream"] }
+reqwest-middleware = "0.2.0"
 base64 = "0.13"
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }

--- a/example-macro/Cargo.toml
+++ b/example-macro/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 chrono = { version = "0.4", features = ["serde"] }
 progenitor = { path = "../progenitor" }
 reqwest = { version = "0.11.12", features = ["json", "stream"] }
+reqwest-middleware = "0.2.0"
 schemars = { version = "0.8.11", features = ["uuid1"] }
 serde = { version = "1.0", features = ["derive"] }
 uuid = { version = "1.2", features = ["serde", "v4"] }

--- a/example-macro/src/main.rs
+++ b/example-macro/src/main.rs
@@ -12,7 +12,7 @@ generate_api!(
     derives = [schemars::JsonSchema],
 );
 
-fn all_done(_: &(), _result: &reqwest::Result<reqwest::Response>) {}
+fn all_done(_: &(), _result: &reqwest_middleware::Result<reqwest::Response>) {}
 
 mod buildomat {
     use progenitor::generate_api;

--- a/progenitor-client/Cargo.toml
+++ b/progenitor-client/Cargo.toml
@@ -11,6 +11,7 @@ bytes = "1.2.1"
 futures-core = "0.3.25"
 percent-encoding = "2.2"
 reqwest = { version = "0.11.12", default-features = false, features = ["json", "stream"] }
+reqwest-middleware = "0.2.0"
 serde = "1.0"
 serde_json = "1.0"
 serde_urlencoded = "0.7.1"

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -251,7 +251,7 @@ impl Generator {
             #[derive(Clone, Debug)]
             pub struct Client {
                 pub(crate) baseurl: String,
-                pub(crate) client: reqwest::Client,
+                pub(crate) client: reqwest_middleware::ClientWithMiddleware,
                 #inner_property
             }
 
@@ -261,17 +261,20 @@ impl Generator {
                     #inner_parameter
                 ) -> Self {
                     let dur = std::time::Duration::from_secs(15);
-                    let client = reqwest::ClientBuilder::new()
-                        .connect_timeout(dur)
-                        .timeout(dur)
-                        .build()
-                        .unwrap();
+                    let client = reqwest_middleware::ClientBuilder::new(
+                        reqwest::ClientBuilder::new()
+                            .connect_timeout(dur)
+                            .timeout(dur)
+                            .build()
+                            .unwrap()
+                    )
+                        .build();
                     Self::new_with_client(baseurl, client, #inner_value)
                 }
 
                 pub fn new_with_client(
                     baseurl: &str,
-                    client: reqwest::Client,
+                    client: reqwest_middleware::ClientWithMiddleware,
                     #inner_parameter
                 ) -> Self {
                     Self {
@@ -285,7 +288,7 @@ impl Generator {
                     &self.baseurl
                 }
 
-                pub fn client(&self) -> &reqwest::Client {
+                pub fn client(&self) -> &reqwest_middleware::ClientWithMiddleware {
                     &self.client
                 }
             }
@@ -448,6 +451,7 @@ impl Generator {
             "futures-core = \"0.3\"",
             "percent-encoding = \"2.1\"",
             "reqwest = { version = \"0.11.12\", features = [\"json\", \"stream\"] }",
+            "reqwest-middleware = \"0.2.0\"",
             "serde = { version = \"1.0\", features = [\"derive\"] }",
             "serde_urlencoded = \"0.7\"",
         ];

--- a/progenitor-impl/tests/output/buildomat-builder-tagged.out
+++ b/progenitor-impl/tests/output/buildomat-builder-tagged.out
@@ -1268,21 +1268,27 @@ pub mod types {
 #[derive(Clone, Debug)]
 pub struct Client {
     pub(crate) baseurl: String,
-    pub(crate) client: reqwest::Client,
+    pub(crate) client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl Client {
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
+        let client = reqwest_middleware::ClientBuilder::new(
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+                .build()
+                .unwrap(),
+        )
+        .build();
         Self::new_with_client(baseurl, client)
     }
 
-    pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
+    pub fn new_with_client(
+        baseurl: &str,
+        client: reqwest_middleware::ClientWithMiddleware,
+    ) -> Self {
         Self {
             baseurl: baseurl.to_string(),
             client,
@@ -1293,7 +1299,7 @@ impl Client {
         &self.baseurl
     }
 
-    pub fn client(&self) -> &reqwest::Client {
+    pub fn client(&self) -> &reqwest_middleware::ClientWithMiddleware {
         &self.client
     }
 }

--- a/progenitor-impl/tests/output/buildomat-builder.out
+++ b/progenitor-impl/tests/output/buildomat-builder.out
@@ -1268,21 +1268,27 @@ pub mod types {
 #[derive(Clone, Debug)]
 pub struct Client {
     pub(crate) baseurl: String,
-    pub(crate) client: reqwest::Client,
+    pub(crate) client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl Client {
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
+        let client = reqwest_middleware::ClientBuilder::new(
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+                .build()
+                .unwrap(),
+        )
+        .build();
         Self::new_with_client(baseurl, client)
     }
 
-    pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
+    pub fn new_with_client(
+        baseurl: &str,
+        client: reqwest_middleware::ClientWithMiddleware,
+    ) -> Self {
         Self {
             baseurl: baseurl.to_string(),
             client,
@@ -1293,7 +1299,7 @@ impl Client {
         &self.baseurl
     }
 
-    pub fn client(&self) -> &reqwest::Client {
+    pub fn client(&self) -> &reqwest_middleware::ClientWithMiddleware {
         &self.client
     }
 }

--- a/progenitor-impl/tests/output/buildomat-positional.out
+++ b/progenitor-impl/tests/output/buildomat-positional.out
@@ -137,21 +137,27 @@ pub mod types {
 #[derive(Clone, Debug)]
 pub struct Client {
     pub(crate) baseurl: String,
-    pub(crate) client: reqwest::Client,
+    pub(crate) client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl Client {
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
+        let client = reqwest_middleware::ClientBuilder::new(
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+                .build()
+                .unwrap(),
+        )
+        .build();
         Self::new_with_client(baseurl, client)
     }
 
-    pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
+    pub fn new_with_client(
+        baseurl: &str,
+        client: reqwest_middleware::ClientWithMiddleware,
+    ) -> Self {
         Self {
             baseurl: baseurl.to_string(),
             client,
@@ -162,7 +168,7 @@ impl Client {
         &self.baseurl
     }
 
-    pub fn client(&self) -> &reqwest::Client {
+    pub fn client(&self) -> &reqwest_middleware::ClientWithMiddleware {
         &self.client
     }
 }

--- a/progenitor-impl/tests/output/keeper-builder-tagged.out
+++ b/progenitor-impl/tests/output/keeper-builder-tagged.out
@@ -730,21 +730,27 @@ pub mod types {
 #[derive(Clone, Debug)]
 pub struct Client {
     pub(crate) baseurl: String,
-    pub(crate) client: reqwest::Client,
+    pub(crate) client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl Client {
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
+        let client = reqwest_middleware::ClientBuilder::new(
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+                .build()
+                .unwrap(),
+        )
+        .build();
         Self::new_with_client(baseurl, client)
     }
 
-    pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
+    pub fn new_with_client(
+        baseurl: &str,
+        client: reqwest_middleware::ClientWithMiddleware,
+    ) -> Self {
         Self {
             baseurl: baseurl.to_string(),
             client,
@@ -755,7 +761,7 @@ impl Client {
         &self.baseurl
     }
 
-    pub fn client(&self) -> &reqwest::Client {
+    pub fn client(&self) -> &reqwest_middleware::ClientWithMiddleware {
         &self.client
     }
 }

--- a/progenitor-impl/tests/output/keeper-builder.out
+++ b/progenitor-impl/tests/output/keeper-builder.out
@@ -730,21 +730,27 @@ pub mod types {
 #[derive(Clone, Debug)]
 pub struct Client {
     pub(crate) baseurl: String,
-    pub(crate) client: reqwest::Client,
+    pub(crate) client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl Client {
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
+        let client = reqwest_middleware::ClientBuilder::new(
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+                .build()
+                .unwrap(),
+        )
+        .build();
         Self::new_with_client(baseurl, client)
     }
 
-    pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
+    pub fn new_with_client(
+        baseurl: &str,
+        client: reqwest_middleware::ClientWithMiddleware,
+    ) -> Self {
         Self {
             baseurl: baseurl.to_string(),
             client,
@@ -755,7 +761,7 @@ impl Client {
         &self.baseurl
     }
 
-    pub fn client(&self) -> &reqwest::Client {
+    pub fn client(&self) -> &reqwest_middleware::ClientWithMiddleware {
         &self.client
     }
 }

--- a/progenitor-impl/tests/output/keeper-positional.out
+++ b/progenitor-impl/tests/output/keeper-positional.out
@@ -78,21 +78,27 @@ pub mod types {
 #[derive(Clone, Debug)]
 pub struct Client {
     pub(crate) baseurl: String,
-    pub(crate) client: reqwest::Client,
+    pub(crate) client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl Client {
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
+        let client = reqwest_middleware::ClientBuilder::new(
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+                .build()
+                .unwrap(),
+        )
+        .build();
         Self::new_with_client(baseurl, client)
     }
 
-    pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
+    pub fn new_with_client(
+        baseurl: &str,
+        client: reqwest_middleware::ClientWithMiddleware,
+    ) -> Self {
         Self {
             baseurl: baseurl.to_string(),
             client,
@@ -103,7 +109,7 @@ impl Client {
         &self.baseurl
     }
 
-    pub fn client(&self) -> &reqwest::Client {
+    pub fn client(&self) -> &reqwest_middleware::ClientWithMiddleware {
         &self.client
     }
 }

--- a/progenitor-impl/tests/output/nexus-builder-tagged.out
+++ b/progenitor-impl/tests/output/nexus-builder-tagged.out
@@ -11052,21 +11052,27 @@ pub mod types {
 #[derive(Clone, Debug)]
 pub struct Client {
     pub(crate) baseurl: String,
-    pub(crate) client: reqwest::Client,
+    pub(crate) client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl Client {
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
+        let client = reqwest_middleware::ClientBuilder::new(
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+                .build()
+                .unwrap(),
+        )
+        .build();
         Self::new_with_client(baseurl, client)
     }
 
-    pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
+    pub fn new_with_client(
+        baseurl: &str,
+        client: reqwest_middleware::ClientWithMiddleware,
+    ) -> Self {
         Self {
             baseurl: baseurl.to_string(),
             client,
@@ -11077,7 +11083,7 @@ impl Client {
         &self.baseurl
     }
 
-    pub fn client(&self) -> &reqwest::Client {
+    pub fn client(&self) -> &reqwest_middleware::ClientWithMiddleware {
         &self.client
     }
 }

--- a/progenitor-impl/tests/output/nexus-builder.out
+++ b/progenitor-impl/tests/output/nexus-builder.out
@@ -11096,21 +11096,27 @@ pub mod types {
 #[derive(Clone, Debug)]
 pub struct Client {
     pub(crate) baseurl: String,
-    pub(crate) client: reqwest::Client,
+    pub(crate) client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl Client {
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
+        let client = reqwest_middleware::ClientBuilder::new(
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+                .build()
+                .unwrap(),
+        )
+        .build();
         Self::new_with_client(baseurl, client)
     }
 
-    pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
+    pub fn new_with_client(
+        baseurl: &str,
+        client: reqwest_middleware::ClientWithMiddleware,
+    ) -> Self {
         Self {
             baseurl: baseurl.to_string(),
             client,
@@ -11121,7 +11127,7 @@ impl Client {
         &self.baseurl
     }
 
-    pub fn client(&self) -> &reqwest::Client {
+    pub fn client(&self) -> &reqwest_middleware::ClientWithMiddleware {
         &self.client
     }
 }

--- a/progenitor-impl/tests/output/nexus-positional.out
+++ b/progenitor-impl/tests/output/nexus-positional.out
@@ -2947,21 +2947,27 @@ pub mod types {
 #[derive(Clone, Debug)]
 pub struct Client {
     pub(crate) baseurl: String,
-    pub(crate) client: reqwest::Client,
+    pub(crate) client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl Client {
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
+        let client = reqwest_middleware::ClientBuilder::new(
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+                .build()
+                .unwrap(),
+        )
+        .build();
         Self::new_with_client(baseurl, client)
     }
 
-    pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
+    pub fn new_with_client(
+        baseurl: &str,
+        client: reqwest_middleware::ClientWithMiddleware,
+    ) -> Self {
         Self {
             baseurl: baseurl.to_string(),
             client,
@@ -2972,7 +2978,7 @@ impl Client {
         &self.baseurl
     }
 
-    pub fn client(&self) -> &reqwest::Client {
+    pub fn client(&self) -> &reqwest_middleware::ClientWithMiddleware {
         &self.client
     }
 }

--- a/progenitor-impl/tests/output/propolis-server-builder-tagged.out
+++ b/progenitor-impl/tests/output/propolis-server-builder-tagged.out
@@ -1500,21 +1500,27 @@ pub mod types {
 #[derive(Clone, Debug)]
 pub struct Client {
     pub(crate) baseurl: String,
-    pub(crate) client: reqwest::Client,
+    pub(crate) client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl Client {
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
+        let client = reqwest_middleware::ClientBuilder::new(
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+                .build()
+                .unwrap(),
+        )
+        .build();
         Self::new_with_client(baseurl, client)
     }
 
-    pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
+    pub fn new_with_client(
+        baseurl: &str,
+        client: reqwest_middleware::ClientWithMiddleware,
+    ) -> Self {
         Self {
             baseurl: baseurl.to_string(),
             client,
@@ -1525,7 +1531,7 @@ impl Client {
         &self.baseurl
     }
 
-    pub fn client(&self) -> &reqwest::Client {
+    pub fn client(&self) -> &reqwest_middleware::ClientWithMiddleware {
         &self.client
     }
 }

--- a/progenitor-impl/tests/output/propolis-server-builder.out
+++ b/progenitor-impl/tests/output/propolis-server-builder.out
@@ -1506,21 +1506,27 @@ pub mod types {
 #[derive(Clone, Debug)]
 pub struct Client {
     pub(crate) baseurl: String,
-    pub(crate) client: reqwest::Client,
+    pub(crate) client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl Client {
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
+        let client = reqwest_middleware::ClientBuilder::new(
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+                .build()
+                .unwrap(),
+        )
+        .build();
         Self::new_with_client(baseurl, client)
     }
 
-    pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
+    pub fn new_with_client(
+        baseurl: &str,
+        client: reqwest_middleware::ClientWithMiddleware,
+    ) -> Self {
         Self {
             baseurl: baseurl.to_string(),
             client,
@@ -1531,7 +1537,7 @@ impl Client {
         &self.baseurl
     }
 
-    pub fn client(&self) -> &reqwest::Client {
+    pub fn client(&self) -> &reqwest_middleware::ClientWithMiddleware {
         &self.client
     }
 }

--- a/progenitor-impl/tests/output/propolis-server-positional.out
+++ b/progenitor-impl/tests/output/propolis-server-positional.out
@@ -340,21 +340,27 @@ pub mod types {
 #[derive(Clone, Debug)]
 pub struct Client {
     pub(crate) baseurl: String,
-    pub(crate) client: reqwest::Client,
+    pub(crate) client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl Client {
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
+        let client = reqwest_middleware::ClientBuilder::new(
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+                .build()
+                .unwrap(),
+        )
+        .build();
         Self::new_with_client(baseurl, client)
     }
 
-    pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
+    pub fn new_with_client(
+        baseurl: &str,
+        client: reqwest_middleware::ClientWithMiddleware,
+    ) -> Self {
         Self {
             baseurl: baseurl.to_string(),
             client,
@@ -365,7 +371,7 @@ impl Client {
         &self.baseurl
     }
 
-    pub fn client(&self) -> &reqwest::Client {
+    pub fn client(&self) -> &reqwest_middleware::ClientWithMiddleware {
         &self.client
     }
 }

--- a/progenitor-impl/tests/output/test_default_params_builder.out
+++ b/progenitor-impl/tests/output/test_default_params_builder.out
@@ -190,21 +190,27 @@ pub mod types {
 #[derive(Clone, Debug)]
 pub struct Client {
     pub(crate) baseurl: String,
-    pub(crate) client: reqwest::Client,
+    pub(crate) client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl Client {
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
+        let client = reqwest_middleware::ClientBuilder::new(
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+                .build()
+                .unwrap(),
+        )
+        .build();
         Self::new_with_client(baseurl, client)
     }
 
-    pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
+    pub fn new_with_client(
+        baseurl: &str,
+        client: reqwest_middleware::ClientWithMiddleware,
+    ) -> Self {
         Self {
             baseurl: baseurl.to_string(),
             client,
@@ -215,7 +221,7 @@ impl Client {
         &self.baseurl
     }
 
-    pub fn client(&self) -> &reqwest::Client {
+    pub fn client(&self) -> &reqwest_middleware::ClientWithMiddleware {
         &self.client
     }
 }

--- a/progenitor-impl/tests/output/test_default_params_positional.out
+++ b/progenitor-impl/tests/output/test_default_params_positional.out
@@ -43,21 +43,27 @@ pub mod types {
 #[derive(Clone, Debug)]
 pub struct Client {
     pub(crate) baseurl: String,
-    pub(crate) client: reqwest::Client,
+    pub(crate) client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl Client {
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
+        let client = reqwest_middleware::ClientBuilder::new(
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+                .build()
+                .unwrap(),
+        )
+        .build();
         Self::new_with_client(baseurl, client)
     }
 
-    pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
+    pub fn new_with_client(
+        baseurl: &str,
+        client: reqwest_middleware::ClientWithMiddleware,
+    ) -> Self {
         Self {
             baseurl: baseurl.to_string(),
             client,
@@ -68,7 +74,7 @@ impl Client {
         &self.baseurl
     }
 
-    pub fn client(&self) -> &reqwest::Client {
+    pub fn client(&self) -> &reqwest_middleware::ClientWithMiddleware {
         &self.client
     }
 }

--- a/progenitor-impl/tests/output/test_freeform_response.out
+++ b/progenitor-impl/tests/output/test_freeform_response.out
@@ -18,21 +18,27 @@ pub mod types {
 #[derive(Clone, Debug)]
 pub struct Client {
     pub(crate) baseurl: String,
-    pub(crate) client: reqwest::Client,
+    pub(crate) client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl Client {
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
+        let client = reqwest_middleware::ClientBuilder::new(
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+                .build()
+                .unwrap(),
+        )
+        .build();
         Self::new_with_client(baseurl, client)
     }
 
-    pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
+    pub fn new_with_client(
+        baseurl: &str,
+        client: reqwest_middleware::ClientWithMiddleware,
+    ) -> Self {
         Self {
             baseurl: baseurl.to_string(),
             client,
@@ -43,7 +49,7 @@ impl Client {
         &self.baseurl
     }
 
-    pub fn client(&self) -> &reqwest::Client {
+    pub fn client(&self) -> &reqwest_middleware::ClientWithMiddleware {
         &self.client
     }
 }

--- a/progenitor-impl/tests/output/test_renamed_parameters.out
+++ b/progenitor-impl/tests/output/test_renamed_parameters.out
@@ -18,21 +18,27 @@ pub mod types {
 #[derive(Clone, Debug)]
 pub struct Client {
     pub(crate) baseurl: String,
-    pub(crate) client: reqwest::Client,
+    pub(crate) client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl Client {
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
+        let client = reqwest_middleware::ClientBuilder::new(
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+                .build()
+                .unwrap(),
+        )
+        .build();
         Self::new_with_client(baseurl, client)
     }
 
-    pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
+    pub fn new_with_client(
+        baseurl: &str,
+        client: reqwest_middleware::ClientWithMiddleware,
+    ) -> Self {
         Self {
             baseurl: baseurl.to_string(),
             client,
@@ -43,7 +49,7 @@ impl Client {
         &self.baseurl
     }
 
-    pub fn client(&self) -> &reqwest::Client {
+    pub fn client(&self) -> &reqwest_middleware::ClientWithMiddleware {
         &self.client
     }
 }

--- a/progenitor/Cargo.toml
+++ b/progenitor/Cargo.toml
@@ -24,5 +24,6 @@ percent-encoding = "2.2"
 rand = "0.8"
 regress = "0.4.1"
 reqwest = { version = "0.11.12", features = ["json", "stream"] }
+reqwest-middleware = "0.2.0"
 schemars = { version = "0.8.11", features = ["uuid1"] }
 uuid = { version = "1.2", features = ["serde", "v4"] }


### PR DESCRIPTION
https://github.com/TrueLayer/reqwest-middleware brings retry & tracing support.

I havent updated the docs yet; waiting to see if there is interest in this feature.

I see a bunch of libs in https://github.com/oxidecomputer/third-party-api-clients are using `reqwest-middleware`, and https://github.com/oxidecomputer/reqwest-conditional-middleware

I see https://crates.io/crates/openapitor/0.0.5/dependencies is also using `reqwest-middleware`, but doesnt have its code published on git.