### PR TITLE
Query param named "query" collision

### DIFF
--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -729,7 +729,7 @@ impl Generator {
             })
             .collect::<Vec<_>>();
         let query_call = if query_items.is_empty() {
-            quote! { }
+            quote! {}
         } else {
             quote! {
                 .query::<[(&str, Option<String>)]>(&[

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -707,12 +707,12 @@ impl Generator {
                     let qn_ident = format_ident!("{}", &param.name);
                     Some(if *required {
                         quote! {
-                            query.push((#qn, #qn_ident .to_string()));
+                            req_query_args.push((#qn, #qn_ident .to_string()));
                         }
                     } else {
                         quote! {
                             if let Some(v) = & #qn_ident {
-                                query.push((#qn, v.to_string()));
+                                req_query_args.push((#qn, v.to_string()));
                             }
                         }
                     })
@@ -724,11 +724,11 @@ impl Generator {
             (quote! {}, quote! {})
         } else {
             let query_build = quote! {
-                let mut query = Vec::new();
+                let mut req_query_args = Vec::new();
                 #(#query_items)*
             };
             let query_use = quote! {
-                .query(&query)
+                .query(&req_query_args)
             };
 
             (query_build, query_use)

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -728,13 +728,13 @@ impl Generator {
                 _ => None,
             })
             .collect::<Vec<_>>();
-        let query_build = if query_items.is_empty() {
-            quote! { vec![] }
+        let query_call = if query_items.is_empty() {
+            quote! { }
         } else {
             quote! {
-                [
+                .query::<[(&str, Option<String>)]>(&[
                     #(#query_items,)*
-                ]
+                ])
             }
         };
 
@@ -937,7 +937,7 @@ impl Generator {
             let request = #client.client
                 . #method_func (#url_path)
                 #(#body_func)*
-                .query::<[(&str, Option<String>)]>(&#query_build)
+                #query_call
                 #websock_hdrs
                 .build()?;
             #pre_hook

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -707,7 +707,7 @@ impl Generator {
                     let qn_ident = format_ident!("{}", &param.name);
                     Some(if *required {
                         quote! {
-                            (#qn, #qn_ident .to_string())
+                            (#qn, Some(#qn_ident .to_string()))
                         }
                     } else {
                         quote! {

--- a/progenitor-impl/src/template.rs
+++ b/progenitor-impl/src/template.rs
@@ -50,7 +50,7 @@ impl PathTemplate {
         });
 
         quote! {
-            let url = format!(#fmt, #client.baseurl, #(#components,)*);
+            format!(#fmt, #client.baseurl, #(#components,)*)
         }
     }
 
@@ -281,10 +281,10 @@ mod tests {
         let t = parse("/measure/{number}").unwrap();
         let out = t.compile(rename, quote::quote! { self });
         let want = quote::quote! {
-            let url = format!("{}/measure/{}",
+            format!("{}/measure/{}",
                 self.baseurl,
                 encode_path(&number.to_string()),
-            );
+            )
         };
         assert_eq!(want.to_string(), out.to_string());
     }
@@ -301,12 +301,12 @@ mod tests {
         let t = parse("/abc/def:{one}:jkl/{two}/a:{three}").unwrap();
         let out = t.compile(rename, quote::quote! { self });
         let want = quote::quote! {
-            let url = format!("{}/abc/def:{}:jkl/{}/a:{}",
+            format!("{}/abc/def:{}:jkl/{}/a:{}",
                 self.baseurl,
                 encode_path(&one.to_string()),
                 encode_path(&two.to_string()),
                 encode_path(&three.to_string()),
-            );
+            )
         };
         assert_eq!(want.to_string(), out.to_string());
     }

--- a/progenitor-impl/tests/output/buildomat-builder-tagged.out
+++ b/progenitor-impl/tests/output/buildomat-builder-tagged.out
@@ -1520,7 +1520,7 @@ pub mod builder {
             let request = client
                 .client
                 .post(format!("{}/v1/control/hold", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1550,7 +1550,7 @@ pub mod builder {
             let request = client
                 .client
                 .post(format!("{}/v1/control/resume", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1599,7 +1599,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&task.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1629,7 +1629,7 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/v1/tasks", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1675,7 +1675,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/v1/tasks", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1791,7 +1791,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&task.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1858,7 +1858,7 @@ pub mod builder {
                     encode_path(&task.to_string()),
                     encode_path(&output.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1904,7 +1904,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/v1/users", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1934,7 +1934,7 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/v1/whoami", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1980,7 +1980,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/v1/worker/bootstrap", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2010,7 +2010,7 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/v1/worker/ping", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2073,7 +2073,7 @@ pub mod builder {
                     encode_path(&task.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2140,7 +2140,7 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/octet-stream"),
                 )
                 .body(body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2203,7 +2203,7 @@ pub mod builder {
                     encode_path(&task.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2266,7 +2266,7 @@ pub mod builder {
                     encode_path(&task.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2296,7 +2296,7 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/v1/workers", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2326,7 +2326,7 @@ pub mod builder {
             let request = client
                 .client
                 .post(format!("{}/v1/workers/recycle", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/buildomat-builder-tagged.out
+++ b/progenitor-impl/tests/output/buildomat-builder-tagged.out
@@ -1724,10 +1724,10 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &minseq {
-                query.push(("minseq", v.to_string()));
-            }
+            let query = [("minseq", minseq.map(|v| v.to_string()))]
+                .into_iter()
+                .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+                .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/buildomat-builder-tagged.out
+++ b/progenitor-impl/tests/output/buildomat-builder-tagged.out
@@ -1517,8 +1517,11 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/control/hold`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/control/hold", client.baseurl,);
-            let request = client.client.post(url).build()?;
+            let request = client
+                .client
+                .post(format!("{}/v1/control/hold", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1544,8 +1547,11 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/control/resume`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/control/resume", client.baseurl,);
-            let request = client.client.post(url).build()?;
+            let request = client
+                .client
+                .post(format!("{}/v1/control/resume", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1586,12 +1592,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Task>, Error<()>> {
             let Self { client, task } = self;
             let task = task.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/v1/task/{}",
-                client.baseurl,
-                encode_path(&task.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/v1/task/{}",
+                    client.baseurl,
+                    encode_path(&task.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1617,8 +1626,11 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/tasks`
         pub async fn send(self) -> Result<ResponseValue<Vec<types::Task>>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/tasks", client.baseurl,);
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!("{}/v1/tasks", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1659,8 +1671,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::TaskSubmitResult>, Error<()>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/tasks", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/v1/tasks", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1719,16 +1735,15 @@ pub mod builder {
             } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let minseq = minseq.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/v1/tasks/{}/events",
-                client.baseurl,
-                encode_path(&task.to_string()),
-            );
-            let query = [("minseq", minseq.map(|v| v.to_string()))]
-                .into_iter()
-                .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-                .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/v1/tasks/{}/events",
+                    client.baseurl,
+                    encode_path(&task.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[("minseq", minseq.map(|v| v.to_string()))])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1769,12 +1784,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<Vec<types::TaskOutput>>, Error<()>> {
             let Self { client, task } = self;
             let task = task.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/v1/tasks/{}/outputs",
-                client.baseurl,
-                encode_path(&task.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/v1/tasks/{}/outputs",
+                    client.baseurl,
+                    encode_path(&task.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1832,13 +1850,16 @@ pub mod builder {
             } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let output = output.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/v1/tasks/{}/outputs/{}",
-                client.baseurl,
-                encode_path(&task.to_string()),
-                encode_path(&output.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/v1/tasks/{}/outputs/{}",
+                    client.baseurl,
+                    encode_path(&task.to_string()),
+                    encode_path(&output.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1879,8 +1900,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::UserCreateResult>, Error<()>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/users", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/v1/users", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1906,8 +1931,11 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/whoami`
         pub async fn send(self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/whoami", client.baseurl,);
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!("{}/v1/whoami", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1948,8 +1976,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::WorkerBootstrapResult>, Error<()>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/worker/bootstrap", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/v1/worker/bootstrap", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1975,8 +2007,11 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/worker/ping`
         pub async fn send(self) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/worker/ping", client.baseurl,);
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!("{}/v1/worker/ping", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -2030,12 +2065,16 @@ pub mod builder {
             let Self { client, task, body } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/v1/worker/task/{}/append",
-                client.baseurl,
-                encode_path(&task.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/v1/worker/task/{}/append",
+                    client.baseurl,
+                    encode_path(&task.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -2089,19 +2128,19 @@ pub mod builder {
             let Self { client, task, body } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/v1/worker/task/{}/chunk",
-                client.baseurl,
-                encode_path(&task.to_string()),
-            );
             let request = client
                 .client
-                .post(url)
+                .post(format!(
+                    "{}/v1/worker/task/{}/chunk",
+                    client.baseurl,
+                    encode_path(&task.to_string()),
+                ))
                 .header(
                     reqwest::header::CONTENT_TYPE,
                     reqwest::header::HeaderValue::from_static("application/octet-stream"),
                 )
                 .body(body)
+                .query::<[(&str, Option<String>)]>(&vec![])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2156,12 +2195,16 @@ pub mod builder {
             let Self { client, task, body } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/v1/worker/task/{}/complete",
-                client.baseurl,
-                encode_path(&task.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/v1/worker/task/{}/complete",
+                    client.baseurl,
+                    encode_path(&task.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -2215,12 +2258,16 @@ pub mod builder {
             let Self { client, task, body } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/v1/worker/task/{}/output",
-                client.baseurl,
-                encode_path(&task.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/v1/worker/task/{}/output",
+                    client.baseurl,
+                    encode_path(&task.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -2246,8 +2293,11 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/workers`
         pub async fn send(self) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/workers", client.baseurl,);
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!("{}/v1/workers", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -2273,8 +2323,11 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/workers/recycle`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/workers/recycle", client.baseurl,);
-            let request = client.client.post(url).build()?;
+            let request = client
+                .client
+                .post(format!("{}/v1/workers/recycle", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {

--- a/progenitor-impl/tests/output/buildomat-builder-tagged.out
+++ b/progenitor-impl/tests/output/buildomat-builder-tagged.out
@@ -1520,7 +1520,6 @@ pub mod builder {
             let request = client
                 .client
                 .post(format!("{}/v1/control/hold", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1550,7 +1549,6 @@ pub mod builder {
             let request = client
                 .client
                 .post(format!("{}/v1/control/resume", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1599,7 +1597,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&task.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1629,7 +1626,6 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/v1/tasks", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1675,7 +1671,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/v1/tasks", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1791,7 +1786,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&task.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1858,7 +1852,6 @@ pub mod builder {
                     encode_path(&task.to_string()),
                     encode_path(&output.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1904,7 +1897,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/v1/users", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1934,7 +1926,6 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/v1/whoami", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1980,7 +1971,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/v1/worker/bootstrap", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2010,7 +2000,6 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/v1/worker/ping", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2073,7 +2062,6 @@ pub mod builder {
                     encode_path(&task.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2140,7 +2128,6 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/octet-stream"),
                 )
                 .body(body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2203,7 +2190,6 @@ pub mod builder {
                     encode_path(&task.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2266,7 +2252,6 @@ pub mod builder {
                     encode_path(&task.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2296,7 +2281,6 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/v1/workers", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2326,7 +2310,6 @@ pub mod builder {
             let request = client
                 .client
                 .post(format!("{}/v1/workers/recycle", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/buildomat-builder.out
+++ b/progenitor-impl/tests/output/buildomat-builder.out
@@ -1520,7 +1520,7 @@ pub mod builder {
             let request = client
                 .client
                 .post(format!("{}/v1/control/hold", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1550,7 +1550,7 @@ pub mod builder {
             let request = client
                 .client
                 .post(format!("{}/v1/control/resume", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1599,7 +1599,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&task.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1629,7 +1629,7 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/v1/tasks", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1675,7 +1675,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/v1/tasks", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1791,7 +1791,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&task.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1858,7 +1858,7 @@ pub mod builder {
                     encode_path(&task.to_string()),
                     encode_path(&output.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1904,7 +1904,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/v1/users", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1934,7 +1934,7 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/v1/whoami", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1980,7 +1980,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/v1/worker/bootstrap", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2010,7 +2010,7 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/v1/worker/ping", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2073,7 +2073,7 @@ pub mod builder {
                     encode_path(&task.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2140,7 +2140,7 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/octet-stream"),
                 )
                 .body(body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2203,7 +2203,7 @@ pub mod builder {
                     encode_path(&task.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2266,7 +2266,7 @@ pub mod builder {
                     encode_path(&task.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2296,7 +2296,7 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/v1/workers", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2326,7 +2326,7 @@ pub mod builder {
             let request = client
                 .client
                 .post(format!("{}/v1/workers/recycle", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/buildomat-builder.out
+++ b/progenitor-impl/tests/output/buildomat-builder.out
@@ -1724,10 +1724,10 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &minseq {
-                query.push(("minseq", v.to_string()));
-            }
+            let query = [("minseq", minseq.map(|v| v.to_string()))]
+                .into_iter()
+                .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+                .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/buildomat-builder.out
+++ b/progenitor-impl/tests/output/buildomat-builder.out
@@ -1517,8 +1517,11 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/control/hold`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/control/hold", client.baseurl,);
-            let request = client.client.post(url).build()?;
+            let request = client
+                .client
+                .post(format!("{}/v1/control/hold", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1544,8 +1547,11 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/control/resume`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/control/resume", client.baseurl,);
-            let request = client.client.post(url).build()?;
+            let request = client
+                .client
+                .post(format!("{}/v1/control/resume", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1586,12 +1592,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Task>, Error<()>> {
             let Self { client, task } = self;
             let task = task.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/v1/task/{}",
-                client.baseurl,
-                encode_path(&task.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/v1/task/{}",
+                    client.baseurl,
+                    encode_path(&task.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1617,8 +1626,11 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/tasks`
         pub async fn send(self) -> Result<ResponseValue<Vec<types::Task>>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/tasks", client.baseurl,);
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!("{}/v1/tasks", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1659,8 +1671,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::TaskSubmitResult>, Error<()>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/tasks", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/v1/tasks", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1719,16 +1735,15 @@ pub mod builder {
             } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let minseq = minseq.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/v1/tasks/{}/events",
-                client.baseurl,
-                encode_path(&task.to_string()),
-            );
-            let query = [("minseq", minseq.map(|v| v.to_string()))]
-                .into_iter()
-                .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-                .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/v1/tasks/{}/events",
+                    client.baseurl,
+                    encode_path(&task.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[("minseq", minseq.map(|v| v.to_string()))])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1769,12 +1784,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<Vec<types::TaskOutput>>, Error<()>> {
             let Self { client, task } = self;
             let task = task.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/v1/tasks/{}/outputs",
-                client.baseurl,
-                encode_path(&task.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/v1/tasks/{}/outputs",
+                    client.baseurl,
+                    encode_path(&task.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1832,13 +1850,16 @@ pub mod builder {
             } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let output = output.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/v1/tasks/{}/outputs/{}",
-                client.baseurl,
-                encode_path(&task.to_string()),
-                encode_path(&output.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/v1/tasks/{}/outputs/{}",
+                    client.baseurl,
+                    encode_path(&task.to_string()),
+                    encode_path(&output.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1879,8 +1900,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::UserCreateResult>, Error<()>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/users", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/v1/users", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1906,8 +1931,11 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/whoami`
         pub async fn send(self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/whoami", client.baseurl,);
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!("{}/v1/whoami", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1948,8 +1976,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::WorkerBootstrapResult>, Error<()>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/worker/bootstrap", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/v1/worker/bootstrap", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1975,8 +2007,11 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/worker/ping`
         pub async fn send(self) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/worker/ping", client.baseurl,);
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!("{}/v1/worker/ping", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -2030,12 +2065,16 @@ pub mod builder {
             let Self { client, task, body } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/v1/worker/task/{}/append",
-                client.baseurl,
-                encode_path(&task.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/v1/worker/task/{}/append",
+                    client.baseurl,
+                    encode_path(&task.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -2089,19 +2128,19 @@ pub mod builder {
             let Self { client, task, body } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/v1/worker/task/{}/chunk",
-                client.baseurl,
-                encode_path(&task.to_string()),
-            );
             let request = client
                 .client
-                .post(url)
+                .post(format!(
+                    "{}/v1/worker/task/{}/chunk",
+                    client.baseurl,
+                    encode_path(&task.to_string()),
+                ))
                 .header(
                     reqwest::header::CONTENT_TYPE,
                     reqwest::header::HeaderValue::from_static("application/octet-stream"),
                 )
                 .body(body)
+                .query::<[(&str, Option<String>)]>(&vec![])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2156,12 +2195,16 @@ pub mod builder {
             let Self { client, task, body } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/v1/worker/task/{}/complete",
-                client.baseurl,
-                encode_path(&task.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/v1/worker/task/{}/complete",
+                    client.baseurl,
+                    encode_path(&task.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -2215,12 +2258,16 @@ pub mod builder {
             let Self { client, task, body } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/v1/worker/task/{}/output",
-                client.baseurl,
-                encode_path(&task.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/v1/worker/task/{}/output",
+                    client.baseurl,
+                    encode_path(&task.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -2246,8 +2293,11 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/workers`
         pub async fn send(self) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/workers", client.baseurl,);
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!("{}/v1/workers", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -2273,8 +2323,11 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/workers/recycle`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/workers/recycle", client.baseurl,);
-            let request = client.client.post(url).build()?;
+            let request = client
+                .client
+                .post(format!("{}/v1/workers/recycle", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {

--- a/progenitor-impl/tests/output/buildomat-builder.out
+++ b/progenitor-impl/tests/output/buildomat-builder.out
@@ -1520,7 +1520,6 @@ pub mod builder {
             let request = client
                 .client
                 .post(format!("{}/v1/control/hold", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1550,7 +1549,6 @@ pub mod builder {
             let request = client
                 .client
                 .post(format!("{}/v1/control/resume", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1599,7 +1597,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&task.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1629,7 +1626,6 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/v1/tasks", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1675,7 +1671,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/v1/tasks", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1791,7 +1786,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&task.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1858,7 +1852,6 @@ pub mod builder {
                     encode_path(&task.to_string()),
                     encode_path(&output.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1904,7 +1897,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/v1/users", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1934,7 +1926,6 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/v1/whoami", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1980,7 +1971,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/v1/worker/bootstrap", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2010,7 +2000,6 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/v1/worker/ping", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2073,7 +2062,6 @@ pub mod builder {
                     encode_path(&task.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2140,7 +2128,6 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/octet-stream"),
                 )
                 .body(body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2203,7 +2190,6 @@ pub mod builder {
                     encode_path(&task.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2266,7 +2252,6 @@ pub mod builder {
                     encode_path(&task.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2296,7 +2281,6 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/v1/workers", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -2326,7 +2310,6 @@ pub mod builder {
             let request = client
                 .client
                 .post(format!("{}/v1/workers/recycle", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/buildomat-positional.out
+++ b/progenitor-impl/tests/output/buildomat-positional.out
@@ -173,7 +173,7 @@ impl Client {
         let request = self
             .client
             .post(format!("{}/v1/control/hold", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -188,7 +188,7 @@ impl Client {
         let request = self
             .client
             .post(format!("{}/v1/control/resume", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -210,7 +210,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&task.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -225,7 +225,7 @@ impl Client {
         let request = self
             .client
             .get(format!("{}/v1/tasks", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -244,7 +244,7 @@ impl Client {
             .client
             .post(format!("{}/v1/tasks", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -289,7 +289,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&task.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -313,7 +313,7 @@ impl Client {
                 encode_path(&task.to_string()),
                 encode_path(&output.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -332,7 +332,7 @@ impl Client {
             .client
             .post(format!("{}/v1/users", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -347,7 +347,7 @@ impl Client {
         let request = self
             .client
             .get(format!("{}/v1/whoami", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -366,7 +366,7 @@ impl Client {
             .client
             .post(format!("{}/v1/worker/bootstrap", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -383,7 +383,7 @@ impl Client {
         let request = self
             .client
             .get(format!("{}/v1/worker/ping", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -407,7 +407,7 @@ impl Client {
                 encode_path(&task.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -435,7 +435,7 @@ impl Client {
                 reqwest::header::HeaderValue::from_static("application/octet-stream"),
             )
             .body(body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -459,7 +459,7 @@ impl Client {
                 encode_path(&task.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -483,7 +483,7 @@ impl Client {
                 encode_path(&task.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -500,7 +500,7 @@ impl Client {
         let request = self
             .client
             .get(format!("{}/v1/workers", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -515,7 +515,7 @@ impl Client {
         let request = self
             .client
             .post(format!("{}/v1/workers/recycle", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;

--- a/progenitor-impl/tests/output/buildomat-positional.out
+++ b/progenitor-impl/tests/output/buildomat-positional.out
@@ -173,7 +173,6 @@ impl Client {
         let request = self
             .client
             .post(format!("{}/v1/control/hold", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -188,7 +187,6 @@ impl Client {
         let request = self
             .client
             .post(format!("{}/v1/control/resume", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -210,7 +208,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&task.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -225,7 +222,6 @@ impl Client {
         let request = self
             .client
             .get(format!("{}/v1/tasks", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -244,7 +240,6 @@ impl Client {
             .client
             .post(format!("{}/v1/tasks", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -289,7 +284,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&task.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -313,7 +307,6 @@ impl Client {
                 encode_path(&task.to_string()),
                 encode_path(&output.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -332,7 +325,6 @@ impl Client {
             .client
             .post(format!("{}/v1/users", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -347,7 +339,6 @@ impl Client {
         let request = self
             .client
             .get(format!("{}/v1/whoami", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -366,7 +357,6 @@ impl Client {
             .client
             .post(format!("{}/v1/worker/bootstrap", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -383,7 +373,6 @@ impl Client {
         let request = self
             .client
             .get(format!("{}/v1/worker/ping", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -407,7 +396,6 @@ impl Client {
                 encode_path(&task.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -435,7 +423,6 @@ impl Client {
                 reqwest::header::HeaderValue::from_static("application/octet-stream"),
             )
             .body(body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -459,7 +446,6 @@ impl Client {
                 encode_path(&task.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -483,7 +469,6 @@ impl Client {
                 encode_path(&task.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -500,7 +485,6 @@ impl Client {
         let request = self
             .client
             .get(format!("{}/v1/workers", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -515,7 +499,6 @@ impl Client {
         let request = self
             .client
             .post(format!("{}/v1/workers/recycle", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;

--- a/progenitor-impl/tests/output/buildomat-positional.out
+++ b/progenitor-impl/tests/output/buildomat-positional.out
@@ -170,8 +170,11 @@ impl Client {
 impl Client {
     ///Sends a `POST` request to `/v1/control/hold`
     pub async fn control_hold<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
-        let url = format!("{}/v1/control/hold", self.baseurl,);
-        let request = self.client.post(url).build()?;
+        let request = self
+            .client
+            .post(format!("{}/v1/control/hold", self.baseurl,))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -182,8 +185,11 @@ impl Client {
 
     ///Sends a `POST` request to `/v1/control/resume`
     pub async fn control_resume<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
-        let url = format!("{}/v1/control/resume", self.baseurl,);
-        let request = self.client.post(url).build()?;
+        let request = self
+            .client
+            .post(format!("{}/v1/control/resume", self.baseurl,))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -197,12 +203,15 @@ impl Client {
         &'a self,
         task: &'a str,
     ) -> Result<ResponseValue<types::Task>, Error<()>> {
-        let url = format!(
-            "{}/v1/task/{}",
-            self.baseurl,
-            encode_path(&task.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/v1/task/{}",
+                self.baseurl,
+                encode_path(&task.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -213,8 +222,11 @@ impl Client {
 
     ///Sends a `GET` request to `/v1/tasks`
     pub async fn tasks_get<'a>(&'a self) -> Result<ResponseValue<Vec<types::Task>>, Error<()>> {
-        let url = format!("{}/v1/tasks", self.baseurl,);
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!("{}/v1/tasks", self.baseurl,))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -228,8 +240,12 @@ impl Client {
         &'a self,
         body: &'a types::TaskSubmit,
     ) -> Result<ResponseValue<types::TaskSubmitResult>, Error<()>> {
-        let url = format!("{}/v1/tasks", self.baseurl,);
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!("{}/v1/tasks", self.baseurl,))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -244,16 +260,15 @@ impl Client {
         task: &'a str,
         minseq: Option<u32>,
     ) -> Result<ResponseValue<Vec<types::TaskEvent>>, Error<()>> {
-        let url = format!(
-            "{}/v1/tasks/{}/events",
-            self.baseurl,
-            encode_path(&task.to_string()),
-        );
-        let query = [("minseq", minseq.map(|v| v.to_string()))]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/v1/tasks/{}/events",
+                self.baseurl,
+                encode_path(&task.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&[("minseq", minseq.map(|v| v.to_string()))])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -267,12 +282,15 @@ impl Client {
         &'a self,
         task: &'a str,
     ) -> Result<ResponseValue<Vec<types::TaskOutput>>, Error<()>> {
-        let url = format!(
-            "{}/v1/tasks/{}/outputs",
-            self.baseurl,
-            encode_path(&task.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/v1/tasks/{}/outputs",
+                self.baseurl,
+                encode_path(&task.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -287,13 +305,16 @@ impl Client {
         task: &'a str,
         output: &'a str,
     ) -> Result<ResponseValue<ByteStream>, Error<()>> {
-        let url = format!(
-            "{}/v1/tasks/{}/outputs/{}",
-            self.baseurl,
-            encode_path(&task.to_string()),
-            encode_path(&output.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/v1/tasks/{}/outputs/{}",
+                self.baseurl,
+                encode_path(&task.to_string()),
+                encode_path(&output.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -307,8 +328,12 @@ impl Client {
         &'a self,
         body: &'a types::UserCreate,
     ) -> Result<ResponseValue<types::UserCreateResult>, Error<()>> {
-        let url = format!("{}/v1/users", self.baseurl,);
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!("{}/v1/users", self.baseurl,))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -319,8 +344,11 @@ impl Client {
 
     ///Sends a `GET` request to `/v1/whoami`
     pub async fn whoami<'a>(&'a self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
-        let url = format!("{}/v1/whoami", self.baseurl,);
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!("{}/v1/whoami", self.baseurl,))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -334,8 +362,12 @@ impl Client {
         &'a self,
         body: &'a types::WorkerBootstrap,
     ) -> Result<ResponseValue<types::WorkerBootstrapResult>, Error<()>> {
-        let url = format!("{}/v1/worker/bootstrap", self.baseurl,);
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!("{}/v1/worker/bootstrap", self.baseurl,))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -348,8 +380,11 @@ impl Client {
     pub async fn worker_ping<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
-        let url = format!("{}/v1/worker/ping", self.baseurl,);
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!("{}/v1/worker/ping", self.baseurl,))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -364,12 +399,16 @@ impl Client {
         task: &'a str,
         body: &'a types::WorkerAppendTask,
     ) -> Result<ResponseValue<()>, Error<()>> {
-        let url = format!(
-            "{}/v1/worker/task/{}/append",
-            self.baseurl,
-            encode_path(&task.to_string()),
-        );
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!(
+                "{}/v1/worker/task/{}/append",
+                self.baseurl,
+                encode_path(&task.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -384,19 +423,19 @@ impl Client {
         task: &'a str,
         body: B,
     ) -> Result<ResponseValue<types::UploadedChunk>, Error<()>> {
-        let url = format!(
-            "{}/v1/worker/task/{}/chunk",
-            self.baseurl,
-            encode_path(&task.to_string()),
-        );
         let request = self
             .client
-            .post(url)
+            .post(format!(
+                "{}/v1/worker/task/{}/chunk",
+                self.baseurl,
+                encode_path(&task.to_string()),
+            ))
             .header(
                 reqwest::header::CONTENT_TYPE,
                 reqwest::header::HeaderValue::from_static("application/octet-stream"),
             )
             .body(body)
+            .query::<[(&str, Option<String>)]>(&vec![])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -412,12 +451,16 @@ impl Client {
         task: &'a str,
         body: &'a types::WorkerCompleteTask,
     ) -> Result<ResponseValue<()>, Error<()>> {
-        let url = format!(
-            "{}/v1/worker/task/{}/complete",
-            self.baseurl,
-            encode_path(&task.to_string()),
-        );
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!(
+                "{}/v1/worker/task/{}/complete",
+                self.baseurl,
+                encode_path(&task.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -432,12 +475,16 @@ impl Client {
         task: &'a str,
         body: &'a types::WorkerAddOutput,
     ) -> Result<ResponseValue<()>, Error<()>> {
-        let url = format!(
-            "{}/v1/worker/task/{}/output",
-            self.baseurl,
-            encode_path(&task.to_string()),
-        );
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!(
+                "{}/v1/worker/task/{}/output",
+                self.baseurl,
+                encode_path(&task.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -450,8 +497,11 @@ impl Client {
     pub async fn workers_list<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
-        let url = format!("{}/v1/workers", self.baseurl,);
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!("{}/v1/workers", self.baseurl,))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -462,8 +512,11 @@ impl Client {
 
     ///Sends a `POST` request to `/v1/workers/recycle`
     pub async fn workers_recycle<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
-        let url = format!("{}/v1/workers/recycle", self.baseurl,);
-        let request = self.client.post(url).build()?;
+        let request = self
+            .client
+            .post(format!("{}/v1/workers/recycle", self.baseurl,))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {

--- a/progenitor-impl/tests/output/buildomat-positional.out
+++ b/progenitor-impl/tests/output/buildomat-positional.out
@@ -249,11 +249,10 @@ impl Client {
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let mut query = Vec::new();
-        if let Some(v) = &minseq {
-            query.push(("minseq", v.to_string()));
-        }
-
+        let query = [("minseq", minseq.map(|v| v.to_string()))]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;

--- a/progenitor-impl/tests/output/keeper-builder-tagged.out
+++ b/progenitor-impl/tests/output/keeper-builder-tagged.out
@@ -865,7 +865,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/enrol", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -895,7 +895,7 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/global/jobs", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -925,7 +925,7 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/ping", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -971,7 +971,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/report/finish", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1017,7 +1017,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/report/output", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1063,7 +1063,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/report/start", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/keeper-builder-tagged.out
+++ b/progenitor-impl/tests/output/keeper-builder-tagged.out
@@ -861,8 +861,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/enrol", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/enrol", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -888,8 +892,11 @@ pub mod builder {
         ///Sends a `GET` request to `/global/jobs`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalJobsResult>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/global/jobs", client.baseurl,);
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!("{}/global/jobs", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -915,8 +922,11 @@ pub mod builder {
         ///Sends a `GET` request to `/ping`
         pub async fn send(self) -> Result<ResponseValue<types::PingResult>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/ping", client.baseurl,);
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!("{}/ping", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -957,8 +967,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/report/finish", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/report/finish", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -999,8 +1013,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/report/output", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/report/output", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1041,8 +1059,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/report/start", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/report/start", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {

--- a/progenitor-impl/tests/output/keeper-builder-tagged.out
+++ b/progenitor-impl/tests/output/keeper-builder-tagged.out
@@ -865,7 +865,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/enrol", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -895,7 +894,6 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/global/jobs", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -925,7 +923,6 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/ping", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -971,7 +968,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/report/finish", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1017,7 +1013,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/report/output", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1063,7 +1058,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/report/start", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/keeper-builder.out
+++ b/progenitor-impl/tests/output/keeper-builder.out
@@ -865,7 +865,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/enrol", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -895,7 +895,7 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/global/jobs", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -925,7 +925,7 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/ping", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -971,7 +971,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/report/finish", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1017,7 +1017,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/report/output", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1063,7 +1063,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/report/start", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/keeper-builder.out
+++ b/progenitor-impl/tests/output/keeper-builder.out
@@ -861,8 +861,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/enrol", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/enrol", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -888,8 +892,11 @@ pub mod builder {
         ///Sends a `GET` request to `/global/jobs`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalJobsResult>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/global/jobs", client.baseurl,);
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!("{}/global/jobs", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -915,8 +922,11 @@ pub mod builder {
         ///Sends a `GET` request to `/ping`
         pub async fn send(self) -> Result<ResponseValue<types::PingResult>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/ping", client.baseurl,);
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!("{}/ping", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -957,8 +967,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/report/finish", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/report/finish", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -999,8 +1013,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/report/output", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/report/output", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1041,8 +1059,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/report/start", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/report/start", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {

--- a/progenitor-impl/tests/output/keeper-builder.out
+++ b/progenitor-impl/tests/output/keeper-builder.out
@@ -865,7 +865,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/enrol", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -895,7 +894,6 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/global/jobs", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -925,7 +923,6 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/ping", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -971,7 +968,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/report/finish", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1017,7 +1013,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/report/output", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1063,7 +1058,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/report/start", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/keeper-positional.out
+++ b/progenitor-impl/tests/output/keeper-positional.out
@@ -114,8 +114,12 @@ impl Client {
         &'a self,
         body: &'a types::EnrolBody,
     ) -> Result<ResponseValue<()>, Error<()>> {
-        let url = format!("{}/enrol", self.baseurl,);
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!("{}/enrol", self.baseurl,))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -128,8 +132,11 @@ impl Client {
     pub async fn global_jobs<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::GlobalJobsResult>, Error<()>> {
-        let url = format!("{}/global/jobs", self.baseurl,);
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!("{}/global/jobs", self.baseurl,))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -140,8 +147,11 @@ impl Client {
 
     ///Sends a `GET` request to `/ping`
     pub async fn ping<'a>(&'a self) -> Result<ResponseValue<types::PingResult>, Error<()>> {
-        let url = format!("{}/ping", self.baseurl,);
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!("{}/ping", self.baseurl,))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -155,8 +165,12 @@ impl Client {
         &'a self,
         body: &'a types::ReportFinishBody,
     ) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
-        let url = format!("{}/report/finish", self.baseurl,);
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!("{}/report/finish", self.baseurl,))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -170,8 +184,12 @@ impl Client {
         &'a self,
         body: &'a types::ReportOutputBody,
     ) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
-        let url = format!("{}/report/output", self.baseurl,);
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!("{}/report/output", self.baseurl,))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -185,8 +203,12 @@ impl Client {
         &'a self,
         body: &'a types::ReportStartBody,
     ) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
-        let url = format!("{}/report/start", self.baseurl,);
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!("{}/report/start", self.baseurl,))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {

--- a/progenitor-impl/tests/output/keeper-positional.out
+++ b/progenitor-impl/tests/output/keeper-positional.out
@@ -118,7 +118,7 @@ impl Client {
             .client
             .post(format!("{}/enrol", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -135,7 +135,7 @@ impl Client {
         let request = self
             .client
             .get(format!("{}/global/jobs", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -150,7 +150,7 @@ impl Client {
         let request = self
             .client
             .get(format!("{}/ping", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -169,7 +169,7 @@ impl Client {
             .client
             .post(format!("{}/report/finish", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -188,7 +188,7 @@ impl Client {
             .client
             .post(format!("{}/report/output", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -207,7 +207,7 @@ impl Client {
             .client
             .post(format!("{}/report/start", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;

--- a/progenitor-impl/tests/output/keeper-positional.out
+++ b/progenitor-impl/tests/output/keeper-positional.out
@@ -118,7 +118,6 @@ impl Client {
             .client
             .post(format!("{}/enrol", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -135,7 +134,6 @@ impl Client {
         let request = self
             .client
             .get(format!("{}/global/jobs", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -147,11 +145,7 @@ impl Client {
 
     ///Sends a `GET` request to `/ping`
     pub async fn ping<'a>(&'a self) -> Result<ResponseValue<types::PingResult>, Error<()>> {
-        let request = self
-            .client
-            .get(format!("{}/ping", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&[])
-            .build()?;
+        let request = self.client.get(format!("{}/ping", self.baseurl,)).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -169,7 +163,6 @@ impl Client {
             .client
             .post(format!("{}/report/finish", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -188,7 +181,6 @@ impl Client {
             .client
             .post(format!("{}/report/output", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -207,7 +199,6 @@ impl Client {
             .client
             .post(format!("{}/report/start", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;

--- a/progenitor-impl/tests/output/nexus-builder-tagged.out
+++ b/progenitor-impl/tests/output/nexus-builder-tagged.out
@@ -13714,12 +13714,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/by-id/disks/{}",
-                client.baseurl,
-                encode_path(&id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/by-id/disks/{}",
+                    client.baseurl,
+                    encode_path(&id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -13766,12 +13769,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/by-id/global-images/{}",
-                client.baseurl,
-                encode_path(&id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/by-id/global-images/{}",
+                    client.baseurl,
+                    encode_path(&id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -13818,12 +13824,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/by-id/images/{}",
-                client.baseurl,
-                encode_path(&id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/by-id/images/{}",
+                    client.baseurl,
+                    encode_path(&id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -13870,12 +13879,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/by-id/instances/{}",
-                client.baseurl,
-                encode_path(&id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/by-id/instances/{}",
+                    client.baseurl,
+                    encode_path(&id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -13925,12 +13937,15 @@ pub mod builder {
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/by-id/network-interfaces/{}",
-                client.baseurl,
-                encode_path(&id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/by-id/network-interfaces/{}",
+                    client.baseurl,
+                    encode_path(&id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -13977,12 +13992,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/by-id/organizations/{}",
-                client.baseurl,
-                encode_path(&id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/by-id/organizations/{}",
+                    client.baseurl,
+                    encode_path(&id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14029,12 +14047,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/by-id/projects/{}",
-                client.baseurl,
-                encode_path(&id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/by-id/projects/{}",
+                    client.baseurl,
+                    encode_path(&id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14081,12 +14102,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/by-id/snapshots/{}",
-                client.baseurl,
-                encode_path(&id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/by-id/snapshots/{}",
+                    client.baseurl,
+                    encode_path(&id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14133,12 +14157,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/by-id/vpc-router-routes/{}",
-                client.baseurl,
-                encode_path(&id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/by-id/vpc-router-routes/{}",
+                    client.baseurl,
+                    encode_path(&id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14185,12 +14212,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/by-id/vpc-routers/{}",
-                client.baseurl,
-                encode_path(&id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/by-id/vpc-routers/{}",
+                    client.baseurl,
+                    encode_path(&id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14237,12 +14267,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/by-id/vpc-subnets/{}",
-                client.baseurl,
-                encode_path(&id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/by-id/vpc-subnets/{}",
+                    client.baseurl,
+                    encode_path(&id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14289,12 +14322,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/by-id/vpcs/{}",
-                client.baseurl,
-                encode_path(&id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/by-id/vpcs/{}",
+                    client.baseurl,
+                    encode_path(&id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14341,8 +14377,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/device/auth", client.baseurl,);
-            let request = client.client.post(url).form_urlencoded(&body)?.build()?;
+            let request = client
+                .client
+                .post(format!("{}/device/auth", client.baseurl,))
+                .form_urlencoded(&body)?
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14383,8 +14423,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/device/confirm", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/device/confirm", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14431,8 +14475,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/device/token", client.baseurl,);
-            let request = client.client.post(url).form_urlencoded(&body)?.build()?;
+            let request = client
+                .client
+                .post(format!("{}/device/token", client.baseurl,))
+                .form_urlencoded(&body)?
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14507,16 +14555,15 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/hardware/racks", client.baseurl,);
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!("{}/hardware/racks", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14610,12 +14657,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Rack>, Error<types::Error>> {
             let Self { client, rack_id } = self;
             let rack_id = rack_id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/hardware/racks/{}",
-                client.baseurl,
-                encode_path(&rack_id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/hardware/racks/{}",
+                    client.baseurl,
+                    encode_path(&rack_id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14696,16 +14746,15 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/hardware/sleds", client.baseurl,);
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!("{}/hardware/sleds", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14799,12 +14848,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Sled>, Error<types::Error>> {
             let Self { client, sled_id } = self;
             let sled_id = sled_id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/hardware/sleds/{}",
-                client.baseurl,
-                encode_path(&sled_id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/hardware/sleds/{}",
+                    client.baseurl,
+                    encode_path(&sled_id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14885,16 +14937,15 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/images", client.baseurl,);
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!("{}/images", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14988,8 +15039,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/images", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/images", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -15036,12 +15091,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
             let Self { client, image_name } = self;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/images/{}",
-                client.baseurl,
-                encode_path(&image_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/images/{}",
+                    client.baseurl,
+                    encode_path(&image_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -15088,12 +15146,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, image_name } = self;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/images/{}",
-                client.baseurl,
-                encode_path(&image_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/images/{}",
+                    client.baseurl,
+                    encode_path(&image_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -15174,16 +15235,15 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/ip-pools", client.baseurl,);
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!("{}/ip-pools", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -15277,8 +15337,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/ip-pools", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/ip-pools", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -15325,12 +15389,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client, pool_name } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/ip-pools/{}",
-                client.baseurl,
-                encode_path(&pool_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/ip-pools/{}",
+                    client.baseurl,
+                    encode_path(&pool_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -15394,12 +15461,16 @@ pub mod builder {
             } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/ip-pools/{}",
-                client.baseurl,
-                encode_path(&pool_name.to_string()),
-            );
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!(
+                    "{}/ip-pools/{}",
+                    client.baseurl,
+                    encode_path(&pool_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -15446,12 +15517,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, pool_name } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/ip-pools/{}",
-                client.baseurl,
-                encode_path(&pool_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/ip-pools/{}",
+                    client.baseurl,
+                    encode_path(&pool_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -15532,19 +15606,18 @@ pub mod builder {
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/ip-pools/{}/ranges",
-                client.baseurl,
-                encode_path(&pool_name.to_string()),
-            );
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/ip-pools/{}/ranges",
+                    client.baseurl,
+                    encode_path(&pool_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -15654,12 +15727,16 @@ pub mod builder {
             } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/ip-pools/{}/ranges/add",
-                client.baseurl,
-                encode_path(&pool_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/ip-pools/{}/ranges/add",
+                    client.baseurl,
+                    encode_path(&pool_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -15723,12 +15800,16 @@ pub mod builder {
             } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/ip-pools/{}/ranges/remove",
-                client.baseurl,
-                encode_path(&pool_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/ip-pools/{}/ranges/remove",
+                    client.baseurl,
+                    encode_path(&pool_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -15775,8 +15856,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/login", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/login", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -15834,13 +15919,16 @@ pub mod builder {
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let provider_name = provider_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/login/{}/{}",
-                client.baseurl,
-                encode_path(&silo_name.to_string()),
-                encode_path(&provider_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/login/{}/{}",
+                    client.baseurl,
+                    encode_path(&silo_name.to_string()),
+                    encode_path(&provider_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -15912,20 +16000,20 @@ pub mod builder {
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let provider_name = provider_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/login/{}/{}",
-                client.baseurl,
-                encode_path(&silo_name.to_string()),
-                encode_path(&provider_name.to_string()),
-            );
             let request = client
                 .client
-                .post(url)
+                .post(format!(
+                    "{}/login/{}/{}",
+                    client.baseurl,
+                    encode_path(&silo_name.to_string()),
+                    encode_path(&provider_name.to_string()),
+                ))
                 .header(
                     reqwest::header::CONTENT_TYPE,
                     reqwest::header::HeaderValue::from_static("application/octet-stream"),
                 )
                 .body(body)
+                .query::<[(&str, Option<String>)]>(&vec![])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15952,8 +16040,11 @@ pub mod builder {
         ///Sends a `POST` request to `/logout`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
             let Self { client } = self;
-            let url = format!("{}/logout", client.baseurl,);
-            let request = client.client.post(url).build()?;
+            let request = client
+                .client
+                .post(format!("{}/logout", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -16028,16 +16119,15 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/organizations", client.baseurl,);
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!("{}/organizations", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -16131,8 +16221,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/organizations", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/organizations", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -16182,12 +16276,15 @@ pub mod builder {
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -16251,12 +16348,16 @@ pub mod builder {
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-            );
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!(
+                    "{}/organizations/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -16306,12 +16407,15 @@ pub mod builder {
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/organizations/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -16363,12 +16467,15 @@ pub mod builder {
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/policy",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/policy",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -16434,12 +16541,16 @@ pub mod builder {
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/policy",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-            );
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!(
+                    "{}/organizations/{}/policy",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -16535,20 +16646,19 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-            );
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -16661,12 +16771,16 @@ pub mod builder {
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -16731,13 +16845,16 @@ pub mod builder {
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -16816,13 +16933,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!(
+                    "{}/organizations/{}/projects/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -16887,13 +17008,16 @@ pub mod builder {
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/organizations/{}/projects/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -17003,21 +17127,20 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/disks",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/disks",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -17144,13 +17267,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/disks",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/disks",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -17230,14 +17357,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let disk_name = disk_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/disks/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&disk_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/disks/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&disk_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -17317,14 +17447,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let disk_name = disk_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/disks/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&disk_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/organizations/{}/projects/{}/disks/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&disk_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -17473,24 +17606,23 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let start_time = start_time.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/disks/{}/metrics/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&disk_name.to_string()),
-                encode_path(&metric_name.to_string()),
-            );
-            let query = [
-                ("end_time", end_time.map(|v| v.to_string())),
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("start_time", start_time.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/disks/{}/metrics/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&disk_name.to_string()),
+                    encode_path(&metric_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("end_time", end_time.map(|v| v.to_string())),
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("start_time", start_time.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -17650,21 +17782,20 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/images",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/images",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -17791,13 +17922,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/images",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/images",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -17877,14 +18012,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/images/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&image_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/images/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&image_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -17964,14 +18102,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/images/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&image_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/organizations/{}/projects/{}/images/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&image_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -18082,21 +18223,20 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/instances",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -18225,13 +18365,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/instances",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -18311,14 +18455,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -18398,14 +18545,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -18530,22 +18680,21 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}/disks",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-            );
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}/disks",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -18688,14 +18837,18 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}/disks/attach",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}/disks/attach",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -18789,14 +18942,18 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}/disks/detach",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}/disks/detach",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -18878,14 +19035,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}/external-ips",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}/external-ips",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -18979,14 +19139,18 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}/migrate",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}/migrate",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -19112,22 +19276,21 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-            );
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -19272,14 +19435,18 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -19375,15 +19542,18 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let interface_name = interface_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-                encode_path(&interface_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                    encode_path(&interface_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -19493,15 +19663,19 @@ pub mod builder {
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let interface_name = interface_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-                encode_path(&interface_name.to_string()),
-            );
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                    encode_path(&interface_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -19595,15 +19769,18 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let interface_name = interface_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-                encode_path(&interface_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                    encode_path(&interface_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -19683,14 +19860,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}/reboot",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-            );
-            let request = client.client.post(url).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}/reboot",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -19817,22 +19997,21 @@ pub mod builder {
             let from_start = from_start.map_err(Error::InvalidRequest)?;
             let max_bytes = max_bytes.map_err(Error::InvalidRequest)?;
             let most_recent = most_recent.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}/serial-console",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-            );
-            let query = [
-                ("from_start", from_start.map(|v| v.to_string())),
-                ("max_bytes", max_bytes.map(|v| v.to_string())),
-                ("most_recent", most_recent.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}/serial-console",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("from_start", from_start.map(|v| v.to_string())),
+                    ("max_bytes", max_bytes.map(|v| v.to_string())),
+                    ("most_recent", most_recent.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -19912,14 +20091,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}/start",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-            );
-            let request = client.client.post(url).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}/start",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -19999,14 +20181,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}/stop",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-            );
-            let request = client.client.post(url).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}/stop",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -20073,13 +20258,16 @@ pub mod builder {
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/policy",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/policy",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -20160,13 +20348,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/policy",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!(
+                    "{}/organizations/{}/projects/{}/policy",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -20277,21 +20469,20 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/snapshots",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/snapshots",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -20420,13 +20611,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/snapshots",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/snapshots",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -20506,14 +20701,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let snapshot_name = snapshot_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/snapshots/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&snapshot_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/snapshots/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&snapshot_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -20593,14 +20791,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let snapshot_name = snapshot_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/snapshots/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&snapshot_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/organizations/{}/projects/{}/snapshots/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&snapshot_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -20710,21 +20911,20 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/vpcs",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -20851,13 +21051,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/vpcs",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -20937,14 +21141,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -21038,14 +21245,18 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-            );
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -21125,14 +21336,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -21214,14 +21428,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -21317,14 +21534,18 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-            );
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -21449,22 +21670,21 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/routers",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-            );
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/routers",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -21607,14 +21827,18 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/routers",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/routers",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -21708,15 +21932,18 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-                encode_path(&router_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                    encode_path(&router_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -21824,15 +22051,19 @@ pub mod builder {
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-                encode_path(&router_name.to_string()),
-            );
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                    encode_path(&router_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -21926,15 +22157,18 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-                encode_path(&router_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                    encode_path(&router_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -22073,23 +22307,22 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-                encode_path(&router_name.to_string()),
-            );
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                    encode_path(&router_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -22246,15 +22479,19 @@ pub mod builder {
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-                encode_path(&router_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                    encode_path(&router_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -22362,16 +22599,19 @@ pub mod builder {
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
             let route_name = route_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-                encode_path(&router_name.to_string()),
-                encode_path(&route_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                    encode_path(&router_name.to_string()),
+                    encode_path(&route_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -22493,16 +22733,20 @@ pub mod builder {
             let router_name = router_name.map_err(Error::InvalidRequest)?;
             let route_name = route_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-                encode_path(&router_name.to_string()),
-                encode_path(&route_name.to_string()),
-            );
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                    encode_path(&router_name.to_string()),
+                    encode_path(&route_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -22610,16 +22854,19 @@ pub mod builder {
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
             let route_name = route_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-                encode_path(&router_name.to_string()),
-                encode_path(&route_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                    encode_path(&router_name.to_string()),
+                    encode_path(&route_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -22744,22 +22991,21 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-            );
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -22902,14 +23148,18 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -23003,15 +23253,18 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-                encode_path(&subnet_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                    encode_path(&subnet_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -23119,15 +23372,19 @@ pub mod builder {
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-                encode_path(&subnet_name.to_string()),
-            );
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                    encode_path(&subnet_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -23221,15 +23478,18 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-                encode_path(&subnet_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                    encode_path(&subnet_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -23369,23 +23629,22 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}/network-interfaces",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-                encode_path(&subnet_name.to_string()),
-            );
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}/network-interfaces",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                    encode_path(&subnet_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -23468,8 +23727,11 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/policy", client.baseurl,);
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!("{}/policy", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -23518,8 +23780,12 @@ pub mod builder {
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/policy", client.baseurl,);
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!("{}/policy", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -23586,15 +23852,14 @@ pub mod builder {
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/roles", client.baseurl,);
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!("{}/roles", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -23687,12 +23952,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Role>, Error<types::Error>> {
             let Self { client, role_name } = self;
             let role_name = role_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/roles/{}",
-                client.baseurl,
-                encode_path(&role_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/roles/{}",
+                    client.baseurl,
+                    encode_path(&role_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -23773,16 +24041,15 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/sagas", client.baseurl,);
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!("{}/sagas", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -23876,12 +24143,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Saga>, Error<types::Error>> {
             let Self { client, saga_id } = self;
             let saga_id = saga_id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/sagas/{}",
-                client.baseurl,
-                encode_path(&saga_id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/sagas/{}",
+                    client.baseurl,
+                    encode_path(&saga_id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -23913,8 +24183,11 @@ pub mod builder {
         ///Sends a `GET` request to `/session/me`
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/session/me", client.baseurl,);
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!("{}/session/me", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -23995,16 +24268,15 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/session/me/sshkeys", client.baseurl,);
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!("{}/session/me/sshkeys", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -24098,8 +24370,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/session/me/sshkeys", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/session/me/sshkeys", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -24149,12 +24425,15 @@ pub mod builder {
                 ssh_key_name,
             } = self;
             let ssh_key_name = ssh_key_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/session/me/sshkeys/{}",
-                client.baseurl,
-                encode_path(&ssh_key_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/session/me/sshkeys/{}",
+                    client.baseurl,
+                    encode_path(&ssh_key_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -24204,12 +24483,15 @@ pub mod builder {
                 ssh_key_name,
             } = self;
             let ssh_key_name = ssh_key_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/session/me/sshkeys/{}",
-                client.baseurl,
-                encode_path(&ssh_key_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/session/me/sshkeys/{}",
+                    client.baseurl,
+                    encode_path(&ssh_key_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -24290,16 +24572,15 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/silos", client.baseurl,);
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!("{}/silos", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -24393,8 +24674,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/silos", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/silos", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -24441,12 +24726,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
             let Self { client, silo_name } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/silos/{}",
-                client.baseurl,
-                encode_path(&silo_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/silos/{}",
+                    client.baseurl,
+                    encode_path(&silo_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -24493,12 +24781,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, silo_name } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/silos/{}",
-                client.baseurl,
-                encode_path(&silo_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/silos/{}",
+                    client.baseurl,
+                    encode_path(&silo_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -24594,20 +24885,19 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/silos/{}/identity-providers",
-                client.baseurl,
-                encode_path(&silo_name.to_string()),
-            );
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/silos/{}/identity-providers",
+                    client.baseurl,
+                    encode_path(&silo_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -24703,12 +24993,15 @@ pub mod builder {
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
             let Self { client, silo_name } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/silos/{}/policy",
-                client.baseurl,
-                encode_path(&silo_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/silos/{}/policy",
+                    client.baseurl,
+                    encode_path(&silo_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -24774,12 +25067,16 @@ pub mod builder {
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/silos/{}/policy",
-                client.baseurl,
-                encode_path(&silo_name.to_string()),
-            );
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!(
+                    "{}/silos/{}/policy",
+                    client.baseurl,
+                    encode_path(&silo_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -24846,12 +25143,16 @@ pub mod builder {
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/silos/{}/saml-identity-providers",
-                client.baseurl,
-                encode_path(&silo_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/silos/{}/saml-identity-providers",
+                    client.baseurl,
+                    encode_path(&silo_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -24918,13 +25219,16 @@ pub mod builder {
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let provider_name = provider_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/silos/{}/saml-identity-providers/{}",
-                client.baseurl,
-                encode_path(&silo_name.to_string()),
-                encode_path(&provider_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/silos/{}/saml-identity-providers/{}",
+                    client.baseurl,
+                    encode_path(&silo_name.to_string()),
+                    encode_path(&provider_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -25005,16 +25309,15 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/user", client.baseurl,);
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!("{}/system/user", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -25108,12 +25411,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::UserBuiltin>, Error<types::Error>> {
             let Self { client, user_name } = self;
             let user_name = user_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/system/user/{}",
-                client.baseurl,
-                encode_path(&user_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/system/user/{}",
+                    client.baseurl,
+                    encode_path(&user_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -25181,15 +25487,14 @@ pub mod builder {
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/timeseries/schema", client.baseurl,);
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!("{}/timeseries/schema", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -25267,8 +25572,11 @@ pub mod builder {
         ///Sends a `POST` request to `/updates/refresh`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/updates/refresh", client.baseurl,);
-            let request = client.client.post(url).build()?;
+            let request = client
+                .client
+                .post(format!("{}/updates/refresh", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -25349,16 +25657,15 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/users", client.baseurl,);
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!("{}/users", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {

--- a/progenitor-impl/tests/output/nexus-builder-tagged.out
+++ b/progenitor-impl/tests/output/nexus-builder-tagged.out
@@ -13721,7 +13721,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -13776,7 +13776,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -13831,7 +13831,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -13886,7 +13886,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -13944,7 +13944,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -13999,7 +13999,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14054,7 +14054,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14109,7 +14109,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14164,7 +14164,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14219,7 +14219,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14274,7 +14274,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14329,7 +14329,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14381,7 +14381,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/device/auth", client.baseurl,))
                 .form_urlencoded(&body)?
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14427,7 +14427,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/device/confirm", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14479,7 +14479,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/device/token", client.baseurl,))
                 .form_urlencoded(&body)?
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14664,7 +14664,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&rack_id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14855,7 +14855,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&sled_id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15043,7 +15043,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/images", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15098,7 +15098,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&image_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15153,7 +15153,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&image_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15341,7 +15341,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/ip-pools", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15396,7 +15396,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&pool_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15469,7 +15469,7 @@ pub mod builder {
                     encode_path(&pool_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15524,7 +15524,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&pool_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15735,7 +15735,7 @@ pub mod builder {
                     encode_path(&pool_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15808,7 +15808,7 @@ pub mod builder {
                     encode_path(&pool_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15860,7 +15860,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/login", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15927,7 +15927,7 @@ pub mod builder {
                     encode_path(&silo_name.to_string()),
                     encode_path(&provider_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16013,7 +16013,7 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/octet-stream"),
                 )
                 .body(body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16043,7 +16043,7 @@ pub mod builder {
             let request = client
                 .client
                 .post(format!("{}/logout", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16225,7 +16225,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/organizations", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16283,7 +16283,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&organization_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16356,7 +16356,7 @@ pub mod builder {
                     encode_path(&organization_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16414,7 +16414,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&organization_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16474,7 +16474,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&organization_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16549,7 +16549,7 @@ pub mod builder {
                     encode_path(&organization_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16779,7 +16779,7 @@ pub mod builder {
                     encode_path(&organization_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16853,7 +16853,7 @@ pub mod builder {
                     encode_path(&organization_name.to_string()),
                     encode_path(&project_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16942,7 +16942,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -17016,7 +17016,7 @@ pub mod builder {
                     encode_path(&organization_name.to_string()),
                     encode_path(&project_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -17276,7 +17276,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -17366,7 +17366,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&disk_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -17456,7 +17456,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&disk_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -17931,7 +17931,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18021,7 +18021,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&image_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18111,7 +18111,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&image_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18374,7 +18374,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18464,7 +18464,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&instance_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18554,7 +18554,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&instance_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18847,7 +18847,7 @@ pub mod builder {
                     encode_path(&instance_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18952,7 +18952,7 @@ pub mod builder {
                     encode_path(&instance_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19044,7 +19044,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&instance_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19149,7 +19149,7 @@ pub mod builder {
                     encode_path(&instance_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19445,7 +19445,7 @@ pub mod builder {
                     encode_path(&instance_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19552,7 +19552,7 @@ pub mod builder {
                     encode_path(&instance_name.to_string()),
                     encode_path(&interface_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19674,7 +19674,7 @@ pub mod builder {
                     encode_path(&interface_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19779,7 +19779,7 @@ pub mod builder {
                     encode_path(&instance_name.to_string()),
                     encode_path(&interface_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19869,7 +19869,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&instance_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20100,7 +20100,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&instance_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20190,7 +20190,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&instance_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20266,7 +20266,7 @@ pub mod builder {
                     encode_path(&organization_name.to_string()),
                     encode_path(&project_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20357,7 +20357,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20620,7 +20620,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20710,7 +20710,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&snapshot_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20800,7 +20800,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&snapshot_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21060,7 +21060,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21150,7 +21150,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&vpc_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21255,7 +21255,7 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21345,7 +21345,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&vpc_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21437,7 +21437,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&vpc_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21544,7 +21544,7 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21837,7 +21837,7 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21942,7 +21942,7 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                     encode_path(&router_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -22062,7 +22062,7 @@ pub mod builder {
                     encode_path(&router_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -22167,7 +22167,7 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                     encode_path(&router_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -22490,7 +22490,7 @@ pub mod builder {
                     encode_path(&router_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -22610,7 +22610,7 @@ pub mod builder {
                     encode_path(&router_name.to_string()),
                     encode_path(&route_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -22745,7 +22745,7 @@ pub mod builder {
                     encode_path(&route_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -22865,7 +22865,7 @@ pub mod builder {
                     encode_path(&router_name.to_string()),
                     encode_path(&route_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23158,7 +23158,7 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23263,7 +23263,7 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                     encode_path(&subnet_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23383,7 +23383,7 @@ pub mod builder {
                     encode_path(&subnet_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23488,7 +23488,7 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                     encode_path(&subnet_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23730,7 +23730,7 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/policy", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23784,7 +23784,7 @@ pub mod builder {
                 .client
                 .put(format!("{}/policy", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23959,7 +23959,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&role_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24150,7 +24150,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&saga_id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24186,7 +24186,7 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/session/me", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24374,7 +24374,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/session/me/sshkeys", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24432,7 +24432,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&ssh_key_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24490,7 +24490,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&ssh_key_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24678,7 +24678,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/silos", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24733,7 +24733,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&silo_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24788,7 +24788,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&silo_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -25000,7 +25000,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&silo_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -25075,7 +25075,7 @@ pub mod builder {
                     encode_path(&silo_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -25151,7 +25151,7 @@ pub mod builder {
                     encode_path(&silo_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -25227,7 +25227,7 @@ pub mod builder {
                     encode_path(&silo_name.to_string()),
                     encode_path(&provider_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -25418,7 +25418,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&user_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -25575,7 +25575,7 @@ pub mod builder {
             let request = client
                 .client
                 .post(format!("{}/updates/refresh", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/nexus-builder-tagged.out
+++ b/progenitor-impl/tests/output/nexus-builder-tagged.out
@@ -13721,7 +13721,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -13776,7 +13775,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -13831,7 +13829,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -13886,7 +13883,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -13944,7 +13940,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -13999,7 +13994,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14054,7 +14048,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14109,7 +14102,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14164,7 +14156,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14219,7 +14210,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14274,7 +14264,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14329,7 +14318,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14381,7 +14369,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/device/auth", client.baseurl,))
                 .form_urlencoded(&body)?
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14427,7 +14414,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/device/confirm", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14479,7 +14465,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/device/token", client.baseurl,))
                 .form_urlencoded(&body)?
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14664,7 +14649,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&rack_id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14855,7 +14839,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&sled_id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15043,7 +15026,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/images", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15098,7 +15080,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&image_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15153,7 +15134,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&image_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15341,7 +15321,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/ip-pools", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15396,7 +15375,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&pool_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15469,7 +15447,6 @@ pub mod builder {
                     encode_path(&pool_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15524,7 +15501,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&pool_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15735,7 +15711,6 @@ pub mod builder {
                     encode_path(&pool_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15808,7 +15783,6 @@ pub mod builder {
                     encode_path(&pool_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15860,7 +15834,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/login", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15927,7 +15900,6 @@ pub mod builder {
                     encode_path(&silo_name.to_string()),
                     encode_path(&provider_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16013,7 +15985,6 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/octet-stream"),
                 )
                 .body(body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16043,7 +16014,6 @@ pub mod builder {
             let request = client
                 .client
                 .post(format!("{}/logout", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16225,7 +16195,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/organizations", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16283,7 +16252,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&organization_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16356,7 +16324,6 @@ pub mod builder {
                     encode_path(&organization_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16414,7 +16381,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&organization_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16474,7 +16440,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&organization_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16549,7 +16514,6 @@ pub mod builder {
                     encode_path(&organization_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16779,7 +16743,6 @@ pub mod builder {
                     encode_path(&organization_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16853,7 +16816,6 @@ pub mod builder {
                     encode_path(&organization_name.to_string()),
                     encode_path(&project_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16942,7 +16904,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -17016,7 +16977,6 @@ pub mod builder {
                     encode_path(&organization_name.to_string()),
                     encode_path(&project_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -17276,7 +17236,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -17366,7 +17325,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&disk_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -17456,7 +17414,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&disk_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -17931,7 +17888,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18021,7 +17977,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&image_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18111,7 +18066,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&image_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18374,7 +18328,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18464,7 +18417,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&instance_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18554,7 +18506,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&instance_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18847,7 +18798,6 @@ pub mod builder {
                     encode_path(&instance_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18952,7 +18902,6 @@ pub mod builder {
                     encode_path(&instance_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19044,7 +18993,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&instance_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19149,7 +19097,6 @@ pub mod builder {
                     encode_path(&instance_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19445,7 +19392,6 @@ pub mod builder {
                     encode_path(&instance_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19552,7 +19498,6 @@ pub mod builder {
                     encode_path(&instance_name.to_string()),
                     encode_path(&interface_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19674,7 +19619,6 @@ pub mod builder {
                     encode_path(&interface_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19779,7 +19723,6 @@ pub mod builder {
                     encode_path(&instance_name.to_string()),
                     encode_path(&interface_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19869,7 +19812,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&instance_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20100,7 +20042,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&instance_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20190,7 +20131,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&instance_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20266,7 +20206,6 @@ pub mod builder {
                     encode_path(&organization_name.to_string()),
                     encode_path(&project_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20357,7 +20296,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20620,7 +20558,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20710,7 +20647,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&snapshot_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20800,7 +20736,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&snapshot_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21060,7 +20995,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21150,7 +21084,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&vpc_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21255,7 +21188,6 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21345,7 +21277,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&vpc_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21437,7 +21368,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&vpc_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21544,7 +21474,6 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21837,7 +21766,6 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21942,7 +21870,6 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                     encode_path(&router_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -22062,7 +21989,6 @@ pub mod builder {
                     encode_path(&router_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -22167,7 +22093,6 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                     encode_path(&router_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -22490,7 +22415,6 @@ pub mod builder {
                     encode_path(&router_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -22610,7 +22534,6 @@ pub mod builder {
                     encode_path(&router_name.to_string()),
                     encode_path(&route_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -22745,7 +22668,6 @@ pub mod builder {
                     encode_path(&route_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -22865,7 +22787,6 @@ pub mod builder {
                     encode_path(&router_name.to_string()),
                     encode_path(&route_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23158,7 +23079,6 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23263,7 +23183,6 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                     encode_path(&subnet_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23383,7 +23302,6 @@ pub mod builder {
                     encode_path(&subnet_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23488,7 +23406,6 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                     encode_path(&subnet_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23730,7 +23647,6 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/policy", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23784,7 +23700,6 @@ pub mod builder {
                 .client
                 .put(format!("{}/policy", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23959,7 +23874,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&role_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24150,7 +24064,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&saga_id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24186,7 +24099,6 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/session/me", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24374,7 +24286,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/session/me/sshkeys", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24432,7 +24343,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&ssh_key_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24490,7 +24400,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&ssh_key_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24678,7 +24587,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/silos", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24733,7 +24641,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&silo_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24788,7 +24695,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&silo_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -25000,7 +24906,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&silo_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -25075,7 +24980,6 @@ pub mod builder {
                     encode_path(&silo_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -25151,7 +25055,6 @@ pub mod builder {
                     encode_path(&silo_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -25227,7 +25130,6 @@ pub mod builder {
                     encode_path(&silo_name.to_string()),
                     encode_path(&provider_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -25418,7 +25320,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&user_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -25575,7 +25476,6 @@ pub mod builder {
             let request = client
                 .client
                 .post(format!("{}/updates/refresh", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/nexus-builder-tagged.out
+++ b/progenitor-impl/tests/output/nexus-builder-tagged.out
@@ -14499,16 +14499,14 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/hardware/racks", client.baseurl,);
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14690,16 +14688,14 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/hardware/sleds", client.baseurl,);
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14881,16 +14877,14 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/images", client.baseurl,);
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15172,16 +15166,14 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/ip-pools", client.baseurl,);
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15536,13 +15528,13 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16028,16 +16020,14 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/organizations", client.baseurl,);
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16541,16 +16531,14 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -17012,16 +17000,14 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -17486,19 +17472,15 @@ pub mod builder {
                 encode_path(&disk_name.to_string()),
                 encode_path(&metric_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &end_time {
-                query.push(("end_time", v.to_string()));
-            }
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &start_time {
-                query.push(("start_time", v.to_string()));
-            }
+            let query = [
+                ("end_time", end_time.map(|v| v.to_string())),
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("start_time", start_time.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -17665,16 +17647,14 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18099,16 +18079,14 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18550,16 +18528,14 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19134,16 +19110,14 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19841,16 +19815,14 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &from_start {
-                query.push(("from_start", v.to_string()));
-            }
-            if let Some(v) = &max_bytes {
-                query.push(("max_bytes", v.to_string()));
-            }
-            if let Some(v) = &most_recent {
-                query.push(("most_recent", v.to_string()));
-            }
+            let query = [
+                ("from_start", from_start.map(|v| v.to_string())),
+                ("max_bytes", max_bytes.map(|v| v.to_string())),
+                ("most_recent", most_recent.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20302,16 +20274,14 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20737,16 +20707,14 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21479,16 +21447,14 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -22106,16 +22072,14 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -22778,16 +22742,14 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23406,16 +23368,14 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23618,13 +23578,13 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/roles", client.baseurl,);
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23805,16 +23765,14 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/sagas", client.baseurl,);
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24029,16 +23987,14 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/sshkeys", client.baseurl,);
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24326,16 +24282,14 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/silos", client.baseurl,);
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24636,16 +24590,14 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -25045,16 +24997,14 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/user", client.baseurl,);
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -25223,13 +25173,13 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/timeseries/schema", client.baseurl,);
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -25391,16 +25341,14 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/users", client.baseurl,);
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/nexus-builder.out
+++ b/progenitor-impl/tests/output/nexus-builder.out
@@ -13541,7 +13541,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -13596,7 +13595,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -13651,7 +13649,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -13706,7 +13703,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -13763,7 +13759,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -13818,7 +13813,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -13873,7 +13867,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -13928,7 +13921,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -13983,7 +13975,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14038,7 +14029,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14093,7 +14083,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14148,7 +14137,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14200,7 +14188,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/device/auth", client.baseurl,))
                 .form_urlencoded(&body)?
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14246,7 +14233,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/device/confirm", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14298,7 +14284,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/device/token", client.baseurl,))
                 .form_urlencoded(&body)?
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14483,7 +14468,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&rack_id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14674,7 +14658,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&sled_id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14862,7 +14845,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/images", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14917,7 +14899,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&image_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14972,7 +14953,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&image_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15160,7 +15140,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/ip-pools", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15215,7 +15194,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&pool_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15288,7 +15266,6 @@ pub mod builder {
                     encode_path(&pool_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15343,7 +15320,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&pool_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15554,7 +15530,6 @@ pub mod builder {
                     encode_path(&pool_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15627,7 +15602,6 @@ pub mod builder {
                     encode_path(&pool_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15679,7 +15653,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/login", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15746,7 +15719,6 @@ pub mod builder {
                     encode_path(&silo_name.to_string()),
                     encode_path(&provider_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15832,7 +15804,6 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/octet-stream"),
                 )
                 .body(body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15862,7 +15833,6 @@ pub mod builder {
             let request = client
                 .client
                 .post(format!("{}/logout", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16044,7 +16014,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/organizations", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16102,7 +16071,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&organization_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16175,7 +16143,6 @@ pub mod builder {
                     encode_path(&organization_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16233,7 +16200,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&organization_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16293,7 +16259,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&organization_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16368,7 +16333,6 @@ pub mod builder {
                     encode_path(&organization_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16598,7 +16562,6 @@ pub mod builder {
                     encode_path(&organization_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16672,7 +16635,6 @@ pub mod builder {
                     encode_path(&organization_name.to_string()),
                     encode_path(&project_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16761,7 +16723,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16835,7 +16796,6 @@ pub mod builder {
                     encode_path(&organization_name.to_string()),
                     encode_path(&project_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -17095,7 +17055,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -17185,7 +17144,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&disk_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -17275,7 +17233,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&disk_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -17750,7 +17707,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -17840,7 +17796,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&image_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -17930,7 +17885,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&image_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18193,7 +18147,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18283,7 +18236,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&instance_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18373,7 +18325,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&instance_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18666,7 +18617,6 @@ pub mod builder {
                     encode_path(&instance_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18771,7 +18721,6 @@ pub mod builder {
                     encode_path(&instance_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18863,7 +18812,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&instance_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18968,7 +18916,6 @@ pub mod builder {
                     encode_path(&instance_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19264,7 +19211,6 @@ pub mod builder {
                     encode_path(&instance_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19371,7 +19317,6 @@ pub mod builder {
                     encode_path(&instance_name.to_string()),
                     encode_path(&interface_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19493,7 +19438,6 @@ pub mod builder {
                     encode_path(&interface_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19598,7 +19542,6 @@ pub mod builder {
                     encode_path(&instance_name.to_string()),
                     encode_path(&interface_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19688,7 +19631,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&instance_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19919,7 +19861,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&instance_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20009,7 +19950,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&instance_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20085,7 +20025,6 @@ pub mod builder {
                     encode_path(&organization_name.to_string()),
                     encode_path(&project_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20176,7 +20115,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20439,7 +20377,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20529,7 +20466,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&snapshot_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20619,7 +20555,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&snapshot_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20879,7 +20814,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20969,7 +20903,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&vpc_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21074,7 +21007,6 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21164,7 +21096,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&vpc_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21256,7 +21187,6 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&vpc_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21363,7 +21293,6 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21656,7 +21585,6 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21761,7 +21689,6 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                     encode_path(&router_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21881,7 +21808,6 @@ pub mod builder {
                     encode_path(&router_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21986,7 +21912,6 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                     encode_path(&router_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -22309,7 +22234,6 @@ pub mod builder {
                     encode_path(&router_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -22429,7 +22353,6 @@ pub mod builder {
                     encode_path(&router_name.to_string()),
                     encode_path(&route_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -22564,7 +22487,6 @@ pub mod builder {
                     encode_path(&route_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -22684,7 +22606,6 @@ pub mod builder {
                     encode_path(&router_name.to_string()),
                     encode_path(&route_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -22977,7 +22898,6 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23082,7 +23002,6 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                     encode_path(&subnet_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23202,7 +23121,6 @@ pub mod builder {
                     encode_path(&subnet_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23307,7 +23225,6 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                     encode_path(&subnet_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23549,7 +23466,6 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/policy", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23603,7 +23519,6 @@ pub mod builder {
                 .client
                 .put(format!("{}/policy", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23778,7 +23693,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&role_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23969,7 +23883,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&saga_id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24005,7 +23918,6 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/session/me", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24193,7 +24105,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/session/me/sshkeys", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24251,7 +24162,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&ssh_key_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24309,7 +24219,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&ssh_key_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24497,7 +24406,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/silos", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24552,7 +24460,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&silo_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24607,7 +24514,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&silo_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24819,7 +24725,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&silo_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24894,7 +24799,6 @@ pub mod builder {
                     encode_path(&silo_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24970,7 +24874,6 @@ pub mod builder {
                     encode_path(&silo_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -25046,7 +24949,6 @@ pub mod builder {
                     encode_path(&silo_name.to_string()),
                     encode_path(&provider_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -25237,7 +25139,6 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&user_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -25394,7 +25295,6 @@ pub mod builder {
             let request = client
                 .client
                 .post(format!("{}/updates/refresh", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/nexus-builder.out
+++ b/progenitor-impl/tests/output/nexus-builder.out
@@ -14318,16 +14318,14 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/hardware/racks", client.baseurl,);
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14509,16 +14507,14 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/hardware/sleds", client.baseurl,);
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14700,16 +14696,14 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/images", client.baseurl,);
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14991,16 +14985,14 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/ip-pools", client.baseurl,);
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15355,13 +15347,13 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15847,16 +15839,14 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/organizations", client.baseurl,);
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16360,16 +16350,14 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16831,16 +16819,14 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -17305,19 +17291,15 @@ pub mod builder {
                 encode_path(&disk_name.to_string()),
                 encode_path(&metric_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &end_time {
-                query.push(("end_time", v.to_string()));
-            }
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &start_time {
-                query.push(("start_time", v.to_string()));
-            }
+            let query = [
+                ("end_time", end_time.map(|v| v.to_string())),
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("start_time", start_time.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -17484,16 +17466,14 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -17918,16 +17898,14 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18369,16 +18347,14 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18953,16 +18929,14 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19660,16 +19634,14 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &from_start {
-                query.push(("from_start", v.to_string()));
-            }
-            if let Some(v) = &max_bytes {
-                query.push(("max_bytes", v.to_string()));
-            }
-            if let Some(v) = &most_recent {
-                query.push(("most_recent", v.to_string()));
-            }
+            let query = [
+                ("from_start", from_start.map(|v| v.to_string())),
+                ("max_bytes", max_bytes.map(|v| v.to_string())),
+                ("most_recent", most_recent.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20121,16 +20093,14 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20556,16 +20526,14 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21298,16 +21266,14 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21925,16 +21891,14 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -22597,16 +22561,14 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23225,16 +23187,14 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23437,13 +23397,13 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/roles", client.baseurl,);
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23624,16 +23584,14 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/sagas", client.baseurl,);
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23848,16 +23806,14 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/sshkeys", client.baseurl,);
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24145,16 +24101,14 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/silos", client.baseurl,);
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24455,16 +24409,14 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24864,16 +24816,14 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/user", client.baseurl,);
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -25042,13 +24992,13 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/timeseries/schema", client.baseurl,);
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -25210,16 +25160,14 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/users", client.baseurl,);
-            let mut query = Vec::new();
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
-            }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
-            }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
-            }
+            let query = [
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/nexus-builder.out
+++ b/progenitor-impl/tests/output/nexus-builder.out
@@ -13534,12 +13534,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/by-id/disks/{}",
-                client.baseurl,
-                encode_path(&id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/by-id/disks/{}",
+                    client.baseurl,
+                    encode_path(&id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -13586,12 +13589,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/by-id/global-images/{}",
-                client.baseurl,
-                encode_path(&id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/by-id/global-images/{}",
+                    client.baseurl,
+                    encode_path(&id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -13638,12 +13644,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/by-id/images/{}",
-                client.baseurl,
-                encode_path(&id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/by-id/images/{}",
+                    client.baseurl,
+                    encode_path(&id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -13690,12 +13699,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/by-id/instances/{}",
-                client.baseurl,
-                encode_path(&id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/by-id/instances/{}",
+                    client.baseurl,
+                    encode_path(&id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -13744,12 +13756,15 @@ pub mod builder {
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/by-id/network-interfaces/{}",
-                client.baseurl,
-                encode_path(&id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/by-id/network-interfaces/{}",
+                    client.baseurl,
+                    encode_path(&id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -13796,12 +13811,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/by-id/organizations/{}",
-                client.baseurl,
-                encode_path(&id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/by-id/organizations/{}",
+                    client.baseurl,
+                    encode_path(&id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -13848,12 +13866,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/by-id/projects/{}",
-                client.baseurl,
-                encode_path(&id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/by-id/projects/{}",
+                    client.baseurl,
+                    encode_path(&id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -13900,12 +13921,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/by-id/snapshots/{}",
-                client.baseurl,
-                encode_path(&id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/by-id/snapshots/{}",
+                    client.baseurl,
+                    encode_path(&id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -13952,12 +13976,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/by-id/vpc-router-routes/{}",
-                client.baseurl,
-                encode_path(&id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/by-id/vpc-router-routes/{}",
+                    client.baseurl,
+                    encode_path(&id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14004,12 +14031,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/by-id/vpc-routers/{}",
-                client.baseurl,
-                encode_path(&id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/by-id/vpc-routers/{}",
+                    client.baseurl,
+                    encode_path(&id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14056,12 +14086,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/by-id/vpc-subnets/{}",
-                client.baseurl,
-                encode_path(&id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/by-id/vpc-subnets/{}",
+                    client.baseurl,
+                    encode_path(&id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14108,12 +14141,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/by-id/vpcs/{}",
-                client.baseurl,
-                encode_path(&id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/by-id/vpcs/{}",
+                    client.baseurl,
+                    encode_path(&id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14160,8 +14196,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/device/auth", client.baseurl,);
-            let request = client.client.post(url).form_urlencoded(&body)?.build()?;
+            let request = client
+                .client
+                .post(format!("{}/device/auth", client.baseurl,))
+                .form_urlencoded(&body)?
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14202,8 +14242,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/device/confirm", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/device/confirm", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14250,8 +14294,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/device/token", client.baseurl,);
-            let request = client.client.post(url).form_urlencoded(&body)?.build()?;
+            let request = client
+                .client
+                .post(format!("{}/device/token", client.baseurl,))
+                .form_urlencoded(&body)?
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14326,16 +14374,15 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/hardware/racks", client.baseurl,);
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!("{}/hardware/racks", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14429,12 +14476,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Rack>, Error<types::Error>> {
             let Self { client, rack_id } = self;
             let rack_id = rack_id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/hardware/racks/{}",
-                client.baseurl,
-                encode_path(&rack_id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/hardware/racks/{}",
+                    client.baseurl,
+                    encode_path(&rack_id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14515,16 +14565,15 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/hardware/sleds", client.baseurl,);
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!("{}/hardware/sleds", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14618,12 +14667,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Sled>, Error<types::Error>> {
             let Self { client, sled_id } = self;
             let sled_id = sled_id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/hardware/sleds/{}",
-                client.baseurl,
-                encode_path(&sled_id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/hardware/sleds/{}",
+                    client.baseurl,
+                    encode_path(&sled_id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14704,16 +14756,15 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/images", client.baseurl,);
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!("{}/images", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14807,8 +14858,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/images", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/images", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14855,12 +14910,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
             let Self { client, image_name } = self;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/images/{}",
-                client.baseurl,
-                encode_path(&image_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/images/{}",
+                    client.baseurl,
+                    encode_path(&image_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14907,12 +14965,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, image_name } = self;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/images/{}",
-                client.baseurl,
-                encode_path(&image_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/images/{}",
+                    client.baseurl,
+                    encode_path(&image_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -14993,16 +15054,15 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/ip-pools", client.baseurl,);
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!("{}/ip-pools", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -15096,8 +15156,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/ip-pools", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/ip-pools", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -15144,12 +15208,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client, pool_name } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/ip-pools/{}",
-                client.baseurl,
-                encode_path(&pool_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/ip-pools/{}",
+                    client.baseurl,
+                    encode_path(&pool_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -15213,12 +15280,16 @@ pub mod builder {
             } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/ip-pools/{}",
-                client.baseurl,
-                encode_path(&pool_name.to_string()),
-            );
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!(
+                    "{}/ip-pools/{}",
+                    client.baseurl,
+                    encode_path(&pool_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -15265,12 +15336,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, pool_name } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/ip-pools/{}",
-                client.baseurl,
-                encode_path(&pool_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/ip-pools/{}",
+                    client.baseurl,
+                    encode_path(&pool_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -15351,19 +15425,18 @@ pub mod builder {
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/ip-pools/{}/ranges",
-                client.baseurl,
-                encode_path(&pool_name.to_string()),
-            );
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/ip-pools/{}/ranges",
+                    client.baseurl,
+                    encode_path(&pool_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -15473,12 +15546,16 @@ pub mod builder {
             } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/ip-pools/{}/ranges/add",
-                client.baseurl,
-                encode_path(&pool_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/ip-pools/{}/ranges/add",
+                    client.baseurl,
+                    encode_path(&pool_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -15542,12 +15619,16 @@ pub mod builder {
             } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/ip-pools/{}/ranges/remove",
-                client.baseurl,
-                encode_path(&pool_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/ip-pools/{}/ranges/remove",
+                    client.baseurl,
+                    encode_path(&pool_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -15594,8 +15675,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/login", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/login", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -15653,13 +15738,16 @@ pub mod builder {
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let provider_name = provider_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/login/{}/{}",
-                client.baseurl,
-                encode_path(&silo_name.to_string()),
-                encode_path(&provider_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/login/{}/{}",
+                    client.baseurl,
+                    encode_path(&silo_name.to_string()),
+                    encode_path(&provider_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -15731,20 +15819,20 @@ pub mod builder {
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let provider_name = provider_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/login/{}/{}",
-                client.baseurl,
-                encode_path(&silo_name.to_string()),
-                encode_path(&provider_name.to_string()),
-            );
             let request = client
                 .client
-                .post(url)
+                .post(format!(
+                    "{}/login/{}/{}",
+                    client.baseurl,
+                    encode_path(&silo_name.to_string()),
+                    encode_path(&provider_name.to_string()),
+                ))
                 .header(
                     reqwest::header::CONTENT_TYPE,
                     reqwest::header::HeaderValue::from_static("application/octet-stream"),
                 )
                 .body(body)
+                .query::<[(&str, Option<String>)]>(&vec![])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15771,8 +15859,11 @@ pub mod builder {
         ///Sends a `POST` request to `/logout`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
             let Self { client } = self;
-            let url = format!("{}/logout", client.baseurl,);
-            let request = client.client.post(url).build()?;
+            let request = client
+                .client
+                .post(format!("{}/logout", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -15847,16 +15938,15 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/organizations", client.baseurl,);
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!("{}/organizations", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -15950,8 +16040,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/organizations", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/organizations", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -16001,12 +16095,15 @@ pub mod builder {
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -16070,12 +16167,16 @@ pub mod builder {
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-            );
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!(
+                    "{}/organizations/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -16125,12 +16226,15 @@ pub mod builder {
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/organizations/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -16182,12 +16286,15 @@ pub mod builder {
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/policy",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/policy",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -16253,12 +16360,16 @@ pub mod builder {
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/policy",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-            );
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!(
+                    "{}/organizations/{}/policy",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -16354,20 +16465,19 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-            );
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -16480,12 +16590,16 @@ pub mod builder {
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -16550,13 +16664,16 @@ pub mod builder {
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -16635,13 +16752,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!(
+                    "{}/organizations/{}/projects/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -16706,13 +16827,16 @@ pub mod builder {
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/organizations/{}/projects/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -16822,21 +16946,20 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/disks",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/disks",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -16963,13 +17086,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/disks",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/disks",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -17049,14 +17176,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let disk_name = disk_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/disks/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&disk_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/disks/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&disk_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -17136,14 +17266,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let disk_name = disk_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/disks/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&disk_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/organizations/{}/projects/{}/disks/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&disk_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -17292,24 +17425,23 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let start_time = start_time.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/disks/{}/metrics/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&disk_name.to_string()),
-                encode_path(&metric_name.to_string()),
-            );
-            let query = [
-                ("end_time", end_time.map(|v| v.to_string())),
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("start_time", start_time.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/disks/{}/metrics/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&disk_name.to_string()),
+                    encode_path(&metric_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("end_time", end_time.map(|v| v.to_string())),
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("start_time", start_time.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -17469,21 +17601,20 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/images",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/images",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -17610,13 +17741,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/images",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/images",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -17696,14 +17831,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/images/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&image_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/images/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&image_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -17783,14 +17921,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/images/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&image_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/organizations/{}/projects/{}/images/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&image_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -17901,21 +18042,20 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/instances",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -18044,13 +18184,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/instances",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -18130,14 +18274,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -18217,14 +18364,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -18349,22 +18499,21 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}/disks",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-            );
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}/disks",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -18507,14 +18656,18 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}/disks/attach",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}/disks/attach",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -18608,14 +18761,18 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}/disks/detach",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}/disks/detach",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -18697,14 +18854,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}/external-ips",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}/external-ips",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -18798,14 +18958,18 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}/migrate",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}/migrate",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -18931,22 +19095,21 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-            );
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -19091,14 +19254,18 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -19194,15 +19361,18 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let interface_name = interface_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-                encode_path(&interface_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                    encode_path(&interface_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -19312,15 +19482,19 @@ pub mod builder {
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let interface_name = interface_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-                encode_path(&interface_name.to_string()),
-            );
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                    encode_path(&interface_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -19414,15 +19588,18 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let interface_name = interface_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-                encode_path(&interface_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                    encode_path(&interface_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -19502,14 +19679,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}/reboot",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-            );
-            let request = client.client.post(url).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}/reboot",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -19636,22 +19816,21 @@ pub mod builder {
             let from_start = from_start.map_err(Error::InvalidRequest)?;
             let max_bytes = max_bytes.map_err(Error::InvalidRequest)?;
             let most_recent = most_recent.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}/serial-console",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-            );
-            let query = [
-                ("from_start", from_start.map(|v| v.to_string())),
-                ("max_bytes", max_bytes.map(|v| v.to_string())),
-                ("most_recent", most_recent.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}/serial-console",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("from_start", from_start.map(|v| v.to_string())),
+                    ("max_bytes", max_bytes.map(|v| v.to_string())),
+                    ("most_recent", most_recent.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -19731,14 +19910,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}/start",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-            );
-            let request = client.client.post(url).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}/start",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -19818,14 +20000,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/instances/{}/stop",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&instance_name.to_string()),
-            );
-            let request = client.client.post(url).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/instances/{}/stop",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&instance_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -19892,13 +20077,16 @@ pub mod builder {
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/policy",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/policy",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -19979,13 +20167,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/policy",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!(
+                    "{}/organizations/{}/projects/{}/policy",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -20096,21 +20288,20 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/snapshots",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/snapshots",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -20239,13 +20430,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/snapshots",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/snapshots",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -20325,14 +20520,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let snapshot_name = snapshot_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/snapshots/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&snapshot_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/snapshots/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&snapshot_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -20412,14 +20610,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let snapshot_name = snapshot_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/snapshots/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&snapshot_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/organizations/{}/projects/{}/snapshots/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&snapshot_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -20529,21 +20730,20 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/vpcs",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -20670,13 +20870,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/vpcs",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -20756,14 +20960,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -20857,14 +21064,18 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-            );
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -20944,14 +21155,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -21033,14 +21247,17 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -21136,14 +21353,18 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-            );
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -21268,22 +21489,21 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/routers",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-            );
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/routers",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -21426,14 +21646,18 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/routers",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/routers",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -21527,15 +21751,18 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-                encode_path(&router_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                    encode_path(&router_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -21643,15 +21870,19 @@ pub mod builder {
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-                encode_path(&router_name.to_string()),
-            );
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                    encode_path(&router_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -21745,15 +21976,18 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-                encode_path(&router_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                    encode_path(&router_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -21892,23 +22126,22 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-                encode_path(&router_name.to_string()),
-            );
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                    encode_path(&router_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -22065,15 +22298,19 @@ pub mod builder {
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-                encode_path(&router_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                    encode_path(&router_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -22181,16 +22418,19 @@ pub mod builder {
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
             let route_name = route_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-                encode_path(&router_name.to_string()),
-                encode_path(&route_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                    encode_path(&router_name.to_string()),
+                    encode_path(&route_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -22312,16 +22552,20 @@ pub mod builder {
             let router_name = router_name.map_err(Error::InvalidRequest)?;
             let route_name = route_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-                encode_path(&router_name.to_string()),
-                encode_path(&route_name.to_string()),
-            );
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                    encode_path(&router_name.to_string()),
+                    encode_path(&route_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -22429,16 +22673,19 @@ pub mod builder {
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
             let route_name = route_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-                encode_path(&router_name.to_string()),
-                encode_path(&route_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                    encode_path(&router_name.to_string()),
+                    encode_path(&route_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -22563,22 +22810,21 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-            );
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -22721,14 +22967,18 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -22822,15 +23072,18 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-                encode_path(&subnet_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                    encode_path(&subnet_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -22938,15 +23191,19 @@ pub mod builder {
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-                encode_path(&subnet_name.to_string()),
-            );
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                    encode_path(&subnet_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -23040,15 +23297,18 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-                encode_path(&subnet_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                    encode_path(&subnet_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -23188,23 +23448,22 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}/network-interfaces",
-                client.baseurl,
-                encode_path(&organization_name.to_string()),
-                encode_path(&project_name.to_string()),
-                encode_path(&vpc_name.to_string()),
-                encode_path(&subnet_name.to_string()),
-            );
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}/network-interfaces",
+                    client.baseurl,
+                    encode_path(&organization_name.to_string()),
+                    encode_path(&project_name.to_string()),
+                    encode_path(&vpc_name.to_string()),
+                    encode_path(&subnet_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -23287,8 +23546,11 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/policy", client.baseurl,);
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!("{}/policy", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -23337,8 +23599,12 @@ pub mod builder {
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/policy", client.baseurl,);
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!("{}/policy", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -23405,15 +23671,14 @@ pub mod builder {
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/roles", client.baseurl,);
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!("{}/roles", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -23506,12 +23771,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Role>, Error<types::Error>> {
             let Self { client, role_name } = self;
             let role_name = role_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/roles/{}",
-                client.baseurl,
-                encode_path(&role_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/roles/{}",
+                    client.baseurl,
+                    encode_path(&role_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -23592,16 +23860,15 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/sagas", client.baseurl,);
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!("{}/sagas", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -23695,12 +23962,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Saga>, Error<types::Error>> {
             let Self { client, saga_id } = self;
             let saga_id = saga_id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/sagas/{}",
-                client.baseurl,
-                encode_path(&saga_id.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/sagas/{}",
+                    client.baseurl,
+                    encode_path(&saga_id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -23732,8 +24002,11 @@ pub mod builder {
         ///Sends a `GET` request to `/session/me`
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/session/me", client.baseurl,);
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!("{}/session/me", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -23814,16 +24087,15 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/session/me/sshkeys", client.baseurl,);
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!("{}/session/me/sshkeys", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -23917,8 +24189,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/session/me/sshkeys", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/session/me/sshkeys", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -23968,12 +24244,15 @@ pub mod builder {
                 ssh_key_name,
             } = self;
             let ssh_key_name = ssh_key_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/session/me/sshkeys/{}",
-                client.baseurl,
-                encode_path(&ssh_key_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/session/me/sshkeys/{}",
+                    client.baseurl,
+                    encode_path(&ssh_key_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -24023,12 +24302,15 @@ pub mod builder {
                 ssh_key_name,
             } = self;
             let ssh_key_name = ssh_key_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/session/me/sshkeys/{}",
-                client.baseurl,
-                encode_path(&ssh_key_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/session/me/sshkeys/{}",
+                    client.baseurl,
+                    encode_path(&ssh_key_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -24109,16 +24391,15 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/silos", client.baseurl,);
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!("{}/silos", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -24212,8 +24493,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/silos", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/silos", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -24260,12 +24545,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
             let Self { client, silo_name } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/silos/{}",
-                client.baseurl,
-                encode_path(&silo_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/silos/{}",
+                    client.baseurl,
+                    encode_path(&silo_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -24312,12 +24600,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, silo_name } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/silos/{}",
-                client.baseurl,
-                encode_path(&silo_name.to_string()),
-            );
-            let request = client.client.delete(url).build()?;
+            let request = client
+                .client
+                .delete(format!(
+                    "{}/silos/{}",
+                    client.baseurl,
+                    encode_path(&silo_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -24413,20 +24704,19 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/silos/{}/identity-providers",
-                client.baseurl,
-                encode_path(&silo_name.to_string()),
-            );
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/silos/{}/identity-providers",
+                    client.baseurl,
+                    encode_path(&silo_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -24522,12 +24812,15 @@ pub mod builder {
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
             let Self { client, silo_name } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/silos/{}/policy",
-                client.baseurl,
-                encode_path(&silo_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/silos/{}/policy",
+                    client.baseurl,
+                    encode_path(&silo_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -24593,12 +24886,16 @@ pub mod builder {
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/silos/{}/policy",
-                client.baseurl,
-                encode_path(&silo_name.to_string()),
-            );
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!(
+                    "{}/silos/{}/policy",
+                    client.baseurl,
+                    encode_path(&silo_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -24665,12 +24962,16 @@ pub mod builder {
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/silos/{}/saml-identity-providers",
-                client.baseurl,
-                encode_path(&silo_name.to_string()),
-            );
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/silos/{}/saml-identity-providers",
+                    client.baseurl,
+                    encode_path(&silo_name.to_string()),
+                ))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -24737,13 +25038,16 @@ pub mod builder {
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let provider_name = provider_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/silos/{}/saml-identity-providers/{}",
-                client.baseurl,
-                encode_path(&silo_name.to_string()),
-                encode_path(&provider_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/silos/{}/saml-identity-providers/{}",
+                    client.baseurl,
+                    encode_path(&silo_name.to_string()),
+                    encode_path(&provider_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -24824,16 +25128,15 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/user", client.baseurl,);
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!("{}/system/user", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -24927,12 +25230,15 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::UserBuiltin>, Error<types::Error>> {
             let Self { client, user_name } = self;
             let user_name = user_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/system/user/{}",
-                client.baseurl,
-                encode_path(&user_name.to_string()),
-            );
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!(
+                    "{}/system/user/{}",
+                    client.baseurl,
+                    encode_path(&user_name.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -25000,15 +25306,14 @@ pub mod builder {
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/timeseries/schema", client.baseurl,);
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!("{}/timeseries/schema", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -25086,8 +25391,11 @@ pub mod builder {
         ///Sends a `POST` request to `/updates/refresh`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/updates/refresh", client.baseurl,);
-            let request = client.client.post(url).build()?;
+            let request = client
+                .client
+                .post(format!("{}/updates/refresh", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -25168,16 +25476,15 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/users", client.baseurl,);
-            let query = [
-                ("limit", limit.map(|v| v.to_string())),
-                ("page_token", page_token.map(|v| v.to_string())),
-                ("sort_by", sort_by.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!("{}/users", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("limit", limit.map(|v| v.to_string())),
+                    ("page_token", page_token.map(|v| v.to_string())),
+                    ("sort_by", sort_by.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {

--- a/progenitor-impl/tests/output/nexus-builder.out
+++ b/progenitor-impl/tests/output/nexus-builder.out
@@ -13541,7 +13541,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -13596,7 +13596,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -13651,7 +13651,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -13706,7 +13706,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -13763,7 +13763,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -13818,7 +13818,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -13873,7 +13873,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -13928,7 +13928,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -13983,7 +13983,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14038,7 +14038,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14093,7 +14093,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14148,7 +14148,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14200,7 +14200,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/device/auth", client.baseurl,))
                 .form_urlencoded(&body)?
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14246,7 +14246,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/device/confirm", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14298,7 +14298,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/device/token", client.baseurl,))
                 .form_urlencoded(&body)?
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14483,7 +14483,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&rack_id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14674,7 +14674,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&sled_id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14862,7 +14862,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/images", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14917,7 +14917,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&image_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -14972,7 +14972,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&image_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15160,7 +15160,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/ip-pools", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15215,7 +15215,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&pool_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15288,7 +15288,7 @@ pub mod builder {
                     encode_path(&pool_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15343,7 +15343,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&pool_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15554,7 +15554,7 @@ pub mod builder {
                     encode_path(&pool_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15627,7 +15627,7 @@ pub mod builder {
                     encode_path(&pool_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15679,7 +15679,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/login", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15746,7 +15746,7 @@ pub mod builder {
                     encode_path(&silo_name.to_string()),
                     encode_path(&provider_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15832,7 +15832,7 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/octet-stream"),
                 )
                 .body(body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -15862,7 +15862,7 @@ pub mod builder {
             let request = client
                 .client
                 .post(format!("{}/logout", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16044,7 +16044,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/organizations", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16102,7 +16102,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&organization_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16175,7 +16175,7 @@ pub mod builder {
                     encode_path(&organization_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16233,7 +16233,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&organization_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16293,7 +16293,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&organization_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16368,7 +16368,7 @@ pub mod builder {
                     encode_path(&organization_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16598,7 +16598,7 @@ pub mod builder {
                     encode_path(&organization_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16672,7 +16672,7 @@ pub mod builder {
                     encode_path(&organization_name.to_string()),
                     encode_path(&project_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16761,7 +16761,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -16835,7 +16835,7 @@ pub mod builder {
                     encode_path(&organization_name.to_string()),
                     encode_path(&project_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -17095,7 +17095,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -17185,7 +17185,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&disk_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -17275,7 +17275,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&disk_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -17750,7 +17750,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -17840,7 +17840,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&image_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -17930,7 +17930,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&image_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18193,7 +18193,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18283,7 +18283,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&instance_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18373,7 +18373,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&instance_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18666,7 +18666,7 @@ pub mod builder {
                     encode_path(&instance_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18771,7 +18771,7 @@ pub mod builder {
                     encode_path(&instance_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18863,7 +18863,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&instance_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -18968,7 +18968,7 @@ pub mod builder {
                     encode_path(&instance_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19264,7 +19264,7 @@ pub mod builder {
                     encode_path(&instance_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19371,7 +19371,7 @@ pub mod builder {
                     encode_path(&instance_name.to_string()),
                     encode_path(&interface_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19493,7 +19493,7 @@ pub mod builder {
                     encode_path(&interface_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19598,7 +19598,7 @@ pub mod builder {
                     encode_path(&instance_name.to_string()),
                     encode_path(&interface_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19688,7 +19688,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&instance_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -19919,7 +19919,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&instance_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20009,7 +20009,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&instance_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20085,7 +20085,7 @@ pub mod builder {
                     encode_path(&organization_name.to_string()),
                     encode_path(&project_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20176,7 +20176,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20439,7 +20439,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20529,7 +20529,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&snapshot_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20619,7 +20619,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&snapshot_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20879,7 +20879,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -20969,7 +20969,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&vpc_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21074,7 +21074,7 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21164,7 +21164,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&vpc_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21256,7 +21256,7 @@ pub mod builder {
                     encode_path(&project_name.to_string()),
                     encode_path(&vpc_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21363,7 +21363,7 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21656,7 +21656,7 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21761,7 +21761,7 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                     encode_path(&router_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21881,7 +21881,7 @@ pub mod builder {
                     encode_path(&router_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -21986,7 +21986,7 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                     encode_path(&router_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -22309,7 +22309,7 @@ pub mod builder {
                     encode_path(&router_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -22429,7 +22429,7 @@ pub mod builder {
                     encode_path(&router_name.to_string()),
                     encode_path(&route_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -22564,7 +22564,7 @@ pub mod builder {
                     encode_path(&route_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -22684,7 +22684,7 @@ pub mod builder {
                     encode_path(&router_name.to_string()),
                     encode_path(&route_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -22977,7 +22977,7 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23082,7 +23082,7 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                     encode_path(&subnet_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23202,7 +23202,7 @@ pub mod builder {
                     encode_path(&subnet_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23307,7 +23307,7 @@ pub mod builder {
                     encode_path(&vpc_name.to_string()),
                     encode_path(&subnet_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23549,7 +23549,7 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/policy", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23603,7 +23603,7 @@ pub mod builder {
                 .client
                 .put(format!("{}/policy", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23778,7 +23778,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&role_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -23969,7 +23969,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&saga_id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24005,7 +24005,7 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/session/me", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24193,7 +24193,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/session/me/sshkeys", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24251,7 +24251,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&ssh_key_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24309,7 +24309,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&ssh_key_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24497,7 +24497,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/silos", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24552,7 +24552,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&silo_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24607,7 +24607,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&silo_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24819,7 +24819,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&silo_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24894,7 +24894,7 @@ pub mod builder {
                     encode_path(&silo_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -24970,7 +24970,7 @@ pub mod builder {
                     encode_path(&silo_name.to_string()),
                 ))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -25046,7 +25046,7 @@ pub mod builder {
                     encode_path(&silo_name.to_string()),
                     encode_path(&provider_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -25237,7 +25237,7 @@ pub mod builder {
                     client.baseurl,
                     encode_path(&user_name.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -25394,7 +25394,7 @@ pub mod builder {
             let request = client
                 .client
                 .post(format!("{}/updates/refresh", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/nexus-positional.out
+++ b/progenitor-impl/tests/output/nexus-positional.out
@@ -3001,7 +3001,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3031,7 +3031,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3061,7 +3061,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3091,7 +3091,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3121,7 +3121,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3151,7 +3151,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3181,7 +3181,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3211,7 +3211,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3241,7 +3241,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3271,7 +3271,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3301,7 +3301,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3331,7 +3331,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3362,7 +3362,7 @@ impl Client {
             .client
             .post(format!("{}/device/auth", self.baseurl,))
             .form_urlencoded(&body)?
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3388,7 +3388,7 @@ impl Client {
             .client
             .post(format!("{}/device/confirm", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3418,7 +3418,7 @@ impl Client {
             .client
             .post(format!("{}/device/token", self.baseurl,))
             .form_urlencoded(&body)?
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3525,7 +3525,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&rack_id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3638,7 +3638,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&sled_id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3755,7 +3755,7 @@ impl Client {
             .client
             .post(format!("{}/images", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3787,7 +3787,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&image_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3821,7 +3821,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&image_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3928,7 +3928,7 @@ impl Client {
             .client
             .post(format!("{}/ip-pools", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3958,7 +3958,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&pool_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3990,7 +3990,7 @@ impl Client {
                 encode_path(&pool_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4020,7 +4020,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&pool_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4140,7 +4140,7 @@ impl Client {
                 encode_path(&pool_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4172,7 +4172,7 @@ impl Client {
                 encode_path(&pool_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4197,7 +4197,7 @@ impl Client {
             .client
             .post(format!("{}/login", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4226,7 +4226,7 @@ impl Client {
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4262,7 +4262,7 @@ impl Client {
                 reqwest::header::HeaderValue::from_static("application/octet-stream"),
             )
             .body(body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4277,7 +4277,7 @@ impl Client {
         let request = self
             .client
             .post(format!("{}/logout", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4379,7 +4379,7 @@ impl Client {
             .client
             .post(format!("{}/organizations", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4412,7 +4412,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&organization_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4448,7 +4448,7 @@ impl Client {
                 encode_path(&organization_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4481,7 +4481,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&organization_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4514,7 +4514,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&organization_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4550,7 +4550,7 @@ impl Client {
                 encode_path(&organization_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4675,7 +4675,7 @@ impl Client {
                 encode_path(&organization_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4712,7 +4712,7 @@ impl Client {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4752,7 +4752,7 @@ impl Client {
                 encode_path(&project_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4789,7 +4789,7 @@ impl Client {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4930,7 +4930,7 @@ impl Client {
                 encode_path(&project_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4966,7 +4966,7 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -5002,7 +5002,7 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -5281,7 +5281,7 @@ impl Client {
                 encode_path(&project_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -5319,7 +5319,7 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -5359,7 +5359,7 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -5501,7 +5501,7 @@ impl Client {
                 encode_path(&project_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -5537,7 +5537,7 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -5573,7 +5573,7 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -5724,7 +5724,7 @@ impl Client {
                 encode_path(&instance_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -5760,7 +5760,7 @@ impl Client {
                 encode_path(&instance_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -5796,7 +5796,7 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -5835,7 +5835,7 @@ impl Client {
                 encode_path(&instance_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -5989,7 +5989,7 @@ impl Client {
                 encode_path(&instance_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6027,7 +6027,7 @@ impl Client {
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6067,7 +6067,7 @@ impl Client {
                 encode_path(&interface_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6110,7 +6110,7 @@ impl Client {
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6146,7 +6146,7 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6241,7 +6241,7 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6277,7 +6277,7 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6314,7 +6314,7 @@ impl Client {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6354,7 +6354,7 @@ impl Client {
                 encode_path(&project_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6496,7 +6496,7 @@ impl Client {
                 encode_path(&project_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6532,7 +6532,7 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6568,7 +6568,7 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6709,7 +6709,7 @@ impl Client {
                 encode_path(&project_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6745,7 +6745,7 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6783,7 +6783,7 @@ impl Client {
                 encode_path(&vpc_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6819,7 +6819,7 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6855,7 +6855,7 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6893,7 +6893,7 @@ impl Client {
                 encode_path(&vpc_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7047,7 +7047,7 @@ impl Client {
                 encode_path(&vpc_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7085,7 +7085,7 @@ impl Client {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7125,7 +7125,7 @@ impl Client {
                 encode_path(&router_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7163,7 +7163,7 @@ impl Client {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7327,7 +7327,7 @@ impl Client {
                 encode_path(&router_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7367,7 +7367,7 @@ impl Client {
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7409,7 +7409,7 @@ impl Client {
                 encode_path(&route_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7449,7 +7449,7 @@ impl Client {
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7603,7 +7603,7 @@ impl Client {
                 encode_path(&vpc_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7641,7 +7641,7 @@ impl Client {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7681,7 +7681,7 @@ impl Client {
                 encode_path(&subnet_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7719,7 +7719,7 @@ impl Client {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7868,7 +7868,7 @@ impl Client {
         let request = self
             .client
             .get(format!("{}/policy", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7895,7 +7895,7 @@ impl Client {
             .client
             .put(format!("{}/policy", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8003,7 +8003,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&role_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8113,7 +8113,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&saga_id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8138,7 +8138,7 @@ impl Client {
         let request = self
             .client
             .get(format!("{}/session/me", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8245,7 +8245,7 @@ impl Client {
             .client
             .post(format!("{}/session/me/sshkeys", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8275,7 +8275,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8305,7 +8305,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8408,7 +8408,7 @@ impl Client {
             .client
             .post(format!("{}/silos", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8441,7 +8441,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&silo_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8474,7 +8474,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&silo_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8596,7 +8596,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&silo_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8632,7 +8632,7 @@ impl Client {
                 encode_path(&silo_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8668,7 +8668,7 @@ impl Client {
                 encode_path(&silo_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8705,7 +8705,7 @@ impl Client {
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8819,7 +8819,7 @@ impl Client {
                 self.baseurl,
                 encode_path(&user_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8918,7 +8918,7 @@ impl Client {
         let request = self
             .client
             .post(format!("{}/updates/refresh", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;

--- a/progenitor-impl/tests/output/nexus-positional.out
+++ b/progenitor-impl/tests/output/nexus-positional.out
@@ -3001,7 +3001,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3031,7 +3030,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3061,7 +3059,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3091,7 +3088,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3121,7 +3117,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3151,7 +3146,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3181,7 +3175,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3211,7 +3204,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3241,7 +3233,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3271,7 +3262,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3301,7 +3291,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3331,7 +3320,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3362,7 +3350,6 @@ impl Client {
             .client
             .post(format!("{}/device/auth", self.baseurl,))
             .form_urlencoded(&body)?
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3388,7 +3375,6 @@ impl Client {
             .client
             .post(format!("{}/device/confirm", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3418,7 +3404,6 @@ impl Client {
             .client
             .post(format!("{}/device/token", self.baseurl,))
             .form_urlencoded(&body)?
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3525,7 +3510,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&rack_id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3638,7 +3622,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&sled_id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3755,7 +3738,6 @@ impl Client {
             .client
             .post(format!("{}/images", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3787,7 +3769,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&image_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3821,7 +3802,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&image_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3928,7 +3908,6 @@ impl Client {
             .client
             .post(format!("{}/ip-pools", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3958,7 +3937,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&pool_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3990,7 +3968,6 @@ impl Client {
                 encode_path(&pool_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4020,7 +3997,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&pool_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4140,7 +4116,6 @@ impl Client {
                 encode_path(&pool_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4172,7 +4147,6 @@ impl Client {
                 encode_path(&pool_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4197,7 +4171,6 @@ impl Client {
             .client
             .post(format!("{}/login", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4226,7 +4199,6 @@ impl Client {
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4262,7 +4234,6 @@ impl Client {
                 reqwest::header::HeaderValue::from_static("application/octet-stream"),
             )
             .body(body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4277,7 +4248,6 @@ impl Client {
         let request = self
             .client
             .post(format!("{}/logout", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4379,7 +4349,6 @@ impl Client {
             .client
             .post(format!("{}/organizations", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4412,7 +4381,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&organization_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4448,7 +4416,6 @@ impl Client {
                 encode_path(&organization_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4481,7 +4448,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&organization_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4514,7 +4480,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&organization_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4550,7 +4515,6 @@ impl Client {
                 encode_path(&organization_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4675,7 +4639,6 @@ impl Client {
                 encode_path(&organization_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4712,7 +4675,6 @@ impl Client {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4752,7 +4714,6 @@ impl Client {
                 encode_path(&project_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4789,7 +4750,6 @@ impl Client {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4930,7 +4890,6 @@ impl Client {
                 encode_path(&project_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4966,7 +4925,6 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -5002,7 +4960,6 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -5281,7 +5238,6 @@ impl Client {
                 encode_path(&project_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -5319,7 +5275,6 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -5359,7 +5314,6 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -5501,7 +5455,6 @@ impl Client {
                 encode_path(&project_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -5537,7 +5490,6 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -5573,7 +5525,6 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -5724,7 +5675,6 @@ impl Client {
                 encode_path(&instance_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -5760,7 +5710,6 @@ impl Client {
                 encode_path(&instance_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -5796,7 +5745,6 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -5835,7 +5783,6 @@ impl Client {
                 encode_path(&instance_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -5989,7 +5936,6 @@ impl Client {
                 encode_path(&instance_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6027,7 +5973,6 @@ impl Client {
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6067,7 +6012,6 @@ impl Client {
                 encode_path(&interface_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6110,7 +6054,6 @@ impl Client {
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6146,7 +6089,6 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6241,7 +6183,6 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6277,7 +6218,6 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6314,7 +6254,6 @@ impl Client {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6354,7 +6293,6 @@ impl Client {
                 encode_path(&project_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6496,7 +6434,6 @@ impl Client {
                 encode_path(&project_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6532,7 +6469,6 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6568,7 +6504,6 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6709,7 +6644,6 @@ impl Client {
                 encode_path(&project_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6745,7 +6679,6 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6783,7 +6716,6 @@ impl Client {
                 encode_path(&vpc_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6819,7 +6751,6 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6855,7 +6786,6 @@ impl Client {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6893,7 +6823,6 @@ impl Client {
                 encode_path(&vpc_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7047,7 +6976,6 @@ impl Client {
                 encode_path(&vpc_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7085,7 +7013,6 @@ impl Client {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7125,7 +7052,6 @@ impl Client {
                 encode_path(&router_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7163,7 +7089,6 @@ impl Client {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7327,7 +7252,6 @@ impl Client {
                 encode_path(&router_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7367,7 +7291,6 @@ impl Client {
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7409,7 +7332,6 @@ impl Client {
                 encode_path(&route_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7449,7 +7371,6 @@ impl Client {
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7603,7 +7524,6 @@ impl Client {
                 encode_path(&vpc_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7641,7 +7561,6 @@ impl Client {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7681,7 +7600,6 @@ impl Client {
                 encode_path(&subnet_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7719,7 +7637,6 @@ impl Client {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7868,7 +7785,6 @@ impl Client {
         let request = self
             .client
             .get(format!("{}/policy", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7895,7 +7811,6 @@ impl Client {
             .client
             .put(format!("{}/policy", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8003,7 +7918,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&role_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8113,7 +8027,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&saga_id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8138,7 +8051,6 @@ impl Client {
         let request = self
             .client
             .get(format!("{}/session/me", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8245,7 +8157,6 @@ impl Client {
             .client
             .post(format!("{}/session/me/sshkeys", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8275,7 +8186,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8305,7 +8215,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8408,7 +8317,6 @@ impl Client {
             .client
             .post(format!("{}/silos", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8441,7 +8349,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&silo_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8474,7 +8381,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&silo_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8596,7 +8502,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&silo_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8632,7 +8537,6 @@ impl Client {
                 encode_path(&silo_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8668,7 +8572,6 @@ impl Client {
                 encode_path(&silo_name.to_string()),
             ))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8705,7 +8608,6 @@ impl Client {
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8819,7 +8721,6 @@ impl Client {
                 self.baseurl,
                 encode_path(&user_name.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8918,7 +8819,6 @@ impl Client {
         let request = self
             .client
             .post(format!("{}/updates/refresh", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;

--- a/progenitor-impl/tests/output/nexus-positional.out
+++ b/progenitor-impl/tests/output/nexus-positional.out
@@ -2994,12 +2994,15 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let url = format!(
-            "{}/by-id/disks/{}",
-            self.baseurl,
-            encode_path(&id.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/by-id/disks/{}",
+                self.baseurl,
+                encode_path(&id.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -3021,12 +3024,15 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-        let url = format!(
-            "{}/by-id/global-images/{}",
-            self.baseurl,
-            encode_path(&id.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/by-id/global-images/{}",
+                self.baseurl,
+                encode_path(&id.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -3048,12 +3054,15 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
-        let url = format!(
-            "{}/by-id/images/{}",
-            self.baseurl,
-            encode_path(&id.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/by-id/images/{}",
+                self.baseurl,
+                encode_path(&id.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -3075,12 +3084,15 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let url = format!(
-            "{}/by-id/instances/{}",
-            self.baseurl,
-            encode_path(&id.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/by-id/instances/{}",
+                self.baseurl,
+                encode_path(&id.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -3102,12 +3114,15 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
-        let url = format!(
-            "{}/by-id/network-interfaces/{}",
-            self.baseurl,
-            encode_path(&id.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/by-id/network-interfaces/{}",
+                self.baseurl,
+                encode_path(&id.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -3129,12 +3144,15 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let url = format!(
-            "{}/by-id/organizations/{}",
-            self.baseurl,
-            encode_path(&id.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/by-id/organizations/{}",
+                self.baseurl,
+                encode_path(&id.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -3156,12 +3174,15 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-        let url = format!(
-            "{}/by-id/projects/{}",
-            self.baseurl,
-            encode_path(&id.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/by-id/projects/{}",
+                self.baseurl,
+                encode_path(&id.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -3183,12 +3204,15 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
-        let url = format!(
-            "{}/by-id/snapshots/{}",
-            self.baseurl,
-            encode_path(&id.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/by-id/snapshots/{}",
+                self.baseurl,
+                encode_path(&id.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -3210,12 +3234,15 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
-        let url = format!(
-            "{}/by-id/vpc-router-routes/{}",
-            self.baseurl,
-            encode_path(&id.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/by-id/vpc-router-routes/{}",
+                self.baseurl,
+                encode_path(&id.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -3237,12 +3264,15 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
-        let url = format!(
-            "{}/by-id/vpc-routers/{}",
-            self.baseurl,
-            encode_path(&id.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/by-id/vpc-routers/{}",
+                self.baseurl,
+                encode_path(&id.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -3264,12 +3294,15 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
-        let url = format!(
-            "{}/by-id/vpc-subnets/{}",
-            self.baseurl,
-            encode_path(&id.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/by-id/vpc-subnets/{}",
+                self.baseurl,
+                encode_path(&id.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -3291,12 +3324,15 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
-        let url = format!(
-            "{}/by-id/vpcs/{}",
-            self.baseurl,
-            encode_path(&id.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/by-id/vpcs/{}",
+                self.baseurl,
+                encode_path(&id.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -3322,8 +3358,12 @@ impl Client {
         &'a self,
         body: &'a types::DeviceAuthRequest,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-        let url = format!("{}/device/auth", self.baseurl,);
-        let request = self.client.post(url).form_urlencoded(&body)?.build()?;
+        let request = self
+            .client
+            .post(format!("{}/device/auth", self.baseurl,))
+            .form_urlencoded(&body)?
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -3344,8 +3384,12 @@ impl Client {
         &'a self,
         body: &'a types::DeviceAuthVerify,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!("{}/device/confirm", self.baseurl,);
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!("{}/device/confirm", self.baseurl,))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -3370,8 +3414,12 @@ impl Client {
         &'a self,
         body: &'a types::DeviceAccessTokenRequest,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-        let url = format!("{}/device/token", self.baseurl,);
-        let request = self.client.post(url).form_urlencoded(&body)?.build()?;
+        let request = self
+            .client
+            .post(format!("{}/device/token", self.baseurl,))
+            .form_urlencoded(&body)?
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -3395,16 +3443,15 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::RackResultsPage>, Error<types::Error>> {
-        let url = format!("{}/hardware/racks", self.baseurl,);
-        let query = [
-            ("limit", limit.map(|v| v.to_string())),
-            ("page_token", page_token.map(|v| v.to_string())),
-            ("sort_by", sort_by.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!("{}/hardware/racks", self.baseurl,))
+            .query::<[(&str, Option<String>)]>(&[
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -3471,12 +3518,15 @@ impl Client {
         &'a self,
         rack_id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Rack>, Error<types::Error>> {
-        let url = format!(
-            "{}/hardware/racks/{}",
-            self.baseurl,
-            encode_path(&rack_id.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/hardware/racks/{}",
+                self.baseurl,
+                encode_path(&rack_id.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -3506,16 +3556,15 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SledResultsPage>, Error<types::Error>> {
-        let url = format!("{}/hardware/sleds", self.baseurl,);
-        let query = [
-            ("limit", limit.map(|v| v.to_string())),
-            ("page_token", page_token.map(|v| v.to_string())),
-            ("sort_by", sort_by.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!("{}/hardware/sleds", self.baseurl,))
+            .query::<[(&str, Option<String>)]>(&[
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -3582,12 +3631,15 @@ impl Client {
         &'a self,
         sled_id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Sled>, Error<types::Error>> {
-        let url = format!(
-            "{}/hardware/sleds/{}",
-            self.baseurl,
-            encode_path(&sled_id.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/hardware/sleds/{}",
+                self.baseurl,
+                encode_path(&sled_id.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -3620,16 +3672,15 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::GlobalImageResultsPage>, Error<types::Error>> {
-        let url = format!("{}/images", self.baseurl,);
-        let query = [
-            ("limit", limit.map(|v| v.to_string())),
-            ("page_token", page_token.map(|v| v.to_string())),
-            ("sort_by", sort_by.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!("{}/images", self.baseurl,))
+            .query::<[(&str, Option<String>)]>(&[
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -3700,8 +3751,12 @@ impl Client {
         &'a self,
         body: &'a types::GlobalImageCreate,
     ) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-        let url = format!("{}/images", self.baseurl,);
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!("{}/images", self.baseurl,))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -3725,12 +3780,15 @@ impl Client {
         &'a self,
         image_name: &'a types::Name,
     ) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-        let url = format!(
-            "{}/images/{}",
-            self.baseurl,
-            encode_path(&image_name.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/images/{}",
+                self.baseurl,
+                encode_path(&image_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -3756,12 +3814,15 @@ impl Client {
         &'a self,
         image_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
-            "{}/images/{}",
-            self.baseurl,
-            encode_path(&image_name.to_string()),
-        );
-        let request = self.client.delete(url).build()?;
+        let request = self
+            .client
+            .delete(format!(
+                "{}/images/{}",
+                self.baseurl,
+                encode_path(&image_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -3791,16 +3852,15 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::IpPoolResultsPage>, Error<types::Error>> {
-        let url = format!("{}/ip-pools", self.baseurl,);
-        let query = [
-            ("limit", limit.map(|v| v.to_string())),
-            ("page_token", page_token.map(|v| v.to_string())),
-            ("sort_by", sort_by.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!("{}/ip-pools", self.baseurl,))
+            .query::<[(&str, Option<String>)]>(&[
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -3864,8 +3924,12 @@ impl Client {
         &'a self,
         body: &'a types::IpPoolCreate,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-        let url = format!("{}/ip-pools", self.baseurl,);
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!("{}/ip-pools", self.baseurl,))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -3887,12 +3951,15 @@ impl Client {
         &'a self,
         pool_name: &'a types::Name,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-        let url = format!(
-            "{}/ip-pools/{}",
-            self.baseurl,
-            encode_path(&pool_name.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/ip-pools/{}",
+                self.baseurl,
+                encode_path(&pool_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -3915,12 +3982,16 @@ impl Client {
         pool_name: &'a types::Name,
         body: &'a types::IpPoolUpdate,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-        let url = format!(
-            "{}/ip-pools/{}",
-            self.baseurl,
-            encode_path(&pool_name.to_string()),
-        );
-        let request = self.client.put(url).json(&body).build()?;
+        let request = self
+            .client
+            .put(format!(
+                "{}/ip-pools/{}",
+                self.baseurl,
+                encode_path(&pool_name.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -3942,12 +4013,15 @@ impl Client {
         &'a self,
         pool_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
-            "{}/ip-pools/{}",
-            self.baseurl,
-            encode_path(&pool_name.to_string()),
-        );
-        let request = self.client.delete(url).build()?;
+        let request = self
+            .client
+            .delete(format!(
+                "{}/ip-pools/{}",
+                self.baseurl,
+                encode_path(&pool_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -3979,19 +4053,18 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
-        let url = format!(
-            "{}/ip-pools/{}/ranges",
-            self.baseurl,
-            encode_path(&pool_name.to_string()),
-        );
-        let query = [
-            ("limit", limit.map(|v| v.to_string())),
-            ("page_token", page_token.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/ip-pools/{}/ranges",
+                self.baseurl,
+                encode_path(&pool_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&[
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -4059,12 +4132,16 @@ impl Client {
         pool_name: &'a types::Name,
         body: &'a types::IpRange,
     ) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
-        let url = format!(
-            "{}/ip-pools/{}/ranges/add",
-            self.baseurl,
-            encode_path(&pool_name.to_string()),
-        );
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!(
+                "{}/ip-pools/{}/ranges/add",
+                self.baseurl,
+                encode_path(&pool_name.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -4087,12 +4164,16 @@ impl Client {
         pool_name: &'a types::Name,
         body: &'a types::IpRange,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
-            "{}/ip-pools/{}/ranges/remove",
-            self.baseurl,
-            encode_path(&pool_name.to_string()),
-        );
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!(
+                "{}/ip-pools/{}/ranges/remove",
+                self.baseurl,
+                encode_path(&pool_name.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -4112,8 +4193,12 @@ impl Client {
         &'a self,
         body: &'a types::SpoofLoginBody,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-        let url = format!("{}/login", self.baseurl,);
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!("{}/login", self.baseurl,))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -4133,13 +4218,16 @@ impl Client {
         silo_name: &'a types::Name,
         provider_name: &'a types::Name,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-        let url = format!(
-            "{}/login/{}/{}",
-            self.baseurl,
-            encode_path(&silo_name.to_string()),
-            encode_path(&provider_name.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/login/{}/{}",
+                self.baseurl,
+                encode_path(&silo_name.to_string()),
+                encode_path(&provider_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -4161,20 +4249,20 @@ impl Client {
         provider_name: &'a types::Name,
         body: B,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-        let url = format!(
-            "{}/login/{}/{}",
-            self.baseurl,
-            encode_path(&silo_name.to_string()),
-            encode_path(&provider_name.to_string()),
-        );
         let request = self
             .client
-            .post(url)
+            .post(format!(
+                "{}/login/{}/{}",
+                self.baseurl,
+                encode_path(&silo_name.to_string()),
+                encode_path(&provider_name.to_string()),
+            ))
             .header(
                 reqwest::header::CONTENT_TYPE,
                 reqwest::header::HeaderValue::from_static("application/octet-stream"),
             )
             .body(body)
+            .query::<[(&str, Option<String>)]>(&vec![])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4186,8 +4274,11 @@ impl Client {
 
     ///Sends a `POST` request to `/logout`
     pub async fn logout<'a>(&'a self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-        let url = format!("{}/logout", self.baseurl,);
-        let request = self.client.post(url).build()?;
+        let request = self
+            .client
+            .post(format!("{}/logout", self.baseurl,))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -4211,16 +4302,15 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
-        let url = format!("{}/organizations", self.baseurl,);
-        let query = [
-            ("limit", limit.map(|v| v.to_string())),
-            ("page_token", page_token.map(|v| v.to_string())),
-            ("sort_by", sort_by.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!("{}/organizations", self.baseurl,))
+            .query::<[(&str, Option<String>)]>(&[
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -4285,8 +4375,12 @@ impl Client {
         &'a self,
         body: &'a types::OrganizationCreate,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let url = format!("{}/organizations", self.baseurl,);
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!("{}/organizations", self.baseurl,))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -4311,12 +4405,15 @@ impl Client {
         &'a self,
         organization_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -4343,12 +4440,16 @@ impl Client {
         organization_name: &'a types::Name,
         body: &'a types::OrganizationUpdate,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-        );
-        let request = self.client.put(url).json(&body).build()?;
+        let request = self
+            .client
+            .put(format!(
+                "{}/organizations/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -4373,12 +4474,15 @@ impl Client {
         &'a self,
         organization_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-        );
-        let request = self.client.delete(url).build()?;
+        let request = self
+            .client
+            .delete(format!(
+                "{}/organizations/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -4403,12 +4507,15 @@ impl Client {
         &'a self,
         organization_name: &'a types::Name,
     ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/policy",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}/policy",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -4435,12 +4542,16 @@ impl Client {
         organization_name: &'a types::Name,
         body: &'a types::OrganizationRolePolicy,
     ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/policy",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-        );
-        let request = self.client.put(url).json(&body).build()?;
+        let request = self
+            .client
+            .put(format!(
+                "{}/organizations/{}/policy",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -4472,20 +4583,19 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-        );
-        let query = [
-            ("limit", limit.map(|v| v.to_string())),
-            ("page_token", page_token.map(|v| v.to_string())),
-            ("sort_by", sort_by.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}/projects",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&[
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -4557,12 +4667,16 @@ impl Client {
         organization_name: &'a types::Name,
         body: &'a types::ProjectCreate,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-        );
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!(
+                "{}/organizations/{}/projects",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -4590,13 +4704,16 @@ impl Client {
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}/projects/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -4626,13 +4743,17 @@ impl Client {
         project_name: &'a types::Name,
         body: &'a types::ProjectUpdate,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-        );
-        let request = self.client.put(url).json(&body).build()?;
+        let request = self
+            .client
+            .put(format!(
+                "{}/organizations/{}/projects/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -4660,13 +4781,16 @@ impl Client {
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-        );
-        let request = self.client.delete(url).build()?;
+        let request = self
+            .client
+            .delete(format!(
+                "{}/organizations/{}/projects/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -4701,21 +4825,20 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/disks",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-        );
-        let query = [
-            ("limit", limit.map(|v| v.to_string())),
-            ("page_token", page_token.map(|v| v.to_string())),
-            ("sort_by", sort_by.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}/projects/{}/disks",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&[
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -4798,13 +4921,17 @@ impl Client {
         project_name: &'a types::Name,
         body: &'a types::DiskCreate,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/disks",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-        );
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!(
+                "{}/organizations/{}/projects/{}/disks",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -4830,14 +4957,17 @@ impl Client {
         project_name: &'a types::Name,
         disk_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/disks/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&disk_name.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}/projects/{}/disks/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&disk_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -4863,14 +4993,17 @@ impl Client {
         project_name: &'a types::Name,
         disk_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/disks/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&disk_name.to_string()),
-        );
-        let request = self.client.delete(url).build()?;
+        let request = self
+            .client
+            .delete(format!(
+                "{}/organizations/{}/projects/{}/disks/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&disk_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -4912,24 +5045,23 @@ impl Client {
         page_token: Option<&'a str>,
         start_time: Option<&'a chrono::DateTime<chrono::offset::Utc>>,
     ) -> Result<ResponseValue<types::MeasurementResultsPage>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/disks/{}/metrics/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&disk_name.to_string()),
-            encode_path(&metric_name.to_string()),
-        );
-        let query = [
-            ("end_time", end_time.map(|v| v.to_string())),
-            ("limit", limit.map(|v| v.to_string())),
-            ("page_token", page_token.map(|v| v.to_string())),
-            ("start_time", start_time.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}/projects/{}/disks/{}/metrics/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&disk_name.to_string()),
+                encode_path(&metric_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&[
+                ("end_time", end_time.map(|v| v.to_string())),
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("start_time", start_time.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -5039,21 +5171,20 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::ImageResultsPage>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/images",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-        );
-        let query = [
-            ("limit", limit.map(|v| v.to_string())),
-            ("page_token", page_token.map(|v| v.to_string())),
-            ("sort_by", sort_by.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}/projects/{}/images",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&[
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -5141,13 +5272,17 @@ impl Client {
         project_name: &'a types::Name,
         body: &'a types::ImageCreate,
     ) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/images",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-        );
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!(
+                "{}/organizations/{}/projects/{}/images",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -5175,14 +5310,17 @@ impl Client {
         project_name: &'a types::Name,
         image_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/images/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&image_name.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}/projects/{}/images/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&image_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -5212,14 +5350,17 @@ impl Client {
         project_name: &'a types::Name,
         image_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/images/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&image_name.to_string()),
-        );
-        let request = self.client.delete(url).build()?;
+        let request = self
+            .client
+            .delete(format!(
+                "{}/organizations/{}/projects/{}/images/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&image_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -5254,21 +5395,20 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/instances",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-        );
-        let query = [
-            ("limit", limit.map(|v| v.to_string())),
-            ("page_token", page_token.map(|v| v.to_string())),
-            ("sort_by", sort_by.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}/projects/{}/instances",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&[
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -5352,13 +5492,17 @@ impl Client {
         project_name: &'a types::Name,
         body: &'a types::InstanceCreate,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/instances",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-        );
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!(
+                "{}/organizations/{}/projects/{}/instances",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -5384,14 +5528,17 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/instances/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}/projects/{}/instances/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&instance_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -5417,14 +5564,17 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/instances/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
-        );
-        let request = self.client.delete(url).build()?;
+        let request = self
+            .client
+            .delete(format!(
+                "{}/organizations/{}/projects/{}/instances/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&instance_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -5462,22 +5612,21 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/instances/{}/disks",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
-        );
-        let query = [
-            ("limit", limit.map(|v| v.to_string())),
-            ("page_token", page_token.map(|v| v.to_string())),
-            ("sort_by", sort_by.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}/projects/{}/instances/{}/disks",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&instance_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&[
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -5565,14 +5714,18 @@ impl Client {
         instance_name: &'a types::Name,
         body: &'a types::DiskIdentifier,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/instances/{}/disks/attach",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
-        );
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!(
+                "{}/organizations/{}/projects/{}/instances/{}/disks/attach",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&instance_name.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -5597,14 +5750,18 @@ impl Client {
         instance_name: &'a types::Name,
         body: &'a types::DiskIdentifier,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/instances/{}/disks/detach",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
-        );
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!(
+                "{}/organizations/{}/projects/{}/instances/{}/disks/detach",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&instance_name.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -5630,14 +5787,17 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
     ) -> Result<ResponseValue<types::ExternalIpResultsPage>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/instances/{}/external-ips",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}/projects/{}/instances/{}/external-ips",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&instance_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -5665,14 +5825,18 @@ impl Client {
         instance_name: &'a types::Name,
         body: &'a types::InstanceMigrate,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/instances/{}/migrate",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
-        );
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!(
+                "{}/organizations/{}/projects/{}/instances/{}/migrate",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&instance_name.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -5710,22 +5874,21 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::NetworkInterfaceResultsPage>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
-        );
-        let query = [
-            ("limit", limit.map(|v| v.to_string())),
-            ("page_token", page_token.map(|v| v.to_string())),
-            ("sort_by", sort_by.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&instance_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&[
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -5816,14 +5979,18 @@ impl Client {
         instance_name: &'a types::Name,
         body: &'a types::NetworkInterfaceCreate,
     ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
-        );
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!(
+                "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&instance_name.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -5850,15 +6017,18 @@ impl Client {
         instance_name: &'a types::Name,
         interface_name: &'a types::Name,
     ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
-            encode_path(&interface_name.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&instance_name.to_string()),
+                encode_path(&interface_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -5886,15 +6056,19 @@ impl Client {
         interface_name: &'a types::Name,
         body: &'a types::NetworkInterfaceUpdate,
     ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
-            encode_path(&interface_name.to_string()),
-        );
-        let request = self.client.put(url).json(&body).build()?;
+        let request = self
+            .client
+            .put(format!(
+                "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&instance_name.to_string()),
+                encode_path(&interface_name.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -5926,15 +6100,18 @@ impl Client {
         instance_name: &'a types::Name,
         interface_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
-            encode_path(&interface_name.to_string()),
-        );
-        let request = self.client.delete(url).build()?;
+        let request = self
+            .client
+            .delete(format!(
+                "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&instance_name.to_string()),
+                encode_path(&interface_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -5960,14 +6137,17 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/instances/{}/reboot",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
-        );
-        let request = self.client.post(url).build()?;
+        let request = self
+            .client
+            .post(format!(
+                "{}/organizations/{}/projects/{}/instances/{}/reboot",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&instance_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -6012,22 +6192,21 @@ impl Client {
         max_bytes: Option<u64>,
         most_recent: Option<u64>,
     ) -> Result<ResponseValue<types::InstanceSerialConsoleData>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/instances/{}/serial-console",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
-        );
-        let query = [
-            ("from_start", from_start.map(|v| v.to_string())),
-            ("max_bytes", max_bytes.map(|v| v.to_string())),
-            ("most_recent", most_recent.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}/projects/{}/instances/{}/serial-console",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&instance_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&[
+                ("from_start", from_start.map(|v| v.to_string())),
+                ("max_bytes", max_bytes.map(|v| v.to_string())),
+                ("most_recent", most_recent.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -6053,14 +6232,17 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/instances/{}/start",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
-        );
-        let request = self.client.post(url).build()?;
+        let request = self
+            .client
+            .post(format!(
+                "{}/organizations/{}/projects/{}/instances/{}/start",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&instance_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -6086,14 +6268,17 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/instances/{}/stop",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&instance_name.to_string()),
-        );
-        let request = self.client.post(url).build()?;
+        let request = self
+            .client
+            .post(format!(
+                "{}/organizations/{}/projects/{}/instances/{}/stop",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&instance_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -6121,13 +6306,16 @@ impl Client {
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
     ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/policy",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}/projects/{}/policy",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -6157,13 +6345,17 @@ impl Client {
         project_name: &'a types::Name,
         body: &'a types::ProjectRolePolicy,
     ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/policy",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-        );
-        let request = self.client.put(url).json(&body).build()?;
+        let request = self
+            .client
+            .put(format!(
+                "{}/organizations/{}/projects/{}/policy",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -6198,21 +6390,20 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::SnapshotResultsPage>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/snapshots",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-        );
-        let query = [
-            ("limit", limit.map(|v| v.to_string())),
-            ("page_token", page_token.map(|v| v.to_string())),
-            ("sort_by", sort_by.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}/projects/{}/snapshots",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&[
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -6296,13 +6487,17 @@ impl Client {
         project_name: &'a types::Name,
         body: &'a types::SnapshotCreate,
     ) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/snapshots",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-        );
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!(
+                "{}/organizations/{}/projects/{}/snapshots",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -6328,14 +6523,17 @@ impl Client {
         project_name: &'a types::Name,
         snapshot_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/snapshots/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&snapshot_name.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}/projects/{}/snapshots/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&snapshot_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -6361,14 +6559,17 @@ impl Client {
         project_name: &'a types::Name,
         snapshot_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/snapshots/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&snapshot_name.to_string()),
-        );
-        let request = self.client.delete(url).build()?;
+        let request = self
+            .client
+            .delete(format!(
+                "{}/organizations/{}/projects/{}/snapshots/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&snapshot_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -6403,21 +6604,20 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::VpcResultsPage>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/vpcs",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-        );
-        let query = [
-            ("limit", limit.map(|v| v.to_string())),
-            ("page_token", page_token.map(|v| v.to_string())),
-            ("sort_by", sort_by.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}/projects/{}/vpcs",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&[
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -6500,13 +6700,17 @@ impl Client {
         project_name: &'a types::Name,
         body: &'a types::VpcCreate,
     ) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/vpcs",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-        );
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!(
+                "{}/organizations/{}/projects/{}/vpcs",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -6532,14 +6736,17 @@ impl Client {
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/vpcs/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}/projects/{}/vpcs/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&vpc_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -6566,14 +6773,18 @@ impl Client {
         vpc_name: &'a types::Name,
         body: &'a types::VpcUpdate,
     ) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/vpcs/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
-        );
-        let request = self.client.put(url).json(&body).build()?;
+        let request = self
+            .client
+            .put(format!(
+                "{}/organizations/{}/projects/{}/vpcs/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&vpc_name.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -6599,14 +6810,17 @@ impl Client {
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/vpcs/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
-        );
-        let request = self.client.delete(url).build()?;
+        let request = self
+            .client
+            .delete(format!(
+                "{}/organizations/{}/projects/{}/vpcs/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&vpc_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -6632,14 +6846,17 @@ impl Client {
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
     ) -> Result<ResponseValue<types::VpcFirewallRules>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&vpc_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -6666,14 +6883,18 @@ impl Client {
         vpc_name: &'a types::Name,
         body: &'a types::VpcFirewallRuleUpdateParams,
     ) -> Result<ResponseValue<types::VpcFirewallRules>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
-        );
-        let request = self.client.put(url).json(&body).build()?;
+        let request = self
+            .client
+            .put(format!(
+                "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&vpc_name.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -6711,22 +6932,21 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::VpcRouterResultsPage>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/vpcs/{}/routers",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
-        );
-        let query = [
-            ("limit", limit.map(|v| v.to_string())),
-            ("page_token", page_token.map(|v| v.to_string())),
-            ("sort_by", sort_by.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}/projects/{}/vpcs/{}/routers",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&vpc_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&[
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -6817,14 +7037,18 @@ impl Client {
         vpc_name: &'a types::Name,
         body: &'a types::VpcRouterCreate,
     ) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/vpcs/{}/routers",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
-        );
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!(
+                "{}/organizations/{}/projects/{}/vpcs/{}/routers",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&vpc_name.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -6851,15 +7075,18 @@ impl Client {
         vpc_name: &'a types::Name,
         router_name: &'a types::Name,
     ) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
-            encode_path(&router_name.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&vpc_name.to_string()),
+                encode_path(&router_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -6887,15 +7114,19 @@ impl Client {
         router_name: &'a types::Name,
         body: &'a types::VpcRouterUpdate,
     ) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
-            encode_path(&router_name.to_string()),
-        );
-        let request = self.client.put(url).json(&body).build()?;
+        let request = self
+            .client
+            .put(format!(
+                "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&vpc_name.to_string()),
+                encode_path(&router_name.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -6922,15 +7153,18 @@ impl Client {
         vpc_name: &'a types::Name,
         router_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
-            encode_path(&router_name.to_string()),
-        );
-        let request = self.client.delete(url).build()?;
+        let request = self
+            .client
+            .delete(format!(
+                "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&vpc_name.to_string()),
+                encode_path(&router_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -6970,23 +7204,22 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::RouterRouteResultsPage>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
-            encode_path(&router_name.to_string()),
-        );
-        let query = [
-            ("limit", limit.map(|v| v.to_string())),
-            ("page_token", page_token.map(|v| v.to_string())),
-            ("sort_by", sort_by.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&vpc_name.to_string()),
+                encode_path(&router_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&[
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -7083,15 +7316,19 @@ impl Client {
         router_name: &'a types::Name,
         body: &'a types::RouterRouteCreateParams,
     ) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
-            encode_path(&router_name.to_string()),
-        );
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!(
+                "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&vpc_name.to_string()),
+                encode_path(&router_name.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -7119,16 +7356,19 @@ impl Client {
         router_name: &'a types::Name,
         route_name: &'a types::Name,
     ) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
-            encode_path(&router_name.to_string()),
-            encode_path(&route_name.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&vpc_name.to_string()),
+                encode_path(&router_name.to_string()),
+                encode_path(&route_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -7157,16 +7397,20 @@ impl Client {
         route_name: &'a types::Name,
         body: &'a types::RouterRouteUpdateParams,
     ) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
-            encode_path(&router_name.to_string()),
-            encode_path(&route_name.to_string()),
-        );
-        let request = self.client.put(url).json(&body).build()?;
+        let request = self
+            .client
+            .put(format!(
+                "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&vpc_name.to_string()),
+                encode_path(&router_name.to_string()),
+                encode_path(&route_name.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -7194,16 +7438,19 @@ impl Client {
         router_name: &'a types::Name,
         route_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
-            encode_path(&router_name.to_string()),
-            encode_path(&route_name.to_string()),
-        );
-        let request = self.client.delete(url).build()?;
+        let request = self
+            .client
+            .delete(format!(
+                "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&vpc_name.to_string()),
+                encode_path(&router_name.to_string()),
+                encode_path(&route_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -7241,22 +7488,21 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::VpcSubnetResultsPage>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
-        );
-        let query = [
-            ("limit", limit.map(|v| v.to_string())),
-            ("page_token", page_token.map(|v| v.to_string())),
-            ("sort_by", sort_by.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&vpc_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&[
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -7347,14 +7593,18 @@ impl Client {
         vpc_name: &'a types::Name,
         body: &'a types::VpcSubnetCreate,
     ) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
-        );
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!(
+                "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&vpc_name.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -7381,15 +7631,18 @@ impl Client {
         vpc_name: &'a types::Name,
         subnet_name: &'a types::Name,
     ) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
-            encode_path(&subnet_name.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&vpc_name.to_string()),
+                encode_path(&subnet_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -7417,15 +7670,19 @@ impl Client {
         subnet_name: &'a types::Name,
         body: &'a types::VpcSubnetUpdate,
     ) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
-            encode_path(&subnet_name.to_string()),
-        );
-        let request = self.client.put(url).json(&body).build()?;
+        let request = self
+            .client
+            .put(format!(
+                "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&vpc_name.to_string()),
+                encode_path(&subnet_name.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -7452,15 +7709,18 @@ impl Client {
         vpc_name: &'a types::Name,
         subnet_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
-            encode_path(&subnet_name.to_string()),
-        );
-        let request = self.client.delete(url).build()?;
+        let request = self
+            .client
+            .delete(format!(
+                "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&vpc_name.to_string()),
+                encode_path(&subnet_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -7500,23 +7760,22 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::NetworkInterfaceResultsPage>, Error<types::Error>> {
-        let url = format!(
-            "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}/network-interfaces",
-            self.baseurl,
-            encode_path(&organization_name.to_string()),
-            encode_path(&project_name.to_string()),
-            encode_path(&vpc_name.to_string()),
-            encode_path(&subnet_name.to_string()),
-        );
-        let query = [
-            ("limit", limit.map(|v| v.to_string())),
-            ("page_token", page_token.map(|v| v.to_string())),
-            ("sort_by", sort_by.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}/network-interfaces",
+                self.baseurl,
+                encode_path(&organization_name.to_string()),
+                encode_path(&project_name.to_string()),
+                encode_path(&vpc_name.to_string()),
+                encode_path(&subnet_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&[
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -7606,8 +7865,11 @@ impl Client {
     pub async fn policy_view<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
-        let url = format!("{}/policy", self.baseurl,);
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!("{}/policy", self.baseurl,))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -7629,8 +7891,12 @@ impl Client {
         &'a self,
         body: &'a types::FleetRolePolicy,
     ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
-        let url = format!("{}/policy", self.baseurl,);
-        let request = self.client.put(url).json(&body).build()?;
+        let request = self
+            .client
+            .put(format!("{}/policy", self.baseurl,))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -7658,15 +7924,14 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::RoleResultsPage>, Error<types::Error>> {
-        let url = format!("{}/roles", self.baseurl,);
-        let query = [
-            ("limit", limit.map(|v| v.to_string())),
-            ("page_token", page_token.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!("{}/roles", self.baseurl,))
+            .query::<[(&str, Option<String>)]>(&[
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -7731,12 +7996,15 @@ impl Client {
         &'a self,
         role_name: &'a str,
     ) -> Result<ResponseValue<types::Role>, Error<types::Error>> {
-        let url = format!(
-            "{}/roles/{}",
-            self.baseurl,
-            encode_path(&role_name.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/roles/{}",
+                self.baseurl,
+                encode_path(&role_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -7766,16 +8034,15 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SagaResultsPage>, Error<types::Error>> {
-        let url = format!("{}/sagas", self.baseurl,);
-        let query = [
-            ("limit", limit.map(|v| v.to_string())),
-            ("page_token", page_token.map(|v| v.to_string())),
-            ("sort_by", sort_by.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!("{}/sagas", self.baseurl,))
+            .query::<[(&str, Option<String>)]>(&[
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -7839,12 +8106,15 @@ impl Client {
         &'a self,
         saga_id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Saga>, Error<types::Error>> {
-        let url = format!(
-            "{}/sagas/{}",
-            self.baseurl,
-            encode_path(&saga_id.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/sagas/{}",
+                self.baseurl,
+                encode_path(&saga_id.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -7865,8 +8135,11 @@ impl Client {
     pub async fn session_me<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::User>, Error<types::Error>> {
-        let url = format!("{}/session/me", self.baseurl,);
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!("{}/session/me", self.baseurl,))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -7896,16 +8169,15 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::SshKeyResultsPage>, Error<types::Error>> {
-        let url = format!("{}/session/me/sshkeys", self.baseurl,);
-        let query = [
-            ("limit", limit.map(|v| v.to_string())),
-            ("page_token", page_token.map(|v| v.to_string())),
-            ("sort_by", sort_by.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!("{}/session/me/sshkeys", self.baseurl,))
+            .query::<[(&str, Option<String>)]>(&[
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -7969,8 +8241,12 @@ impl Client {
         &'a self,
         body: &'a types::SshKeyCreate,
     ) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
-        let url = format!("{}/session/me/sshkeys", self.baseurl,);
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!("{}/session/me/sshkeys", self.baseurl,))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -7992,12 +8268,15 @@ impl Client {
         &'a self,
         ssh_key_name: &'a types::Name,
     ) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
-        let url = format!(
-            "{}/session/me/sshkeys/{}",
-            self.baseurl,
-            encode_path(&ssh_key_name.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/session/me/sshkeys/{}",
+                self.baseurl,
+                encode_path(&ssh_key_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -8019,12 +8298,15 @@ impl Client {
         &'a self,
         ssh_key_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
-            "{}/session/me/sshkeys/{}",
-            self.baseurl,
-            encode_path(&ssh_key_name.to_string()),
-        );
-        let request = self.client.delete(url).build()?;
+        let request = self
+            .client
+            .delete(format!(
+                "{}/session/me/sshkeys/{}",
+                self.baseurl,
+                encode_path(&ssh_key_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -8052,16 +8334,15 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::SiloResultsPage>, Error<types::Error>> {
-        let url = format!("{}/silos", self.baseurl,);
-        let query = [
-            ("limit", limit.map(|v| v.to_string())),
-            ("page_token", page_token.map(|v| v.to_string())),
-            ("sort_by", sort_by.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!("{}/silos", self.baseurl,))
+            .query::<[(&str, Option<String>)]>(&[
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -8123,8 +8404,12 @@ impl Client {
         &'a self,
         body: &'a types::SiloCreate,
     ) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-        let url = format!("{}/silos", self.baseurl,);
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!("{}/silos", self.baseurl,))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -8149,12 +8434,15 @@ impl Client {
         &'a self,
         silo_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-        let url = format!(
-            "{}/silos/{}",
-            self.baseurl,
-            encode_path(&silo_name.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/silos/{}",
+                self.baseurl,
+                encode_path(&silo_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -8179,12 +8467,15 @@ impl Client {
         &'a self,
         silo_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
-            "{}/silos/{}",
-            self.baseurl,
-            encode_path(&silo_name.to_string()),
-        );
-        let request = self.client.delete(url).build()?;
+        let request = self
+            .client
+            .delete(format!(
+                "{}/silos/{}",
+                self.baseurl,
+                encode_path(&silo_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -8216,20 +8507,19 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::IdentityProviderResultsPage>, Error<types::Error>> {
-        let url = format!(
-            "{}/silos/{}/identity-providers",
-            self.baseurl,
-            encode_path(&silo_name.to_string()),
-        );
-        let query = [
-            ("limit", limit.map(|v| v.to_string())),
-            ("page_token", page_token.map(|v| v.to_string())),
-            ("sort_by", sort_by.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/silos/{}/identity-providers",
+                self.baseurl,
+                encode_path(&silo_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&[
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -8299,12 +8589,15 @@ impl Client {
         &'a self,
         silo_name: &'a types::Name,
     ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-        let url = format!(
-            "{}/silos/{}/policy",
-            self.baseurl,
-            encode_path(&silo_name.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/silos/{}/policy",
+                self.baseurl,
+                encode_path(&silo_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -8331,12 +8624,16 @@ impl Client {
         silo_name: &'a types::Name,
         body: &'a types::SiloRolePolicy,
     ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-        let url = format!(
-            "{}/silos/{}/policy",
-            self.baseurl,
-            encode_path(&silo_name.to_string()),
-        );
-        let request = self.client.put(url).json(&body).build()?;
+        let request = self
+            .client
+            .put(format!(
+                "{}/silos/{}/policy",
+                self.baseurl,
+                encode_path(&silo_name.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -8363,12 +8660,16 @@ impl Client {
         silo_name: &'a types::Name,
         body: &'a types::SamlIdentityProviderCreate,
     ) -> Result<ResponseValue<types::SamlIdentityProvider>, Error<types::Error>> {
-        let url = format!(
-            "{}/silos/{}/saml-identity-providers",
-            self.baseurl,
-            encode_path(&silo_name.to_string()),
-        );
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!(
+                "{}/silos/{}/saml-identity-providers",
+                self.baseurl,
+                encode_path(&silo_name.to_string()),
+            ))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -8396,13 +8697,16 @@ impl Client {
         silo_name: &'a types::Name,
         provider_name: &'a types::Name,
     ) -> Result<ResponseValue<types::SamlIdentityProvider>, Error<types::Error>> {
-        let url = format!(
-            "{}/silos/{}/saml-identity-providers/{}",
-            self.baseurl,
-            encode_path(&silo_name.to_string()),
-            encode_path(&provider_name.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/silos/{}/saml-identity-providers/{}",
+                self.baseurl,
+                encode_path(&silo_name.to_string()),
+                encode_path(&provider_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -8432,16 +8736,15 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::UserBuiltinResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/user", self.baseurl,);
-        let query = [
-            ("limit", limit.map(|v| v.to_string())),
-            ("page_token", page_token.map(|v| v.to_string())),
-            ("sort_by", sort_by.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!("{}/system/user", self.baseurl,))
+            .query::<[(&str, Option<String>)]>(&[
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -8509,12 +8812,15 @@ impl Client {
         &'a self,
         user_name: &'a types::Name,
     ) -> Result<ResponseValue<types::UserBuiltin>, Error<types::Error>> {
-        let url = format!(
-            "{}/system/user/{}",
-            self.baseurl,
-            encode_path(&user_name.to_string()),
-        );
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/system/user/{}",
+                self.baseurl,
+                encode_path(&user_name.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -8542,15 +8848,14 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::TimeseriesSchemaResultsPage>, Error<types::Error>> {
-        let url = format!("{}/timeseries/schema", self.baseurl,);
-        let query = [
-            ("limit", limit.map(|v| v.to_string())),
-            ("page_token", page_token.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!("{}/timeseries/schema", self.baseurl,))
+            .query::<[(&str, Option<String>)]>(&[
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -8610,8 +8915,11 @@ impl Client {
     ///
     ///Sends a `POST` request to `/updates/refresh`
     pub async fn updates_refresh<'a>(&'a self) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!("{}/updates/refresh", self.baseurl,);
-        let request = self.client.post(url).build()?;
+        let request = self
+            .client
+            .post(format!("{}/updates/refresh", self.baseurl,))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -8641,16 +8949,15 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
-        let url = format!("{}/users", self.baseurl,);
-        let query = [
-            ("limit", limit.map(|v| v.to_string())),
-            ("page_token", page_token.map(|v| v.to_string())),
-            ("sort_by", sort_by.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!("{}/users", self.baseurl,))
+            .query::<[(&str, Option<String>)]>(&[
+                ("limit", limit.map(|v| v.to_string())),
+                ("page_token", page_token.map(|v| v.to_string())),
+                ("sort_by", sort_by.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {

--- a/progenitor-impl/tests/output/nexus-positional.out
+++ b/progenitor-impl/tests/output/nexus-positional.out
@@ -3387,19 +3387,14 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::RackResultsPage>, Error<types::Error>> {
         let url = format!("{}/hardware/racks", self.baseurl,);
-        let mut query = Vec::new();
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
+        let query = [
+            ("limit", limit.map(|v| v.to_string())),
+            ("page_token", page_token.map(|v| v.to_string())),
+            ("sort_by", sort_by.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3503,19 +3498,14 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SledResultsPage>, Error<types::Error>> {
         let url = format!("{}/hardware/sleds", self.baseurl,);
-        let mut query = Vec::new();
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
+        let query = [
+            ("limit", limit.map(|v| v.to_string())),
+            ("page_token", page_token.map(|v| v.to_string())),
+            ("sort_by", sort_by.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3622,19 +3612,14 @@ impl Client {
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::GlobalImageResultsPage>, Error<types::Error>> {
         let url = format!("{}/images", self.baseurl,);
-        let mut query = Vec::new();
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
+        let query = [
+            ("limit", limit.map(|v| v.to_string())),
+            ("page_token", page_token.map(|v| v.to_string())),
+            ("sort_by", sort_by.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3798,19 +3783,14 @@ impl Client {
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::IpPoolResultsPage>, Error<types::Error>> {
         let url = format!("{}/ip-pools", self.baseurl,);
-        let mut query = Vec::new();
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
+        let query = [
+            ("limit", limit.map(|v| v.to_string())),
+            ("page_token", page_token.map(|v| v.to_string())),
+            ("sort_by", sort_by.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -3995,15 +3975,13 @@ impl Client {
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let mut query = Vec::new();
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
+        let query = [
+            ("limit", limit.map(|v| v.to_string())),
+            ("page_token", page_token.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4225,19 +4203,14 @@ impl Client {
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
         let url = format!("{}/organizations", self.baseurl,);
-        let mut query = Vec::new();
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
+        let query = [
+            ("limit", limit.map(|v| v.to_string())),
+            ("page_token", page_token.map(|v| v.to_string())),
+            ("sort_by", sort_by.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4495,19 +4468,14 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let mut query = Vec::new();
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
+        let query = [
+            ("limit", limit.map(|v| v.to_string())),
+            ("page_token", page_token.map(|v| v.to_string())),
+            ("sort_by", sort_by.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4730,19 +4698,14 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut query = Vec::new();
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
+        let query = [
+            ("limit", limit.map(|v| v.to_string())),
+            ("page_token", page_token.map(|v| v.to_string())),
+            ("sort_by", sort_by.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -4948,23 +4911,15 @@ impl Client {
             encode_path(&disk_name.to_string()),
             encode_path(&metric_name.to_string()),
         );
-        let mut query = Vec::new();
-        if let Some(v) = &end_time {
-            query.push(("end_time", v.to_string()));
-        }
-
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &start_time {
-            query.push(("start_time", v.to_string()));
-        }
-
+        let query = [
+            ("end_time", end_time.map(|v| v.to_string())),
+            ("limit", limit.map(|v| v.to_string())),
+            ("page_token", page_token.map(|v| v.to_string())),
+            ("start_time", start_time.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -5081,19 +5036,14 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut query = Vec::new();
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
+        let query = [
+            ("limit", limit.map(|v| v.to_string())),
+            ("page_token", page_token.map(|v| v.to_string())),
+            ("sort_by", sort_by.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -5301,19 +5251,14 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut query = Vec::new();
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
+        let query = [
+            ("limit", limit.map(|v| v.to_string())),
+            ("page_token", page_token.map(|v| v.to_string())),
+            ("sort_by", sort_by.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -5515,19 +5460,14 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut query = Vec::new();
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
+        let query = [
+            ("limit", limit.map(|v| v.to_string())),
+            ("page_token", page_token.map(|v| v.to_string())),
+            ("sort_by", sort_by.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -5768,19 +5708,14 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut query = Vec::new();
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
+        let query = [
+            ("limit", limit.map(|v| v.to_string())),
+            ("page_token", page_token.map(|v| v.to_string())),
+            ("sort_by", sort_by.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6075,19 +6010,14 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut query = Vec::new();
-        if let Some(v) = &from_start {
-            query.push(("from_start", v.to_string()));
-        }
-
-        if let Some(v) = &max_bytes {
-            query.push(("max_bytes", v.to_string()));
-        }
-
-        if let Some(v) = &most_recent {
-            query.push(("most_recent", v.to_string()));
-        }
-
+        let query = [
+            ("from_start", from_start.map(|v| v.to_string())),
+            ("max_bytes", max_bytes.map(|v| v.to_string())),
+            ("most_recent", most_recent.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6265,19 +6195,14 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut query = Vec::new();
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
+        let query = [
+            ("limit", limit.map(|v| v.to_string())),
+            ("page_token", page_token.map(|v| v.to_string())),
+            ("sort_by", sort_by.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6475,19 +6400,14 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut query = Vec::new();
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
+        let query = [
+            ("limit", limit.map(|v| v.to_string())),
+            ("page_token", page_token.map(|v| v.to_string())),
+            ("sort_by", sort_by.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -6789,19 +6709,14 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let mut query = Vec::new();
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
+        let query = [
+            ("limit", limit.map(|v| v.to_string())),
+            ("page_token", page_token.map(|v| v.to_string())),
+            ("sort_by", sort_by.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7054,19 +6969,14 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
-        let mut query = Vec::new();
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
+        let query = [
+            ("limit", limit.map(|v| v.to_string())),
+            ("page_token", page_token.map(|v| v.to_string())),
+            ("sort_by", sort_by.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7329,19 +7239,14 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let mut query = Vec::new();
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
+        let query = [
+            ("limit", limit.map(|v| v.to_string())),
+            ("page_token", page_token.map(|v| v.to_string())),
+            ("sort_by", sort_by.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7594,19 +7499,14 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&subnet_name.to_string()),
         );
-        let mut query = Vec::new();
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
+        let query = [
+            ("limit", limit.map(|v| v.to_string())),
+            ("page_token", page_token.map(|v| v.to_string())),
+            ("sort_by", sort_by.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7750,15 +7650,13 @@ impl Client {
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::RoleResultsPage>, Error<types::Error>> {
         let url = format!("{}/roles", self.baseurl,);
-        let mut query = Vec::new();
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
+        let query = [
+            ("limit", limit.map(|v| v.to_string())),
+            ("page_token", page_token.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7860,19 +7758,14 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SagaResultsPage>, Error<types::Error>> {
         let url = format!("{}/sagas", self.baseurl,);
-        let mut query = Vec::new();
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
+        let query = [
+            ("limit", limit.map(|v| v.to_string())),
+            ("page_token", page_token.map(|v| v.to_string())),
+            ("sort_by", sort_by.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -7995,19 +7888,14 @@ impl Client {
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::SshKeyResultsPage>, Error<types::Error>> {
         let url = format!("{}/session/me/sshkeys", self.baseurl,);
-        let mut query = Vec::new();
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
+        let query = [
+            ("limit", limit.map(|v| v.to_string())),
+            ("page_token", page_token.map(|v| v.to_string())),
+            ("sort_by", sort_by.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8156,19 +8044,14 @@ impl Client {
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::SiloResultsPage>, Error<types::Error>> {
         let url = format!("{}/silos", self.baseurl,);
-        let mut query = Vec::new();
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
+        let query = [
+            ("limit", limit.map(|v| v.to_string())),
+            ("page_token", page_token.map(|v| v.to_string())),
+            ("sort_by", sort_by.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8329,19 +8212,14 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let mut query = Vec::new();
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
+        let query = [
+            ("limit", limit.map(|v| v.to_string())),
+            ("page_token", page_token.map(|v| v.to_string())),
+            ("sort_by", sort_by.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8546,19 +8424,14 @@ impl Client {
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::UserBuiltinResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/user", self.baseurl,);
-        let mut query = Vec::new();
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
+        let query = [
+            ("limit", limit.map(|v| v.to_string())),
+            ("page_token", page_token.map(|v| v.to_string())),
+            ("sort_by", sort_by.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8661,15 +8534,13 @@ impl Client {
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::TimeseriesSchemaResultsPage>, Error<types::Error>> {
         let url = format!("{}/timeseries/schema", self.baseurl,);
-        let mut query = Vec::new();
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
+        let query = [
+            ("limit", limit.map(|v| v.to_string())),
+            ("page_token", page_token.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -8762,19 +8633,14 @@ impl Client {
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
         let url = format!("{}/users", self.baseurl,);
-        let mut query = Vec::new();
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
-        }
-
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
-        }
-
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
-        }
-
+        let query = [
+            ("limit", limit.map(|v| v.to_string())),
+            ("page_token", page_token.map(|v| v.to_string())),
+            ("sort_by", sort_by.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;

--- a/progenitor-impl/tests/output/param-collision-builder-tagged.out
+++ b/progenitor-impl/tests/output/param-collision-builder-tagged.out
@@ -43,18 +43,16 @@ impl Client {
 impl Client {
     ///Gets a key
     ///
-    ///Sends a `GET` request to `/key`
+    ///Sends a `GET` request to `/key/{query}`
     ///
     ///Arguments:
-    /// - `key`: The same key parameter that overlaps with the path level
-    ///   parameter
-    /// - `unique_key`: A key parameter that will not be overridden by the path
-    ///   spec
+    /// - `query`: Parameter name that was previously colliding
+    /// - `url`: Parameter name that was previously colliding
     ///
     ///```ignore
     /// let response = client.key_get()
-    ///    .key(key)
-    ///    .unique_key(unique_key)
+    ///    .query(query)
+    ///    .url(url)
     ///    .send()
     ///    .await;
     /// ```
@@ -73,57 +71,52 @@ pub mod builder {
     #[derive(Debug, Clone)]
     pub struct KeyGet<'a> {
         client: &'a super::Client,
-        key: Result<Option<bool>, String>,
-        unique_key: Result<Option<String>, String>,
+        query: Result<bool, String>,
+        url: Result<bool, String>,
     }
 
     impl<'a> KeyGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                key: Ok(None),
-                unique_key: Ok(None),
+                query: Err("query was not initialized".to_string()),
+                url: Err("url was not initialized".to_string()),
             }
         }
 
-        pub fn key<V>(mut self, value: V) -> Self
+        pub fn query<V>(mut self, value: V) -> Self
         where
             V: std::convert::TryInto<bool>,
         {
-            self.key = value
+            self.query = value
                 .try_into()
-                .map(Some)
-                .map_err(|_| "conversion to `Option < bool >` for key failed".to_string());
+                .map_err(|_| "conversion to `bool` for query failed".to_string());
             self
         }
 
-        pub fn unique_key<V>(mut self, value: V) -> Self
+        pub fn url<V>(mut self, value: V) -> Self
         where
-            V: std::convert::TryInto<String>,
+            V: std::convert::TryInto<bool>,
         {
-            self.unique_key = value
+            self.url = value
                 .try_into()
-                .map(Some)
-                .map_err(|_| "conversion to `Option < String >` for unique_key failed".to_string());
+                .map_err(|_| "conversion to `bool` for url failed".to_string());
             self
         }
 
-        ///Sends a `GET` request to `/key`
+        ///Sends a `GET` request to `/key/{query}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self {
-                client,
-                key,
-                unique_key,
-            } = self;
-            let key = key.map_err(Error::InvalidRequest)?;
-            let unique_key = unique_key.map_err(Error::InvalidRequest)?;
+            let Self { client, query, url } = self;
+            let query = query.map_err(Error::InvalidRequest)?;
+            let url = url.map_err(Error::InvalidRequest)?;
             let request = client
                 .client
-                .get(format!("{}/key", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[
-                    ("key", key.map(|v| v.to_string())),
-                    ("uniqueKey", unique_key.map(|v| v.to_string())),
-                ])
+                .get(format!(
+                    "{}/key/{}",
+                    client.baseurl,
+                    encode_path(&query.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[("url", Some(url.to_string()))])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -136,5 +129,5 @@ pub mod builder {
 }
 
 pub mod prelude {
-    pub use self::super::Client;
+    pub use super::Client;
 }

--- a/progenitor-impl/tests/output/param-collision-builder.out
+++ b/progenitor-impl/tests/output/param-collision-builder.out
@@ -43,18 +43,16 @@ impl Client {
 impl Client {
     ///Gets a key
     ///
-    ///Sends a `GET` request to `/key`
+    ///Sends a `GET` request to `/key/{query}`
     ///
     ///Arguments:
-    /// - `key`: The same key parameter that overlaps with the path level
-    ///   parameter
-    /// - `unique_key`: A key parameter that will not be overridden by the path
-    ///   spec
+    /// - `query`: Parameter name that was previously colliding
+    /// - `url`: Parameter name that was previously colliding
     ///
     ///```ignore
     /// let response = client.key_get()
-    ///    .key(key)
-    ///    .unique_key(unique_key)
+    ///    .query(query)
+    ///    .url(url)
     ///    .send()
     ///    .await;
     /// ```
@@ -73,57 +71,52 @@ pub mod builder {
     #[derive(Debug, Clone)]
     pub struct KeyGet<'a> {
         client: &'a super::Client,
-        key: Result<Option<bool>, String>,
-        unique_key: Result<Option<String>, String>,
+        query: Result<bool, String>,
+        url: Result<bool, String>,
     }
 
     impl<'a> KeyGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client,
-                key: Ok(None),
-                unique_key: Ok(None),
+                query: Err("query was not initialized".to_string()),
+                url: Err("url was not initialized".to_string()),
             }
         }
 
-        pub fn key<V>(mut self, value: V) -> Self
+        pub fn query<V>(mut self, value: V) -> Self
         where
             V: std::convert::TryInto<bool>,
         {
-            self.key = value
+            self.query = value
                 .try_into()
-                .map(Some)
-                .map_err(|_| "conversion to `Option < bool >` for key failed".to_string());
+                .map_err(|_| "conversion to `bool` for query failed".to_string());
             self
         }
 
-        pub fn unique_key<V>(mut self, value: V) -> Self
+        pub fn url<V>(mut self, value: V) -> Self
         where
-            V: std::convert::TryInto<String>,
+            V: std::convert::TryInto<bool>,
         {
-            self.unique_key = value
+            self.url = value
                 .try_into()
-                .map(Some)
-                .map_err(|_| "conversion to `Option < String >` for unique_key failed".to_string());
+                .map_err(|_| "conversion to `bool` for url failed".to_string());
             self
         }
 
-        ///Sends a `GET` request to `/key`
+        ///Sends a `GET` request to `/key/{query}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self {
-                client,
-                key,
-                unique_key,
-            } = self;
-            let key = key.map_err(Error::InvalidRequest)?;
-            let unique_key = unique_key.map_err(Error::InvalidRequest)?;
+            let Self { client, query, url } = self;
+            let query = query.map_err(Error::InvalidRequest)?;
+            let url = url.map_err(Error::InvalidRequest)?;
             let request = client
                 .client
-                .get(format!("{}/key", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[
-                    ("key", key.map(|v| v.to_string())),
-                    ("uniqueKey", unique_key.map(|v| v.to_string())),
-                ])
+                .get(format!(
+                    "{}/key/{}",
+                    client.baseurl,
+                    encode_path(&query.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&[("url", Some(url.to_string()))])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/param-collision-positional.out
+++ b/progenitor-impl/tests/output/param-collision-positional.out
@@ -5,14 +5,6 @@ pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
     use std::convert::TryFrom;
-    ///Error information from a response.
-    #[derive(Clone, Debug, Deserialize, Serialize)]
-    pub struct Error {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub error_code: Option<String>,
-        pub message: String,
-        pub request_id: String,
-    }
 }
 
 #[derive(Clone, Debug)]
@@ -49,20 +41,32 @@ impl Client {
 }
 
 impl Client {
-    ///Sends a `GET` request to `/`
-    pub async fn freeform_response<'a>(
+    ///Gets a key
+    ///
+    ///Sends a `GET` request to `/key/{query}`
+    ///
+    ///Arguments:
+    /// - `query`: Parameter name that was previously colliding
+    /// - `url`: Parameter name that was previously colliding
+    pub async fn key_get<'a>(
         &'a self,
-    ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
+        query: bool,
+        url: bool,
+    ) -> Result<ResponseValue<()>, Error<()>> {
         let request = self
             .client
-            .get(format!("{}/", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .get(format!(
+                "{}/key/{}",
+                self.baseurl,
+                encode_path(&query.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&[("url", Some(url.to_string()))])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
-            200..=299 => Ok(ResponseValue::stream(response)),
-            _ => Err(Error::ErrorResponse(ResponseValue::stream(response))),
+            200u16 => Ok(ResponseValue::empty(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 }

--- a/progenitor-impl/tests/output/param-overrides-builder-tagged.out
+++ b/progenitor-impl/tests/output/param-overrides-builder-tagged.out
@@ -118,13 +118,13 @@ pub mod builder {
             let key = key.map_err(Error::InvalidRequest)?;
             let unique_key = unique_key.map_err(Error::InvalidRequest)?;
             let url = format!("{}/key", client.baseurl,);
-            let mut query = Vec::new();
-            if let Some(v) = &key {
-                query.push(("key", v.to_string()));
-            }
-            if let Some(v) = &unique_key {
-                query.push(("uniqueKey", v.to_string()));
-            }
+            let query = [
+                ("key", key.map(|v| v.to_string())),
+                ("uniqueKey", unique_key.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/param-overrides-builder-tagged.out
+++ b/progenitor-impl/tests/output/param-overrides-builder-tagged.out
@@ -117,15 +117,14 @@ pub mod builder {
             } = self;
             let key = key.map_err(Error::InvalidRequest)?;
             let unique_key = unique_key.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/key", client.baseurl,);
-            let query = [
-                ("key", key.map(|v| v.to_string())),
-                ("uniqueKey", unique_key.map(|v| v.to_string())),
-            ]
-            .into_iter()
-            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-            .collect::<Vec<_>>();
-            let request = client.client.get(url).query(&query).build()?;
+            let request = client
+                .client
+                .get(format!("{}/key", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&[
+                    ("key", key.map(|v| v.to_string())),
+                    ("uniqueKey", unique_key.map(|v| v.to_string())),
+                ])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {

--- a/progenitor-impl/tests/output/param-overrides-builder.out
+++ b/progenitor-impl/tests/output/param-overrides-builder.out
@@ -118,13 +118,13 @@ pub mod builder {
             let key = key.map_err(Error::InvalidRequest)?;
             let unique_key = unique_key.map_err(Error::InvalidRequest)?;
             let url = format!("{}/key", client.baseurl,);
-            let mut query = Vec::new();
-            if let Some(v) = &key {
-                query.push(("key", v.to_string()));
-            }
-            if let Some(v) = &unique_key {
-                query.push(("uniqueKey", v.to_string()));
-            }
+            let query = [
+                ("key", key.map(|v| v.to_string())),
+                ("uniqueKey", unique_key.map(|v| v.to_string())),
+            ]
+            .into_iter()
+            .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+            .collect::<Vec<_>>();
             let request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/param-overrides-positional.out
+++ b/progenitor-impl/tests/output/param-overrides-positional.out
@@ -56,15 +56,13 @@ impl Client {
         unique_key: Option<&'a str>,
     ) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/key", self.baseurl,);
-        let mut query = Vec::new();
-        if let Some(v) = &key {
-            query.push(("key", v.to_string()));
-        }
-
-        if let Some(v) = &unique_key {
-            query.push(("uniqueKey", v.to_string()));
-        }
-
+        let query = [
+            ("key", key.map(|v| v.to_string())),
+            ("uniqueKey", unique_key.map(|v| v.to_string())),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;

--- a/progenitor-impl/tests/output/param-overrides-positional.out
+++ b/progenitor-impl/tests/output/param-overrides-positional.out
@@ -55,15 +55,14 @@ impl Client {
         key: Option<bool>,
         unique_key: Option<&'a str>,
     ) -> Result<ResponseValue<()>, Error<()>> {
-        let url = format!("{}/key", self.baseurl,);
-        let query = [
-            ("key", key.map(|v| v.to_string())),
-            ("uniqueKey", unique_key.map(|v| v.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!("{}/key", self.baseurl,))
+            .query::<[(&str, Option<String>)]>(&[
+                ("key", key.map(|v| v.to_string())),
+                ("uniqueKey", unique_key.map(|v| v.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {

--- a/progenitor-impl/tests/output/propolis-server-builder-tagged.out
+++ b/progenitor-impl/tests/output/propolis-server-builder-tagged.out
@@ -1634,8 +1634,11 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/instance", client.baseurl,);
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!("{}/instance", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1684,8 +1687,12 @@ pub mod builder {
         ) -> Result<ResponseValue<types::InstanceEnsureResponse>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/instance", client.baseurl,);
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!("{}/instance", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1750,13 +1757,16 @@ pub mod builder {
             } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let snapshot_id = snapshot_id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/instance/disk/{}/snapshot/{}",
-                client.baseurl,
-                encode_path(&id.to_string()),
-                encode_path(&snapshot_id.to_string()),
-            );
-            let request = client.client.post(url).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/instance/disk/{}/snapshot/{}",
+                    client.baseurl,
+                    encode_path(&id.to_string()),
+                    encode_path(&snapshot_id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1806,8 +1816,12 @@ pub mod builder {
         {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/instance/migrate/status", client.baseurl,);
-            let request = client.client.get(url).json(&body).build()?;
+            let request = client
+                .client
+                .get(format!("{}/instance/migrate/status", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1841,10 +1855,10 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
             let Self { client } = self;
-            let url = format!("{}/instance/serial", client.baseurl,);
             let request = client
                 .client
-                .get(url)
+                .get(format!("{}/instance/serial", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
                 .header(reqwest::header::CONNECTION, "Upgrade")
                 .header(reqwest::header::UPGRADE, "websocket")
                 .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -1894,8 +1908,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/instance/state", client.baseurl,);
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!("{}/instance/state", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1945,8 +1963,12 @@ pub mod builder {
         {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/instance/state-monitor", client.baseurl,);
-            let request = client.client.get(url).json(&body).build()?;
+            let request = client
+                .client
+                .get(format!("{}/instance/state-monitor", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {

--- a/progenitor-impl/tests/output/propolis-server-builder-tagged.out
+++ b/progenitor-impl/tests/output/propolis-server-builder-tagged.out
@@ -1637,7 +1637,6 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/instance", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1691,7 +1690,6 @@ pub mod builder {
                 .client
                 .put(format!("{}/instance", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1765,7 +1763,6 @@ pub mod builder {
                     encode_path(&id.to_string()),
                     encode_path(&snapshot_id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1820,7 +1817,6 @@ pub mod builder {
                 .client
                 .get(format!("{}/instance/migrate/status", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1858,7 +1854,6 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/instance/serial", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .header(reqwest::header::CONNECTION, "Upgrade")
                 .header(reqwest::header::UPGRADE, "websocket")
                 .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -1912,7 +1907,6 @@ pub mod builder {
                 .client
                 .put(format!("{}/instance/state", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1967,7 +1961,6 @@ pub mod builder {
                 .client
                 .get(format!("{}/instance/state-monitor", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/propolis-server-builder-tagged.out
+++ b/progenitor-impl/tests/output/propolis-server-builder-tagged.out
@@ -1637,7 +1637,7 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/instance", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1691,7 +1691,7 @@ pub mod builder {
                 .client
                 .put(format!("{}/instance", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1765,7 +1765,7 @@ pub mod builder {
                     encode_path(&id.to_string()),
                     encode_path(&snapshot_id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1820,7 +1820,7 @@ pub mod builder {
                 .client
                 .get(format!("{}/instance/migrate/status", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1858,7 +1858,7 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/instance/serial", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .header(reqwest::header::CONNECTION, "Upgrade")
                 .header(reqwest::header::UPGRADE, "websocket")
                 .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -1912,7 +1912,7 @@ pub mod builder {
                 .client
                 .put(format!("{}/instance/state", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1967,7 +1967,7 @@ pub mod builder {
                 .client
                 .get(format!("{}/instance/state-monitor", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/propolis-server-builder.out
+++ b/progenitor-impl/tests/output/propolis-server-builder.out
@@ -1643,7 +1643,6 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/instance", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1697,7 +1696,6 @@ pub mod builder {
                 .client
                 .put(format!("{}/instance", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1771,7 +1769,6 @@ pub mod builder {
                     encode_path(&id.to_string()),
                     encode_path(&snapshot_id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1826,7 +1823,6 @@ pub mod builder {
                 .client
                 .get(format!("{}/instance/migrate/status", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1864,7 +1860,6 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/instance/serial", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&[])
                 .header(reqwest::header::CONNECTION, "Upgrade")
                 .header(reqwest::header::UPGRADE, "websocket")
                 .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -1918,7 +1913,6 @@ pub mod builder {
                 .client
                 .put(format!("{}/instance/state", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1973,7 +1967,6 @@ pub mod builder {
                 .client
                 .get(format!("{}/instance/state-monitor", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/propolis-server-builder.out
+++ b/progenitor-impl/tests/output/propolis-server-builder.out
@@ -1640,8 +1640,11 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/instance", client.baseurl,);
-            let request = client.client.get(url).build()?;
+            let request = client
+                .client
+                .get(format!("{}/instance", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1690,8 +1693,12 @@ pub mod builder {
         ) -> Result<ResponseValue<types::InstanceEnsureResponse>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/instance", client.baseurl,);
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!("{}/instance", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1756,13 +1763,16 @@ pub mod builder {
             } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let snapshot_id = snapshot_id.map_err(Error::InvalidRequest)?;
-            let url = format!(
-                "{}/instance/disk/{}/snapshot/{}",
-                client.baseurl,
-                encode_path(&id.to_string()),
-                encode_path(&snapshot_id.to_string()),
-            );
-            let request = client.client.post(url).build()?;
+            let request = client
+                .client
+                .post(format!(
+                    "{}/instance/disk/{}/snapshot/{}",
+                    client.baseurl,
+                    encode_path(&id.to_string()),
+                    encode_path(&snapshot_id.to_string()),
+                ))
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1812,8 +1822,12 @@ pub mod builder {
         {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/instance/migrate/status", client.baseurl,);
-            let request = client.client.get(url).json(&body).build()?;
+            let request = client
+                .client
+                .get(format!("{}/instance/migrate/status", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1847,10 +1861,10 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
             let Self { client } = self;
-            let url = format!("{}/instance/serial", client.baseurl,);
             let request = client
                 .client
-                .get(url)
+                .get(format!("{}/instance/serial", client.baseurl,))
+                .query::<[(&str, Option<String>)]>(&vec![])
                 .header(reqwest::header::CONNECTION, "Upgrade")
                 .header(reqwest::header::UPGRADE, "websocket")
                 .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -1900,8 +1914,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/instance/state", client.baseurl,);
-            let request = client.client.put(url).json(&body).build()?;
+            let request = client
+                .client
+                .put(format!("{}/instance/state", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -1951,8 +1969,12 @@ pub mod builder {
         {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/instance/state-monitor", client.baseurl,);
-            let request = client.client.get(url).json(&body).build()?;
+            let request = client
+                .client
+                .get(format!("{}/instance/state-monitor", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {

--- a/progenitor-impl/tests/output/propolis-server-builder.out
+++ b/progenitor-impl/tests/output/propolis-server-builder.out
@@ -1643,7 +1643,7 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/instance", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1697,7 +1697,7 @@ pub mod builder {
                 .client
                 .put(format!("{}/instance", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1771,7 +1771,7 @@ pub mod builder {
                     encode_path(&id.to_string()),
                     encode_path(&snapshot_id.to_string()),
                 ))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1826,7 +1826,7 @@ pub mod builder {
                 .client
                 .get(format!("{}/instance/migrate/status", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1864,7 +1864,7 @@ pub mod builder {
             let request = client
                 .client
                 .get(format!("{}/instance/serial", client.baseurl,))
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .header(reqwest::header::CONNECTION, "Upgrade")
                 .header(reqwest::header::UPGRADE, "websocket")
                 .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -1918,7 +1918,7 @@ pub mod builder {
                 .client
                 .put(format!("{}/instance/state", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
@@ -1973,7 +1973,7 @@ pub mod builder {
                 .client
                 .get(format!("{}/instance/state-monitor", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/propolis-server-positional.out
+++ b/progenitor-impl/tests/output/propolis-server-positional.out
@@ -378,7 +378,7 @@ impl Client {
         let request = self
             .client
             .get(format!("{}/instance", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -403,7 +403,7 @@ impl Client {
             .client
             .put(format!("{}/instance", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -435,7 +435,7 @@ impl Client {
                 encode_path(&id.to_string()),
                 encode_path(&snapshot_id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -460,7 +460,7 @@ impl Client {
             .client
             .get(format!("{}/instance/migrate/status", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -483,7 +483,7 @@ impl Client {
         let request = self
             .client
             .get(format!("{}/instance/serial", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .header(reqwest::header::CONNECTION, "Upgrade")
             .header(reqwest::header::UPGRADE, "websocket")
             .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -510,7 +510,7 @@ impl Client {
             .client
             .put(format!("{}/instance/state", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -535,7 +535,7 @@ impl Client {
             .client
             .get(format!("{}/instance/state-monitor", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;

--- a/progenitor-impl/tests/output/propolis-server-positional.out
+++ b/progenitor-impl/tests/output/propolis-server-positional.out
@@ -375,8 +375,11 @@ impl Client {
     pub async fn instance_get<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
-        let url = format!("{}/instance", self.baseurl,);
-        let request = self.client.get(url).build()?;
+        let request = self
+            .client
+            .get(format!("{}/instance", self.baseurl,))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -396,8 +399,12 @@ impl Client {
         &'a self,
         body: &'a types::InstanceEnsureRequest,
     ) -> Result<ResponseValue<types::InstanceEnsureResponse>, Error<types::Error>> {
-        let url = format!("{}/instance", self.baseurl,);
-        let request = self.client.put(url).json(&body).build()?;
+        let request = self
+            .client
+            .put(format!("{}/instance", self.baseurl,))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -420,13 +427,16 @@ impl Client {
         id: &'a uuid::Uuid,
         snapshot_id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
-            "{}/instance/disk/{}/snapshot/{}",
-            self.baseurl,
-            encode_path(&id.to_string()),
-            encode_path(&snapshot_id.to_string()),
-        );
-        let request = self.client.post(url).build()?;
+        let request = self
+            .client
+            .post(format!(
+                "{}/instance/disk/{}/snapshot/{}",
+                self.baseurl,
+                encode_path(&id.to_string()),
+                encode_path(&snapshot_id.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -446,8 +456,12 @@ impl Client {
         &'a self,
         body: &'a types::InstanceMigrateStatusRequest,
     ) -> Result<ResponseValue<types::InstanceMigrateStatusResponse>, Error<types::Error>> {
-        let url = format!("{}/instance/migrate/status", self.baseurl,);
-        let request = self.client.get(url).json(&body).build()?;
+        let request = self
+            .client
+            .get(format!("{}/instance/migrate/status", self.baseurl,))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -466,10 +480,10 @@ impl Client {
     pub async fn instance_serial<'a>(
         &'a self,
     ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
-        let url = format!("{}/instance/serial", self.baseurl,);
         let request = self
             .client
-            .get(url)
+            .get(format!("{}/instance/serial", self.baseurl,))
+            .query::<[(&str, Option<String>)]>(&vec![])
             .header(reqwest::header::CONNECTION, "Upgrade")
             .header(reqwest::header::UPGRADE, "websocket")
             .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -492,8 +506,12 @@ impl Client {
         &'a self,
         body: types::InstanceStateRequested,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!("{}/instance/state", self.baseurl,);
-        let request = self.client.put(url).json(&body).build()?;
+        let request = self
+            .client
+            .put(format!("{}/instance/state", self.baseurl,))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -513,8 +531,12 @@ impl Client {
         &'a self,
         body: &'a types::InstanceStateMonitorRequest,
     ) -> Result<ResponseValue<types::InstanceStateMonitorResponse>, Error<types::Error>> {
-        let url = format!("{}/instance/state-monitor", self.baseurl,);
-        let request = self.client.get(url).json(&body).build()?;
+        let request = self
+            .client
+            .get(format!("{}/instance/state-monitor", self.baseurl,))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {

--- a/progenitor-impl/tests/output/propolis-server-positional.out
+++ b/progenitor-impl/tests/output/propolis-server-positional.out
@@ -378,7 +378,6 @@ impl Client {
         let request = self
             .client
             .get(format!("{}/instance", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -403,7 +402,6 @@ impl Client {
             .client
             .put(format!("{}/instance", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -435,7 +433,6 @@ impl Client {
                 encode_path(&id.to_string()),
                 encode_path(&snapshot_id.to_string()),
             ))
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -460,7 +457,6 @@ impl Client {
             .client
             .get(format!("{}/instance/migrate/status", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -483,7 +479,6 @@ impl Client {
         let request = self
             .client
             .get(format!("{}/instance/serial", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&[])
             .header(reqwest::header::CONNECTION, "Upgrade")
             .header(reqwest::header::UPGRADE, "websocket")
             .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -510,7 +505,6 @@ impl Client {
             .client
             .put(format!("{}/instance/state", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
@@ -535,7 +529,6 @@ impl Client {
             .client
             .get(format!("{}/instance/state-monitor", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;

--- a/progenitor-impl/tests/output/test_default_params_builder.out
+++ b/progenitor-impl/tests/output/test_default_params_builder.out
@@ -272,7 +272,6 @@ pub mod builder {
                 .client
                 .post(format!("{}/", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/test_default_params_builder.out
+++ b/progenitor-impl/tests/output/test_default_params_builder.out
@@ -268,8 +268,12 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            let request = client
+                .client
+                .post(format!("{}/", client.baseurl,))
+                .json(&body)
+                .query::<[(&str, Option<String>)]>(&vec![])
+                .build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {

--- a/progenitor-impl/tests/output/test_default_params_builder.out
+++ b/progenitor-impl/tests/output/test_default_params_builder.out
@@ -272,7 +272,7 @@ pub mod builder {
                 .client
                 .post(format!("{}/", client.baseurl,))
                 .json(&body)
-                .query::<[(&str, Option<String>)]>(&vec![])
+                .query::<[(&str, Option<String>)]>(&[])
                 .build()?;
             let result = client.client.execute(request).await;
             let response = result?;

--- a/progenitor-impl/tests/output/test_default_params_positional.out
+++ b/progenitor-impl/tests/output/test_default_params_positional.out
@@ -83,7 +83,7 @@ impl Client {
             .client
             .post(format!("{}/", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;

--- a/progenitor-impl/tests/output/test_default_params_positional.out
+++ b/progenitor-impl/tests/output/test_default_params_positional.out
@@ -79,8 +79,12 @@ impl Client {
         &'a self,
         body: &'a types::BodyWithDefaults,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-        let url = format!("{}/", self.baseurl,);
-        let request = self.client.post(url).json(&body).build()?;
+        let request = self
+            .client
+            .post(format!("{}/", self.baseurl,))
+            .json(&body)
+            .query::<[(&str, Option<String>)]>(&vec![])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {

--- a/progenitor-impl/tests/output/test_default_params_positional.out
+++ b/progenitor-impl/tests/output/test_default_params_positional.out
@@ -83,7 +83,6 @@ impl Client {
             .client
             .post(format!("{}/", self.baseurl,))
             .json(&body)
-            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;

--- a/progenitor-impl/tests/output/test_freeform_response.out
+++ b/progenitor-impl/tests/output/test_freeform_response.out
@@ -56,7 +56,7 @@ impl Client {
         let request = self
             .client
             .get(format!("{}/", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&vec![])
+            .query::<[(&str, Option<String>)]>(&[])
             .build()?;
         let result = self.client.execute(request).await;
         let response = result?;

--- a/progenitor-impl/tests/output/test_freeform_response.out
+++ b/progenitor-impl/tests/output/test_freeform_response.out
@@ -53,11 +53,7 @@ impl Client {
     pub async fn freeform_response<'a>(
         &'a self,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-        let request = self
-            .client
-            .get(format!("{}/", self.baseurl,))
-            .query::<[(&str, Option<String>)]>(&[])
-            .build()?;
+        let request = self.client.get(format!("{}/", self.baseurl,)).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {

--- a/progenitor-impl/tests/output/test_renamed_parameters.out
+++ b/progenitor-impl/tests/output/test_renamed_parameters.out
@@ -67,9 +67,9 @@ impl Client {
             encode_path(&trait_.to_string()),
         );
         let query = [
-            ("if", if_.to_string()),
-            ("in", in_.to_string()),
-            ("use", use_.to_string()),
+            ("if", Some(if_.to_string())),
+            ("in", Some(in_.to_string())),
+            ("use", Some(use_.to_string())),
         ]
         .into_iter()
         .filter_map(|(name, arg)| arg.map(|value| (name, value)))

--- a/progenitor-impl/tests/output/test_renamed_parameters.out
+++ b/progenitor-impl/tests/output/test_renamed_parameters.out
@@ -59,22 +59,21 @@ impl Client {
         in_: &'a str,
         use_: &'a str,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
-            "{}/{}/{}/{}",
-            self.baseurl,
-            encode_path(&ref_.to_string()),
-            encode_path(&type_.to_string()),
-            encode_path(&trait_.to_string()),
-        );
-        let query = [
-            ("if", Some(if_.to_string())),
-            ("in", Some(in_.to_string())),
-            ("use", Some(use_.to_string())),
-        ]
-        .into_iter()
-        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
-        .collect::<Vec<_>>();
-        let request = self.client.get(url).query(&query).build()?;
+        let request = self
+            .client
+            .get(format!(
+                "{}/{}/{}/{}",
+                self.baseurl,
+                encode_path(&ref_.to_string()),
+                encode_path(&type_.to_string()),
+                encode_path(&trait_.to_string()),
+            ))
+            .query::<[(&str, Option<String>)]>(&[
+                ("if", Some(if_.to_string())),
+                ("in", Some(in_.to_string())),
+                ("use", Some(use_.to_string())),
+            ])
+            .build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {

--- a/progenitor-impl/tests/output/test_renamed_parameters.out
+++ b/progenitor-impl/tests/output/test_renamed_parameters.out
@@ -66,10 +66,14 @@ impl Client {
             encode_path(&type_.to_string()),
             encode_path(&trait_.to_string()),
         );
-        let mut query = Vec::new();
-        query.push(("if", if_.to_string()));
-        query.push(("in", in_.to_string()));
-        query.push(("use", use_.to_string()));
+        let query = [
+            ("if", if_.to_string()),
+            ("in", in_.to_string()),
+            ("use", use_.to_string()),
+        ]
+        .into_iter()
+        .filter_map(|(name, arg)| arg.map(|value| (name, value)))
+        .collect::<Vec<_>>();
         let request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;

--- a/progenitor-impl/tests/test_output.rs
+++ b/progenitor-impl/tests/test_output.rs
@@ -71,6 +71,11 @@ fn test_param_override() {
     verify_apis("param-overrides");
 }
 
+#[test]
+fn test_query_collision_override() {
+    verify_apis("param-collision");
+}
+
 // TODO this file is full of inconsistencies and incorrectly specified types.
 // It's an interesting test to consider whether we try to do our best to
 // interpret the intent or just fail.

--- a/sample_openapi/param-collision.json
+++ b/sample_openapi/param-collision.json
@@ -1,0 +1,42 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "description": "Minimal API for testing collision between parameter names and generated code",
+    "title": "Parameter name collision test",
+    "version": "v1"
+  },
+  "paths": {
+    "/key/{query}": {
+      "get": {
+        "description": "Gets a key",
+        "operationId": "key.get",
+        "parameters": [
+          {
+            "description": "Parameter name that was previously colliding",
+            "in": "path",
+            "name": "query",
+            "required": true,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Parameter name that was previously colliding",
+            "in": "query",
+            "name": "url",
+            "required": true,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "type": "string",
+            "description": "Successful response"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
If an API spec has a query parameter name `query`, then the generated operation will contain a block that looks like:

**Positional**
```rust
pub async fn operation_method<'a>(
    &'a self,
    query: Option<&'a str>,
) -> Result<ResponseValue<types::ResponseType>, Error<()>> {
    let url = format!(
        "{}/path/to/method",
        self.baseurl,
    );
    let mut query = Vec::new();
    if let Some(v) = &query {
        query.push(("query", v.to_string()));
    }
    // ...
    let request = self.client.get(url).query(&query).build()?;
    // ..
}
```

**Builder**
```rust
pub async fn send(self) -> Result<ResponseValue<types::ResponseType>, Error<()>> {
    let Self {
        client,
        query,
    } = self;
    let query = query.map_err(Error::InvalidRequest)?;
    let url = format!(
        "{}/path/to/method",
        client.baseurl,
    );
    let mut query = Vec::new();
    if let Some(v) = &query {
        query.push(("query", v.to_string()));
    }
    // ...
    let request = client.client.get(url).query(&query).build()?;
    // ...
}
```

This PR initially is here to highlight the collision. I have a different idea for how to resolve it that I will push shortly.