### PR TITLE
Add support for wasm

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,3 +60,29 @@ jobs:
       run: cargo build --locked --tests --verbose
     - name: Run tests
       run: cargo test --locked --verbose
+
+  test-wasm:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install nightly
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        components: rustfmt
+        default: false
+        target: wasm32-unknown-unknown
+    - uses: nanasess/setup-chromedriver@v1
+    - name: Install stable
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        components: rustfmt
+        default: true
+        target: wasm32-unknown-unknown
+    - name: Install wasm-bindgen-cli
+      run: cargo install --version 0.2.84 wasm-bindgen-cli
+    - name: Run tests
+      run: |
+        cd example-wasm
+        CHROMEDRIVER=$(which chromedriver) cargo test --target wasm32-unknown-unknown --locked --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +457,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "example-wasm"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "chrono",
+ "progenitor",
+ "progenitor-client",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "uuid",
+ "wasm-bindgen-test",
+]
+
+[[package]]
 name = "expectorate"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,8 +636,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -867,9 +894,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.59"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1513,6 +1540,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -2212,6 +2245,7 @@ checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
  "getrandom",
  "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2261,9 +2295,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.82"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2271,9 +2305,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.82"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
@@ -2286,9 +2320,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.28"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2298,9 +2332,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.82"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2308,9 +2342,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.82"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2321,9 +2355,33 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.82"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db36fc0f9fb209e88fb3642590ae0205bb5a56216dabd963ba15879fe53a30b"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0734759ae6b3b1717d661fe4f016efcfb9828f5edb4520c18eaee05af3b43be9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "wasm-streams"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
 	"example-build",
 	"example-macro",
+	"example-wasm",
 	"progenitor",
 	"progenitor-client",
 	"progenitor-impl",

--- a/example-wasm/.cargo/config
+++ b/example-wasm/.cargo/config
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+runner = 'wasm-bindgen-test-runner'

--- a/example-wasm/Cargo.toml
+++ b/example-wasm/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "example-wasm"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+chrono = { version = "0.4", features = ["serde"] }
+progenitor-client = { path = "../progenitor-client" }
+reqwest = { version = "0.11.16", features = ["json", "stream"] }
+base64 = "0.21"
+serde = { version = "1.0", features = ["derive"] }
+uuid = { version = "1.3", features = ["serde", "v4", "js"] }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3.34"
+
+[build-dependencies]
+progenitor = { path = "../progenitor" }
+serde_json = "1.0"

--- a/example-wasm/build.rs
+++ b/example-wasm/build.rs
@@ -1,0 +1,22 @@
+// Copyright 2022 Oxide Computer Company
+
+use std::{
+    env,
+    fs::{self, File},
+    path::Path,
+};
+
+fn main() {
+    let src = "../sample_openapi/keeper.json";
+    println!("cargo:rerun-if-changed={}", src);
+    let file = File::open(src).unwrap();
+    let spec = serde_json::from_reader(file).unwrap();
+    let mut generator = progenitor::Generator::default();
+
+    let content = generator.generate_text(&spec).unwrap();
+
+    let mut out_file = Path::new(&env::var("OUT_DIR").unwrap()).to_path_buf();
+    out_file.push("codegen.rs");
+
+    fs::write(out_file, content).unwrap();
+}

--- a/example-wasm/release.toml
+++ b/example-wasm/release.toml
@@ -1,0 +1,1 @@
+release = false

--- a/example-wasm/src/main.rs
+++ b/example-wasm/src/main.rs
@@ -1,0 +1,15 @@
+// Copyright 2021 Oxide Computer Company
+
+// Include the generated code.
+include!(concat!(env!("OUT_DIR"), "/codegen.rs"));
+
+fn main() {
+    let client = Client::new("https://foo/bar");
+    let _ = client.enrol(
+        "auth-token",
+        &types::EnrolBody {
+            host: "".to_string(),
+            key: "".to_string(),
+        },
+    );
+}

--- a/example-wasm/tests/client.rs
+++ b/example-wasm/tests/client.rs
@@ -1,0 +1,11 @@
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+include!(concat!(env!("OUT_DIR"), "/codegen.rs"));
+
+#[wasm_bindgen_test]
+fn test_client_new() {
+    let client = Client::new("http://foo/bar");
+    assert!(client.baseurl == "http://foo/bar");
+}

--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -11,8 +11,13 @@ use futures_core::Stream;
 use reqwest::RequestBuilder;
 use serde::{de::DeserializeOwned, Serialize};
 
+#[cfg(not(target_arch = "wasm32"))]
 type InnerByteStream =
     std::pin::Pin<Box<dyn Stream<Item = reqwest::Result<Bytes>> + Send + Sync>>;
+
+#[cfg(target_arch = "wasm32")]
+type InnerByteStream =
+    std::pin::Pin<Box<dyn Stream<Item = reqwest::Result<Bytes>>>>;
 
 /// Untyped byte stream used for both success and error responses.
 pub struct ByteStream(InnerByteStream);
@@ -76,6 +81,7 @@ impl<T: DeserializeOwned> ResponseValue<T> {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl ResponseValue<reqwest::Upgraded> {
     #[doc(hidden)]
     pub async fn upgrade<E: std::fmt::Debug>(

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -345,13 +345,18 @@ impl Generator {
                     baseurl: &str,
                     #inner_parameter
                 ) -> Self {
-                    let dur = std::time::Duration::from_secs(15);
-                    let client = reqwest::ClientBuilder::new()
-                        .connect_timeout(dur)
-                        .timeout(dur)
-                        .build()
-                        .unwrap();
-                    Self::new_with_client(baseurl, client, #inner_value)
+                    #[cfg(not(target_arch = "wasm32"))]
+                    let client = {
+                        let dur = std::time::Duration::from_secs(15);
+
+                        reqwest::ClientBuilder::new()
+                            .connect_timeout(dur)
+                            .timeout(dur)
+                    };
+                    #[cfg(target_arch = "wasm32")]
+                    let client = reqwest::ClientBuilder::new();
+
+                    Self::new_with_client(baseurl, client.build().unwrap(), #inner_value)
                 }
 
                 /// Construct a new client with an existing `reqwest::Client`,

--- a/progenitor-impl/tests/output/buildomat-builder-tagged.out
+++ b/progenitor-impl/tests/output/buildomat-builder-tagged.out
@@ -1591,13 +1591,16 @@ impl Client {
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
-        let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
-        Self::new_with_client(baseurl, client)
+        #[cfg(not(target_arch = "wasm32"))]
+        let client = {
+            let dur = std::time::Duration::from_secs(15);
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+        };
+        #[cfg(target_arch = "wasm32")]
+        let client = reqwest::ClientBuilder::new();
+        Self::new_with_client(baseurl, client.build().unwrap())
     }
 
     /// Construct a new client with an existing `reqwest::Client`,

--- a/progenitor-impl/tests/output/buildomat-builder.out
+++ b/progenitor-impl/tests/output/buildomat-builder.out
@@ -1591,13 +1591,16 @@ impl Client {
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
-        let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
-        Self::new_with_client(baseurl, client)
+        #[cfg(not(target_arch = "wasm32"))]
+        let client = {
+            let dur = std::time::Duration::from_secs(15);
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+        };
+        #[cfg(target_arch = "wasm32")]
+        let client = reqwest::ClientBuilder::new();
+        Self::new_with_client(baseurl, client.build().unwrap())
     }
 
     /// Construct a new client with an existing `reqwest::Client`,

--- a/progenitor-impl/tests/output/buildomat-positional.out
+++ b/progenitor-impl/tests/output/buildomat-positional.out
@@ -266,13 +266,16 @@ impl Client {
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
-        let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
-        Self::new_with_client(baseurl, client)
+        #[cfg(not(target_arch = "wasm32"))]
+        let client = {
+            let dur = std::time::Duration::from_secs(15);
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+        };
+        #[cfg(target_arch = "wasm32")]
+        let client = reqwest::ClientBuilder::new();
+        Self::new_with_client(baseurl, client.build().unwrap())
     }
 
     /// Construct a new client with an existing `reqwest::Client`,

--- a/progenitor-impl/tests/output/keeper-builder-tagged.out
+++ b/progenitor-impl/tests/output/keeper-builder-tagged.out
@@ -916,13 +916,16 @@ impl Client {
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
-        let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
-        Self::new_with_client(baseurl, client)
+        #[cfg(not(target_arch = "wasm32"))]
+        let client = {
+            let dur = std::time::Duration::from_secs(15);
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+        };
+        #[cfg(target_arch = "wasm32")]
+        let client = reqwest::ClientBuilder::new();
+        Self::new_with_client(baseurl, client.build().unwrap())
     }
 
     /// Construct a new client with an existing `reqwest::Client`,

--- a/progenitor-impl/tests/output/keeper-builder.out
+++ b/progenitor-impl/tests/output/keeper-builder.out
@@ -916,13 +916,16 @@ impl Client {
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
-        let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
-        Self::new_with_client(baseurl, client)
+        #[cfg(not(target_arch = "wasm32"))]
+        let client = {
+            let dur = std::time::Duration::from_secs(15);
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+        };
+        #[cfg(target_arch = "wasm32")]
+        let client = reqwest::ClientBuilder::new();
+        Self::new_with_client(baseurl, client.build().unwrap())
     }
 
     /// Construct a new client with an existing `reqwest::Client`,

--- a/progenitor-impl/tests/output/keeper-positional.out
+++ b/progenitor-impl/tests/output/keeper-positional.out
@@ -155,13 +155,16 @@ impl Client {
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
-        let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
-        Self::new_with_client(baseurl, client)
+        #[cfg(not(target_arch = "wasm32"))]
+        let client = {
+            let dur = std::time::Duration::from_secs(15);
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+        };
+        #[cfg(target_arch = "wasm32")]
+        let client = reqwest::ClientBuilder::new();
+        Self::new_with_client(baseurl, client.build().unwrap())
     }
 
     /// Construct a new client with an existing `reqwest::Client`,

--- a/progenitor-impl/tests/output/nexus-builder-tagged.out
+++ b/progenitor-impl/tests/output/nexus-builder-tagged.out
@@ -17048,13 +17048,16 @@ impl Client {
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
-        let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
-        Self::new_with_client(baseurl, client)
+        #[cfg(not(target_arch = "wasm32"))]
+        let client = {
+            let dur = std::time::Duration::from_secs(15);
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+        };
+        #[cfg(target_arch = "wasm32")]
+        let client = reqwest::ClientBuilder::new();
+        Self::new_with_client(baseurl, client.build().unwrap())
     }
 
     /// Construct a new client with an existing `reqwest::Client`,

--- a/progenitor-impl/tests/output/nexus-builder.out
+++ b/progenitor-impl/tests/output/nexus-builder.out
@@ -17104,13 +17104,16 @@ impl Client {
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
-        let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
-        Self::new_with_client(baseurl, client)
+        #[cfg(not(target_arch = "wasm32"))]
+        let client = {
+            let dur = std::time::Duration::from_secs(15);
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+        };
+        #[cfg(target_arch = "wasm32")]
+        let client = reqwest::ClientBuilder::new();
+        Self::new_with_client(baseurl, client.build().unwrap())
     }
 
     /// Construct a new client with an existing `reqwest::Client`,

--- a/progenitor-impl/tests/output/nexus-positional.out
+++ b/progenitor-impl/tests/output/nexus-positional.out
@@ -5876,13 +5876,16 @@ impl Client {
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
-        let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
-        Self::new_with_client(baseurl, client)
+        #[cfg(not(target_arch = "wasm32"))]
+        let client = {
+            let dur = std::time::Duration::from_secs(15);
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+        };
+        #[cfg(target_arch = "wasm32")]
+        let client = reqwest::ClientBuilder::new();
+        Self::new_with_client(baseurl, client.build().unwrap())
     }
 
     /// Construct a new client with an existing `reqwest::Client`,

--- a/progenitor-impl/tests/output/param-overrides-builder-tagged.out
+++ b/progenitor-impl/tests/output/param-overrides-builder-tagged.out
@@ -27,13 +27,16 @@ impl Client {
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
-        let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
-        Self::new_with_client(baseurl, client)
+        #[cfg(not(target_arch = "wasm32"))]
+        let client = {
+            let dur = std::time::Duration::from_secs(15);
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+        };
+        #[cfg(target_arch = "wasm32")]
+        let client = reqwest::ClientBuilder::new();
+        Self::new_with_client(baseurl, client.build().unwrap())
     }
 
     /// Construct a new client with an existing `reqwest::Client`,

--- a/progenitor-impl/tests/output/param-overrides-builder.out
+++ b/progenitor-impl/tests/output/param-overrides-builder.out
@@ -27,13 +27,16 @@ impl Client {
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
-        let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
-        Self::new_with_client(baseurl, client)
+        #[cfg(not(target_arch = "wasm32"))]
+        let client = {
+            let dur = std::time::Duration::from_secs(15);
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+        };
+        #[cfg(target_arch = "wasm32")]
+        let client = reqwest::ClientBuilder::new();
+        Self::new_with_client(baseurl, client.build().unwrap())
     }
 
     /// Construct a new client with an existing `reqwest::Client`,

--- a/progenitor-impl/tests/output/param-overrides-positional.out
+++ b/progenitor-impl/tests/output/param-overrides-positional.out
@@ -27,13 +27,16 @@ impl Client {
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
-        let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
-        Self::new_with_client(baseurl, client)
+        #[cfg(not(target_arch = "wasm32"))]
+        let client = {
+            let dur = std::time::Duration::from_secs(15);
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+        };
+        #[cfg(target_arch = "wasm32")]
+        let client = reqwest::ClientBuilder::new();
+        Self::new_with_client(baseurl, client.build().unwrap())
     }
 
     /// Construct a new client with an existing `reqwest::Client`,

--- a/progenitor-impl/tests/output/propolis-server-builder-tagged.out
+++ b/progenitor-impl/tests/output/propolis-server-builder-tagged.out
@@ -1969,13 +1969,16 @@ impl Client {
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
-        let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
-        Self::new_with_client(baseurl, client)
+        #[cfg(not(target_arch = "wasm32"))]
+        let client = {
+            let dur = std::time::Duration::from_secs(15);
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+        };
+        #[cfg(target_arch = "wasm32")]
+        let client = reqwest::ClientBuilder::new();
+        Self::new_with_client(baseurl, client.build().unwrap())
     }
 
     /// Construct a new client with an existing `reqwest::Client`,

--- a/progenitor-impl/tests/output/propolis-server-builder.out
+++ b/progenitor-impl/tests/output/propolis-server-builder.out
@@ -1975,13 +1975,16 @@ impl Client {
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
-        let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
-        Self::new_with_client(baseurl, client)
+        #[cfg(not(target_arch = "wasm32"))]
+        let client = {
+            let dur = std::time::Duration::from_secs(15);
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+        };
+        #[cfg(target_arch = "wasm32")]
+        let client = reqwest::ClientBuilder::new();
+        Self::new_with_client(baseurl, client.build().unwrap())
     }
 
     /// Construct a new client with an existing `reqwest::Client`,

--- a/progenitor-impl/tests/output/propolis-server-positional.out
+++ b/progenitor-impl/tests/output/propolis-server-positional.out
@@ -622,13 +622,16 @@ impl Client {
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
-        let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
-        Self::new_with_client(baseurl, client)
+        #[cfg(not(target_arch = "wasm32"))]
+        let client = {
+            let dur = std::time::Duration::from_secs(15);
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+        };
+        #[cfg(target_arch = "wasm32")]
+        let client = reqwest::ClientBuilder::new();
+        Self::new_with_client(baseurl, client.build().unwrap())
     }
 
     /// Construct a new client with an existing `reqwest::Client`,

--- a/progenitor-impl/tests/output/test_default_params_builder.out
+++ b/progenitor-impl/tests/output/test_default_params_builder.out
@@ -240,13 +240,16 @@ impl Client {
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
-        let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
-        Self::new_with_client(baseurl, client)
+        #[cfg(not(target_arch = "wasm32"))]
+        let client = {
+            let dur = std::time::Duration::from_secs(15);
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+        };
+        #[cfg(target_arch = "wasm32")]
+        let client = reqwest::ClientBuilder::new();
+        Self::new_with_client(baseurl, client.build().unwrap())
     }
 
     /// Construct a new client with an existing `reqwest::Client`,

--- a/progenitor-impl/tests/output/test_default_params_positional.out
+++ b/progenitor-impl/tests/output/test_default_params_positional.out
@@ -70,13 +70,16 @@ impl Client {
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
-        let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
-        Self::new_with_client(baseurl, client)
+        #[cfg(not(target_arch = "wasm32"))]
+        let client = {
+            let dur = std::time::Duration::from_secs(15);
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+        };
+        #[cfg(target_arch = "wasm32")]
+        let client = reqwest::ClientBuilder::new();
+        Self::new_with_client(baseurl, client.build().unwrap())
     }
 
     /// Construct a new client with an existing `reqwest::Client`,

--- a/progenitor-impl/tests/output/test_freeform_response.out
+++ b/progenitor-impl/tests/output/test_freeform_response.out
@@ -39,13 +39,16 @@ impl Client {
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
-        let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
-        Self::new_with_client(baseurl, client)
+        #[cfg(not(target_arch = "wasm32"))]
+        let client = {
+            let dur = std::time::Duration::from_secs(15);
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+        };
+        #[cfg(target_arch = "wasm32")]
+        let client = reqwest::ClientBuilder::new();
+        Self::new_with_client(baseurl, client.build().unwrap())
     }
 
     /// Construct a new client with an existing `reqwest::Client`,

--- a/progenitor-impl/tests/output/test_renamed_parameters.out
+++ b/progenitor-impl/tests/output/test_renamed_parameters.out
@@ -39,13 +39,16 @@ impl Client {
     /// `reqwest::Client`, and should include a scheme and hostname,
     /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
-        let dur = std::time::Duration::from_secs(15);
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur)
-            .build()
-            .unwrap();
-        Self::new_with_client(baseurl, client)
+        #[cfg(not(target_arch = "wasm32"))]
+        let client = {
+            let dur = std::time::Duration::from_secs(15);
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+        };
+        #[cfg(target_arch = "wasm32")]
+        let client = reqwest::ClientBuilder::new();
+        Self::new_with_client(baseurl, client.build().unwrap())
     }
 
     /// Construct a new client with an existing `reqwest::Client`,


### PR DESCRIPTION
This PR adds support for wasm when using the `build.rs` flow (using the macro is untested and might not `work). Since `progenitor-client` uses the `stream` feature of `reqwest` it also depends on: https://github.com/seanmonstar/reqwest/issues/1704