### PR TITLE
[dist] add feature for rustls

### DIFF
--- a/progenitor-client/Cargo.toml
+++ b/progenitor-client/Cargo.toml
@@ -14,3 +14,6 @@ reqwest = { version = "0.11.13", default-features = false, features = ["json", "
 serde = "1.0"
 serde_json = "1.0"
 serde_urlencoded = "0.7.1"
+
+[features]
+rustls = ["reqwest/rustls-tls"]


### PR DESCRIPTION
I wanted to expose the ability to use progenitor-client with only rustls to keep ssl dependencies contained. Let me know if i missed something in trying to expose this. Thanks!
