### PR TITLE
Add docstrings to the generated Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You'll need to add the following to `Cargo.toml`:
 
 ```diff
 [dependencies]
-+futures = 0.3
++futures = "0.3"
 +progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
 +reqwest = { version = "0.11", features = ["json", "stream"] }
 +serde = { version = "1.0", features = ["derive"] }
@@ -115,7 +115,7 @@ You'll need to add add the following to `Cargo.toml`:
 
 ```diff
 [dependencies]
-+futures = 0.3
++futures = "0.3"
 +progenitor-client = { git = "https://github.com/oxidecomputer/progenitor" }
 +reqwest = { version = "0.11", features = ["json", "stream"] }
 +serde = { version = "1.0", features = ["derive"] }

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -255,6 +255,12 @@ impl Generator {
             }
         });
 
+        let client_docstring = if let Some(description) = &spec.info.description
+        {
+            format!("Client for {}\n\n{}", spec.info.title, description)
+        } else {
+            format!("Client for {}", spec.info.title)
+        };
         let file = quote! {
             // Re-export ResponseValue and Error since those are used by the
             // public interface of Client.
@@ -275,6 +281,7 @@ impl Generator {
             }
 
             #[derive(Clone, Debug)]
+            #[doc = #client_docstring]
             pub struct Client {
                 pub(crate) baseurl: String,
                 pub(crate) client: reqwest::Client,
@@ -282,6 +289,11 @@ impl Generator {
             }
 
             impl Client {
+                /// Create a new client.
+                ///
+                /// `baseurl` is the base URL provided to the internal
+                /// `reqwest::Client`, and should include a scheme and hostname,
+                /// as well as port and a path stem if applicable.
                 pub fn new(
                     baseurl: &str,
                     #inner_parameter
@@ -295,6 +307,12 @@ impl Generator {
                     Self::new_with_client(baseurl, client, #inner_value)
                 }
 
+                /// Construct a new client with an existing `reqwest::Client`,
+                /// allowing more control over its configuration.
+                ///
+                /// `baseurl` is the base URL provided to the internal
+                /// `reqwest::Client`, and should include a scheme and hostname,
+                /// as well as port and a path stem if applicable.
                 pub fn new_with_client(
                     baseurl: &str,
                     client: reqwest::Client,
@@ -307,10 +325,12 @@ impl Generator {
                     }
                 }
 
+                /// Return the base URL to which requests are made.
                 pub fn baseurl(&self) -> &String {
                     &self.baseurl
                 }
 
+                /// Return the internal `reqwest::Client` used to make requests.
                 pub fn client(&self) -> &reqwest::Client {
                     &self.client
                 }

--- a/progenitor-impl/tests/output/buildomat-builder-tagged.out
+++ b/progenitor-impl/tests/output/buildomat-builder-tagged.out
@@ -1268,12 +1268,18 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
+///Client for Buildomat
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
 }
 
 impl Client {
+    /// Create a new client.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
         let client = reqwest::ClientBuilder::new()
@@ -1284,6 +1290,12 @@ impl Client {
         Self::new_with_client(baseurl, client)
     }
 
+    /// Construct a new client with an existing `reqwest::Client`,
+    /// allowing more control over its configuration.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),
@@ -1291,10 +1303,12 @@ impl Client {
         }
     }
 
+    /// Return the base URL to which requests are made.
     pub fn baseurl(&self) -> &String {
         &self.baseurl
     }
 
+    /// Return the internal `reqwest::Client` used to make requests.
     pub fn client(&self) -> &reqwest::Client {
         &self.client
     }

--- a/progenitor-impl/tests/output/buildomat-builder.out
+++ b/progenitor-impl/tests/output/buildomat-builder.out
@@ -1268,12 +1268,18 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
+///Client for Buildomat
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
 }
 
 impl Client {
+    /// Create a new client.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
         let client = reqwest::ClientBuilder::new()
@@ -1284,6 +1290,12 @@ impl Client {
         Self::new_with_client(baseurl, client)
     }
 
+    /// Construct a new client with an existing `reqwest::Client`,
+    /// allowing more control over its configuration.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),
@@ -1291,10 +1303,12 @@ impl Client {
         }
     }
 
+    /// Return the base URL to which requests are made.
     pub fn baseurl(&self) -> &String {
         &self.baseurl
     }
 
+    /// Return the internal `reqwest::Client` used to make requests.
     pub fn client(&self) -> &reqwest::Client {
         &self.client
     }

--- a/progenitor-impl/tests/output/buildomat-positional.out
+++ b/progenitor-impl/tests/output/buildomat-positional.out
@@ -137,12 +137,18 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
+///Client for Buildomat
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
 }
 
 impl Client {
+    /// Create a new client.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
         let client = reqwest::ClientBuilder::new()
@@ -153,6 +159,12 @@ impl Client {
         Self::new_with_client(baseurl, client)
     }
 
+    /// Construct a new client with an existing `reqwest::Client`,
+    /// allowing more control over its configuration.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),
@@ -160,10 +172,12 @@ impl Client {
         }
     }
 
+    /// Return the base URL to which requests are made.
     pub fn baseurl(&self) -> &String {
         &self.baseurl
     }
 
+    /// Return the internal `reqwest::Client` used to make requests.
     pub fn client(&self) -> &reqwest::Client {
         &self.client
     }

--- a/progenitor-impl/tests/output/keeper-builder-tagged.out
+++ b/progenitor-impl/tests/output/keeper-builder-tagged.out
@@ -730,12 +730,20 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
+///Client for Keeper API
+///
+///report execution of cron jobs through a mechanism other than mail
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
 }
 
 impl Client {
+    /// Create a new client.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
         let client = reqwest::ClientBuilder::new()
@@ -746,6 +754,12 @@ impl Client {
         Self::new_with_client(baseurl, client)
     }
 
+    /// Construct a new client with an existing `reqwest::Client`,
+    /// allowing more control over its configuration.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),
@@ -753,10 +767,12 @@ impl Client {
         }
     }
 
+    /// Return the base URL to which requests are made.
     pub fn baseurl(&self) -> &String {
         &self.baseurl
     }
 
+    /// Return the internal `reqwest::Client` used to make requests.
     pub fn client(&self) -> &reqwest::Client {
         &self.client
     }

--- a/progenitor-impl/tests/output/keeper-builder.out
+++ b/progenitor-impl/tests/output/keeper-builder.out
@@ -730,12 +730,20 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
+///Client for Keeper API
+///
+///report execution of cron jobs through a mechanism other than mail
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
 }
 
 impl Client {
+    /// Create a new client.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
         let client = reqwest::ClientBuilder::new()
@@ -746,6 +754,12 @@ impl Client {
         Self::new_with_client(baseurl, client)
     }
 
+    /// Construct a new client with an existing `reqwest::Client`,
+    /// allowing more control over its configuration.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),
@@ -753,10 +767,12 @@ impl Client {
         }
     }
 
+    /// Return the base URL to which requests are made.
     pub fn baseurl(&self) -> &String {
         &self.baseurl
     }
 
+    /// Return the internal `reqwest::Client` used to make requests.
     pub fn client(&self) -> &reqwest::Client {
         &self.client
     }

--- a/progenitor-impl/tests/output/keeper-positional.out
+++ b/progenitor-impl/tests/output/keeper-positional.out
@@ -78,12 +78,20 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
+///Client for Keeper API
+///
+///report execution of cron jobs through a mechanism other than mail
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
 }
 
 impl Client {
+    /// Create a new client.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
         let client = reqwest::ClientBuilder::new()
@@ -94,6 +102,12 @@ impl Client {
         Self::new_with_client(baseurl, client)
     }
 
+    /// Construct a new client with an existing `reqwest::Client`,
+    /// allowing more control over its configuration.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),
@@ -101,10 +115,12 @@ impl Client {
         }
     }
 
+    /// Return the base URL to which requests are made.
     pub fn baseurl(&self) -> &String {
         &self.baseurl
     }
 
+    /// Return the internal `reqwest::Client` used to make requests.
     pub fn client(&self) -> &reqwest::Client {
         &self.client
     }

--- a/progenitor-impl/tests/output/nexus-builder-tagged.out
+++ b/progenitor-impl/tests/output/nexus-builder-tagged.out
@@ -11061,12 +11061,20 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
+///Client for Oxide Region API
+///
+///API for interacting with the Oxide control plane
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
 }
 
 impl Client {
+    /// Create a new client.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
         let client = reqwest::ClientBuilder::new()
@@ -11077,6 +11085,12 @@ impl Client {
         Self::new_with_client(baseurl, client)
     }
 
+    /// Construct a new client with an existing `reqwest::Client`,
+    /// allowing more control over its configuration.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),
@@ -11084,10 +11098,12 @@ impl Client {
         }
     }
 
+    /// Return the base URL to which requests are made.
     pub fn baseurl(&self) -> &String {
         &self.baseurl
     }
 
+    /// Return the internal `reqwest::Client` used to make requests.
     pub fn client(&self) -> &reqwest::Client {
         &self.client
     }

--- a/progenitor-impl/tests/output/nexus-builder.out
+++ b/progenitor-impl/tests/output/nexus-builder.out
@@ -11105,12 +11105,20 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
+///Client for Oxide Region API
+///
+///API for interacting with the Oxide control plane
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
 }
 
 impl Client {
+    /// Create a new client.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
         let client = reqwest::ClientBuilder::new()
@@ -11121,6 +11129,12 @@ impl Client {
         Self::new_with_client(baseurl, client)
     }
 
+    /// Construct a new client with an existing `reqwest::Client`,
+    /// allowing more control over its configuration.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),
@@ -11128,10 +11142,12 @@ impl Client {
         }
     }
 
+    /// Return the base URL to which requests are made.
     pub fn baseurl(&self) -> &String {
         &self.baseurl
     }
 
+    /// Return the internal `reqwest::Client` used to make requests.
     pub fn client(&self) -> &reqwest::Client {
         &self.client
     }

--- a/progenitor-impl/tests/output/nexus-positional.out
+++ b/progenitor-impl/tests/output/nexus-positional.out
@@ -2956,12 +2956,20 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
+///Client for Oxide Region API
+///
+///API for interacting with the Oxide control plane
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
 }
 
 impl Client {
+    /// Create a new client.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
         let client = reqwest::ClientBuilder::new()
@@ -2972,6 +2980,12 @@ impl Client {
         Self::new_with_client(baseurl, client)
     }
 
+    /// Construct a new client with an existing `reqwest::Client`,
+    /// allowing more control over its configuration.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),
@@ -2979,10 +2993,12 @@ impl Client {
         }
     }
 
+    /// Return the base URL to which requests are made.
     pub fn baseurl(&self) -> &String {
         &self.baseurl
     }
 
+    /// Return the internal `reqwest::Client` used to make requests.
     pub fn client(&self) -> &reqwest::Client {
         &self.client
     }

--- a/progenitor-impl/tests/output/param-overrides-builder-tagged.out
+++ b/progenitor-impl/tests/output/param-overrides-builder-tagged.out
@@ -10,12 +10,20 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
+///Client for Parameter override test
+///
+///Minimal API for testing parameter overrides
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
 }
 
 impl Client {
+    /// Create a new client.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
         let client = reqwest::ClientBuilder::new()
@@ -26,6 +34,12 @@ impl Client {
         Self::new_with_client(baseurl, client)
     }
 
+    /// Construct a new client with an existing `reqwest::Client`,
+    /// allowing more control over its configuration.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),
@@ -33,10 +47,12 @@ impl Client {
         }
     }
 
+    /// Return the base URL to which requests are made.
     pub fn baseurl(&self) -> &String {
         &self.baseurl
     }
 
+    /// Return the internal `reqwest::Client` used to make requests.
     pub fn client(&self) -> &reqwest::Client {
         &self.client
     }

--- a/progenitor-impl/tests/output/param-overrides-builder.out
+++ b/progenitor-impl/tests/output/param-overrides-builder.out
@@ -10,12 +10,20 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
+///Client for Parameter override test
+///
+///Minimal API for testing parameter overrides
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
 }
 
 impl Client {
+    /// Create a new client.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
         let client = reqwest::ClientBuilder::new()
@@ -26,6 +34,12 @@ impl Client {
         Self::new_with_client(baseurl, client)
     }
 
+    /// Construct a new client with an existing `reqwest::Client`,
+    /// allowing more control over its configuration.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),
@@ -33,10 +47,12 @@ impl Client {
         }
     }
 
+    /// Return the base URL to which requests are made.
     pub fn baseurl(&self) -> &String {
         &self.baseurl
     }
 
+    /// Return the internal `reqwest::Client` used to make requests.
     pub fn client(&self) -> &reqwest::Client {
         &self.client
     }

--- a/progenitor-impl/tests/output/param-overrides-positional.out
+++ b/progenitor-impl/tests/output/param-overrides-positional.out
@@ -10,12 +10,20 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
+///Client for Parameter override test
+///
+///Minimal API for testing parameter overrides
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
 }
 
 impl Client {
+    /// Create a new client.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
         let client = reqwest::ClientBuilder::new()
@@ -26,6 +34,12 @@ impl Client {
         Self::new_with_client(baseurl, client)
     }
 
+    /// Construct a new client with an existing `reqwest::Client`,
+    /// allowing more control over its configuration.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),
@@ -33,10 +47,12 @@ impl Client {
         }
     }
 
+    /// Return the base URL to which requests are made.
     pub fn baseurl(&self) -> &String {
         &self.baseurl
     }
 
+    /// Return the internal `reqwest::Client` used to make requests.
     pub fn client(&self) -> &reqwest::Client {
         &self.client
     }

--- a/progenitor-impl/tests/output/propolis-server-builder-tagged.out
+++ b/progenitor-impl/tests/output/propolis-server-builder-tagged.out
@@ -1500,12 +1500,20 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
+///Client for Oxide Propolis Server API
+///
+///API for interacting with the Propolis hypervisor frontend.
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
 }
 
 impl Client {
+    /// Create a new client.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
         let client = reqwest::ClientBuilder::new()
@@ -1516,6 +1524,12 @@ impl Client {
         Self::new_with_client(baseurl, client)
     }
 
+    /// Construct a new client with an existing `reqwest::Client`,
+    /// allowing more control over its configuration.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),
@@ -1523,10 +1537,12 @@ impl Client {
         }
     }
 
+    /// Return the base URL to which requests are made.
     pub fn baseurl(&self) -> &String {
         &self.baseurl
     }
 
+    /// Return the internal `reqwest::Client` used to make requests.
     pub fn client(&self) -> &reqwest::Client {
         &self.client
     }

--- a/progenitor-impl/tests/output/propolis-server-builder.out
+++ b/progenitor-impl/tests/output/propolis-server-builder.out
@@ -1506,12 +1506,20 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
+///Client for Oxide Propolis Server API
+///
+///API for interacting with the Propolis hypervisor frontend.
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
 }
 
 impl Client {
+    /// Create a new client.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
         let client = reqwest::ClientBuilder::new()
@@ -1522,6 +1530,12 @@ impl Client {
         Self::new_with_client(baseurl, client)
     }
 
+    /// Construct a new client with an existing `reqwest::Client`,
+    /// allowing more control over its configuration.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),
@@ -1529,10 +1543,12 @@ impl Client {
         }
     }
 
+    /// Return the base URL to which requests are made.
     pub fn baseurl(&self) -> &String {
         &self.baseurl
     }
 
+    /// Return the internal `reqwest::Client` used to make requests.
     pub fn client(&self) -> &reqwest::Client {
         &self.client
     }

--- a/progenitor-impl/tests/output/propolis-server-positional.out
+++ b/progenitor-impl/tests/output/propolis-server-positional.out
@@ -340,12 +340,20 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
+///Client for Oxide Propolis Server API
+///
+///API for interacting with the Propolis hypervisor frontend.
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
 }
 
 impl Client {
+    /// Create a new client.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
         let client = reqwest::ClientBuilder::new()
@@ -356,6 +364,12 @@ impl Client {
         Self::new_with_client(baseurl, client)
     }
 
+    /// Construct a new client with an existing `reqwest::Client`,
+    /// allowing more control over its configuration.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),
@@ -363,10 +377,12 @@ impl Client {
         }
     }
 
+    /// Return the base URL to which requests are made.
     pub fn baseurl(&self) -> &String {
         &self.baseurl
     }
 
+    /// Return the internal `reqwest::Client` used to make requests.
     pub fn client(&self) -> &reqwest::Client {
         &self.client
     }

--- a/progenitor-impl/tests/output/test_default_params_builder.out
+++ b/progenitor-impl/tests/output/test_default_params_builder.out
@@ -190,12 +190,18 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
+///Client for pagination-demo
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
 }
 
 impl Client {
+    /// Create a new client.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
         let client = reqwest::ClientBuilder::new()
@@ -206,6 +212,12 @@ impl Client {
         Self::new_with_client(baseurl, client)
     }
 
+    /// Construct a new client with an existing `reqwest::Client`,
+    /// allowing more control over its configuration.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),
@@ -213,10 +225,12 @@ impl Client {
         }
     }
 
+    /// Return the base URL to which requests are made.
     pub fn baseurl(&self) -> &String {
         &self.baseurl
     }
 
+    /// Return the internal `reqwest::Client` used to make requests.
     pub fn client(&self) -> &reqwest::Client {
         &self.client
     }

--- a/progenitor-impl/tests/output/test_default_params_positional.out
+++ b/progenitor-impl/tests/output/test_default_params_positional.out
@@ -43,12 +43,18 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
+///Client for pagination-demo
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
 }
 
 impl Client {
+    /// Create a new client.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
         let client = reqwest::ClientBuilder::new()
@@ -59,6 +65,12 @@ impl Client {
         Self::new_with_client(baseurl, client)
     }
 
+    /// Construct a new client with an existing `reqwest::Client`,
+    /// allowing more control over its configuration.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),
@@ -66,10 +78,12 @@ impl Client {
         }
     }
 
+    /// Return the base URL to which requests are made.
     pub fn baseurl(&self) -> &String {
         &self.baseurl
     }
 
+    /// Return the internal `reqwest::Client` used to make requests.
     pub fn client(&self) -> &reqwest::Client {
         &self.client
     }

--- a/progenitor-impl/tests/output/test_freeform_response.out
+++ b/progenitor-impl/tests/output/test_freeform_response.out
@@ -18,12 +18,18 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
+///Client for pagination-demo
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
 }
 
 impl Client {
+    /// Create a new client.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
         let client = reqwest::ClientBuilder::new()
@@ -34,6 +40,12 @@ impl Client {
         Self::new_with_client(baseurl, client)
     }
 
+    /// Construct a new client with an existing `reqwest::Client`,
+    /// allowing more control over its configuration.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),
@@ -41,10 +53,12 @@ impl Client {
         }
     }
 
+    /// Return the base URL to which requests are made.
     pub fn baseurl(&self) -> &String {
         &self.baseurl
     }
 
+    /// Return the internal `reqwest::Client` used to make requests.
     pub fn client(&self) -> &reqwest::Client {
         &self.client
     }

--- a/progenitor-impl/tests/output/test_renamed_parameters.out
+++ b/progenitor-impl/tests/output/test_renamed_parameters.out
@@ -18,12 +18,18 @@ pub mod types {
 }
 
 #[derive(Clone, Debug)]
+///Client for pagination-demo
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
 }
 
 impl Client {
+    /// Create a new client.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new(baseurl: &str) -> Self {
         let dur = std::time::Duration::from_secs(15);
         let client = reqwest::ClientBuilder::new()
@@ -34,6 +40,12 @@ impl Client {
         Self::new_with_client(baseurl, client)
     }
 
+    /// Construct a new client with an existing `reqwest::Client`,
+    /// allowing more control over its configuration.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
     pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
         Self {
             baseurl: baseurl.to_string(),
@@ -41,10 +53,12 @@ impl Client {
         }
     }
 
+    /// Return the base URL to which requests are made.
     pub fn baseurl(&self) -> &String {
         &self.baseurl
     }
 
+    /// Return the internal `reqwest::Client` used to make requests.
     pub fn client(&self) -> &reqwest::Client {
         &self.client
     }


### PR DESCRIPTION
- Add docstring to the `Client`, based on the OpenAPI title and description, if provided.
- Add docstrings to the constructors and getters shared by all generated clients.
- Update expectorate tests.
- Small typo-fix in README.