### PR TITLE
generate using built dependency versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b9c056b9ed43aee5e064b683aa1ec783e19c6acec7559e3ae931b7490472fbe"
+dependencies = [
+ "cargo-lock",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,6 +122,18 @@ name = "bytes"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+
+[[package]]
+name = "cargo-lock"
+version = "8.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031718ddb8f78aa5def78a09e90defe30151d1f6c672f937af4dd916429ed996"
+dependencies = [
+ "semver 1.0.16",
+ "serde",
+ "toml",
+ "url",
+]
 
 [[package]]
 name = "cc"
@@ -1096,6 +1117,7 @@ version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
+ "built",
  "chrono",
  "clap",
  "futures",
@@ -1104,6 +1126,7 @@ dependencies = [
  "progenitor-client",
  "progenitor-impl",
  "progenitor-macro",
+ "project-root",
  "rand",
  "regress",
  "reqwest",
@@ -1168,6 +1191,12 @@ dependencies = [
  "serde_yaml",
  "syn",
 ]
+
+[[package]]
+name = "project-root"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bccbff07d5ed689c4087d20d7307a52ab6141edeedf487c3876a55b86cf63df"
 
 [[package]]
 name = "quote"
@@ -1466,6 +1495,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
  "semver-parser",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1891,7 +1929,7 @@ dependencies = [
  "home",
  "lazy_static",
  "regex",
- "semver",
+ "semver 0.11.0",
  "walkdir",
 ]
 

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -505,43 +505,17 @@ impl Generator {
         })
     }
 
-    pub fn dependencies(&self) -> Vec<String> {
-        let mut deps = vec![
-            "bytes = \"1.3.0\"",
-            "futures-core = \"0.3\"",
-            "percent-encoding = \"2.2\"",
-            "reqwest = { version = \"0.11.13\", default-features=false, features = [\"json\", \"stream\"] }",
-            "serde = { version = \"1.0\", features = [\"derive\"] }",
-            "serde_urlencoded = \"0.7.1\"",
-        ];
-        if self.type_space.uses_regress() {
-            deps.push("regress = \"0.4.1\"")
-        }
-        if self.type_space.uses_uuid() {
-            deps.push(
-                "uuid = { version = \">=0.8.0, <2.0.0\", features = [\"serde\", \"v4\"] }",
-            )
-        }
-        if self.type_space.uses_chrono() {
-            deps.push("chrono = { version = \"0.4\", default-features=false, features = [\"serde\"] }")
-        }
-        if self.uses_futures {
-            deps.push("futures = \"0.3\"")
-        }
-        if self.uses_websockets {
-            deps.push("base64 = \"0.21\"");
-            deps.push("rand = \"0.8\"");
-        }
-        if self.type_space.uses_serde_json() {
-            deps.push("serde_json = \"1.0\"")
-        }
-        deps.sort_unstable();
-        deps.iter().map(ToString::to_string).collect()
-    }
-
     // TODO deprecate?
     pub fn get_type_space(&self) -> &TypeSpace {
         &self.type_space
+    }
+
+    pub fn uses_futures(&self) -> bool {
+        self.uses_futures
+    }
+
+    pub fn uses_websockets(&self) -> bool {
+        self.uses_websockets
     }
 }
 

--- a/progenitor/Cargo.toml
+++ b/progenitor/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/oxidecomputer/progenitor.git"
 readme = "../README.md"
 keywords = ["openapi", "openapiv3", "sdk", "generator", "proc_macro"]
 categories = ["api-bindings", "compilers"]
+build = "build.rs"
 
 [dependencies]
 progenitor-client = { version = "0.2.1-dev", path = "../progenitor-client" }
@@ -19,6 +20,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 clap = { version = "4.1.1", features = ["derive"] }
+
+[build-dependencies]
+built = { version = "0.5" }
+project-root = "*"
 
 [dev-dependencies]
 base64 = "0.21"

--- a/progenitor/build.rs
+++ b/progenitor/build.rs
@@ -1,0 +1,10 @@
+fn main() {
+    let mut opts = built::Options::default();
+    opts.set_dependencies(true);
+
+    let src = project_root::get_project_root().unwrap();
+    let dst = std::path::Path::new(&std::env::var("OUT_DIR").unwrap())
+        .join("built.rs");
+    built::write_built_file_with_opts(&opts, src.as_ref(), &dst)
+        .expect("Failed to acquire build-time information");
+}


### PR DESCRIPTION
This avoids the generated Cargo.toml having different versions than the project manifests, which are being regularly updated using [dependabot](https://github.com/apps/dependabot).

e.g. at the moment, reqwest is different https://github.com/oxidecomputer/progenitor/blob/57031d7/progenitor/Cargo.toml#L29 (0.11.13) vs https://github.com/oxidecomputer/progenitor/blob/ba189e6/progenitor-impl/src/lib.rs#L500 (0.11.12).

That difference isnt too bad, but this PR is to prevent more serious differences.

Using https://docs.rs/built/ was easiest way to do this.  Happy to re-implement the various bits needed to achieve this with fewer added dependencies, but there are not many - `built` only depends on https://docs.rs/cargo-lock , which has only a few deps which might be omittable with a hand-crafted implementation.

If we dont use the `Cargo.lock`, and instead use `Cargo.toml`, the number/size of deps likely increases due to the complexity of cargo toml parsing libraries.

I avoided adding `built` to `progenitor-impl` to avoid that growing in size, which means if we need this in the macro, the implementation in the progenitor bin needs to be copied across to the -macro. Alternatively we can just add this to `progenitor-impl`, which means the version mapping no longer needs to be passed through the `GenerationSettings` and the fallback default of version `"*"` is no longer needed.