### PR TITLE
progenitor_impl using only typify_impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,7 +1222,7 @@ dependencies = [
  "serde_yaml",
  "syn",
  "thiserror",
- "typify",
+ "typify-impl",
  "unicode-ident",
 ]
 
@@ -2023,15 +2023,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
-name = "typify"
-version = "0.0.11-dev"
-source = "git+https://github.com/oxidecomputer/typify#d579a526b3cc2e0c36d17fae8df549a03187f177"
-dependencies = [
- "typify-impl",
- "typify-macro",
-]
-
-[[package]]
 name = "typify-impl"
 version = "0.0.11-dev"
 source = "git+https://github.com/oxidecomputer/typify#d579a526b3cc2e0c36d17fae8df549a03187f177"
@@ -2047,21 +2038,6 @@ dependencies = [
  "syn",
  "thiserror",
  "unicode-ident",
-]
-
-[[package]]
-name = "typify-macro"
-version = "0.0.11-dev"
-source = "git+https://github.com/oxidecomputer/typify#d579a526b3cc2e0c36d17fae8df549a03187f177"
-dependencies = [
- "proc-macro2",
- "quote",
- "schemars",
- "serde",
- "serde_json",
- "serde_tokenstream",
- "syn",
- "typify-impl",
 ]
 
 [[package]]

--- a/progenitor-impl/Cargo.toml
+++ b/progenitor-impl/Cargo.toml
@@ -22,8 +22,8 @@ serde_json = "1.0"
 syn = { version = "1.0", features = ["parsing"] }
 thiserror = "1.0"
 # To publish, use a numbered version
-#typify = "0.0.10"
-typify = { git = "https://github.com/oxidecomputer/typify" }
+#typify-impl = "0.0.10"
+typify-impl = { git = "https://github.com/oxidecomputer/typify" }
 unicode-ident = "1.0.6"
 
 [dev-dependencies]

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -7,12 +7,12 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use serde::Deserialize;
 use thiserror::Error;
-use typify::{TypeSpace, TypeSpaceSettings};
+use typify_impl::{TypeSpace, TypeSpaceSettings};
 
 use crate::to_schema::ToSchema;
 
-pub use typify::TypeSpaceImpl as TypeImpl;
-pub use typify::TypeSpacePatch as TypePatch;
+pub use typify_impl::TypeSpaceImpl as TypeImpl;
+pub use typify_impl::TypeSpacePatch as TypePatch;
 
 mod method;
 mod template;
@@ -24,7 +24,7 @@ pub enum Error {
     #[error("unexpected value type {0}: {1}")]
     BadValue(String, serde_json::Value),
     #[error("type error {0}")]
-    TypeError(#[from] typify::Error),
+    TypeError(#[from] typify_impl::Error),
     #[error("unexpected or unhandled format in the OpenAPI document {0}")]
     UnexpectedFormat(String),
     #[error("invalid operation path {0}")]

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -9,7 +9,7 @@ use std::{
 use openapiv3::{Components, Parameter, ReferenceOr, Response, StatusCode};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};
-use typify::TypeId;
+use typify_impl::{TypeDetails, TypeId};
 
 use crate::{
     template::PathTemplate,
@@ -1218,7 +1218,7 @@ impl Generator {
 
         let typ = self.type_space.get_type(success_response).ok()?;
         let details = match typ.details() {
-            typify::TypeDetails::Struct(details) => details,
+            TypeDetails::Struct(details) => details,
             _ => return None,
         };
 
@@ -1230,7 +1230,7 @@ impl Generator {
         }
 
         // We need a next_page property that's an Option<String>.
-        if let typify::TypeDetails::Option(ref opt_id) = self
+        if let TypeDetails::Option(ref opt_id) = self
             .type_space
             .get_type(properties.get("next_page")?)
             .ok()?
@@ -1238,7 +1238,7 @@ impl Generator {
         {
             if !matches!(
                 self.type_space.get_type(opt_id).ok()?.details(),
-                typify::TypeDetails::String
+                TypeDetails::String
             ) {
                 return None;
             }
@@ -1252,9 +1252,7 @@ impl Generator {
             .ok()?
             .details()
         {
-            typify::TypeDetails::Array(item) => {
-                Some(DropshotPagination { item })
-            }
+            TypeDetails::Array(item) => Some(DropshotPagination { item }),
             _ => None,
         }
     }
@@ -1377,7 +1375,7 @@ impl Generator {
                     OperationParameterType::Type(type_id) => {
                         let ty = self.type_space.get_type(type_id)?;
                         let details = ty.details();
-                        matches!(&details, typify::TypeDetails::Option(_))
+                        matches!(&details, TypeDetails::Option(_))
                     }
                     OperationParameterType::RawBody => false,
                 };
@@ -1402,7 +1400,7 @@ impl Generator {
                         let ty = self.type_space.get_type(type_id)?;
                         let details = ty.details();
                         match &details {
-                            typify::TypeDetails::Option(opt_id) => {
+                            TypeDetails::Option(opt_id) => {
                                 // TODO currently we explicitly turn optional
                                 // parameters into Option types; we could
                                 // probably defer this to the code generation


### PR DESCRIPTION
Users of `progenitor_impl` shouldnt need all of `typify` - they only need to depend on `typify_impl`.