### PR TITLE
Export missing `TypeImpl`

### DIFF
--- a/progenitor/src/lib.rs
+++ b/progenitor/src/lib.rs
@@ -16,5 +16,6 @@ pub use progenitor_impl::GenerationSettings;
 pub use progenitor_impl::Generator;
 pub use progenitor_impl::InterfaceStyle;
 pub use progenitor_impl::TagStyle;
+pub use progenitor_impl::TypeImpl;
 pub use progenitor_impl::TypePatch;
 pub use progenitor_macro::generate_api;


### PR DESCRIPTION
During attempting to use `progenitor` I stumbled upon a few small issues:

* lack of a re-export of `TypeImpl`