### PR TITLE
Allow for parameters in content types

### DIFF
--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -456,8 +456,11 @@ impl Generator {
                 // content type of the response just as it currently examines
                 // the status code.
                 let typ = if let Some(mt) =
-                    response.content.iter().find_map(|(x, v)| (x == "application/json" || x.starts_with("application/json;")).then_some(v))
-                {
+                    response.content.iter().find_map(|(x, v)| {
+                        (x == "application/json"
+                            || x.starts_with("application/json;"))
+                        .then_some(v)
+                    }) {
                     assert!(mt.encoding.is_empty());
 
                     let typ = if let Some(schema) = &mt.schema {

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -126,7 +126,8 @@ impl FromStr for BodyContentType {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self> {
-        match s {
+        let offset = s.find(';').unwrap_or(s.len());
+        match &s[..offset] {
             "application/octet-stream" => Ok(Self::OctetStream),
             "application/json" => Ok(Self::Json),
             "application/x-www-form-urlencoded" => Ok(Self::FormUrlencoded),
@@ -455,7 +456,7 @@ impl Generator {
                 // content type of the response just as it currently examines
                 // the status code.
                 let typ = if let Some(mt) =
-                    response.content.get("application/json")
+                    response.content.iter().find_map(|(x, v)| (x == "application/json" || x.starts_with("application/json;")).then_some(v))
                 {
                     assert!(mt.encoding.is_empty());
 

--- a/sample_openapi/buildomat.json
+++ b/sample_openapi/buildomat.json
@@ -12,7 +12,7 @@
           "200": {
             "description": "successful operation",
             "content": {
-              "application/json": {
+              "application/json; charset=utf-8": {
                 "schema": {
                   "enum": [
                     null
@@ -52,7 +52,7 @@
           "200": {
             "description": "successful operation",
             "content": {
-              "application/json": {
+              "application/json; charset=utf-8": {
                 "schema": {
                   "$ref": "#/components/schemas/Task"
                 }
@@ -69,7 +69,7 @@
           "200": {
             "description": "successful operation",
             "content": {
-              "application/json": {
+              "application/json; charset=utf-8": {
                 "schema": {
                   "title": "Array_of_Task",
                   "type": "array",
@@ -86,7 +86,7 @@
         "operationId": "task_submit",
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/json; charset=utf-8": {
               "schema": {
                 "$ref": "#/components/schemas/TaskSubmit"
               }
@@ -98,7 +98,7 @@
           "201": {
             "description": "successful creation",
             "content": {
-              "application/json": {
+              "application/json; charset=utf-8": {
                 "schema": {
                   "$ref": "#/components/schemas/TaskSubmitResult"
                 }
@@ -136,7 +136,7 @@
           "200": {
             "description": "successful operation",
             "content": {
-              "application/json": {
+              "application/json; charset=utf-8": {
                 "schema": {
                   "title": "Array_of_TaskEvent",
                   "type": "array",
@@ -168,7 +168,7 @@
           "200": {
             "description": "successful operation",
             "content": {
-              "application/json": {
+              "application/json; charset=utf-8": {
                 "schema": {
                   "title": "Array_of_TaskOutput",
                   "type": "array",
@@ -213,7 +213,7 @@
         "operationId": "user_create",
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/json; charset=utf-8": {
               "schema": {
                 "$ref": "#/components/schemas/UserCreate"
               }
@@ -225,7 +225,7 @@
           "201": {
             "description": "successful creation",
             "content": {
-              "application/json": {
+              "application/json; charset=utf-8": {
                 "schema": {
                   "$ref": "#/components/schemas/UserCreateResult"
                 }
@@ -242,7 +242,7 @@
           "200": {
             "description": "successful operation",
             "content": {
-              "application/json": {
+              "application/json; charset=utf-8": {
                 "schema": {
                   "$ref": "#/components/schemas/WhoamiResult"
                 }
@@ -257,7 +257,7 @@
         "operationId": "worker_bootstrap",
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/json; charset=utf-8": {
               "schema": {
                 "$ref": "#/components/schemas/WorkerBootstrap"
               }
@@ -269,7 +269,7 @@
           "201": {
             "description": "successful creation",
             "content": {
-              "application/json": {
+              "application/json; charset=utf-8": {
                 "schema": {
                   "$ref": "#/components/schemas/WorkerBootstrapResult"
                 }
@@ -286,7 +286,7 @@
           "200": {
             "description": "successful operation",
             "content": {
-              "application/json": {
+              "application/json; charset=utf-8": {
                 "schema": {
                   "$ref": "#/components/schemas/WorkerPingResult"
                 }
@@ -312,7 +312,7 @@
         ],
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/json; charset=utf-8": {
               "schema": {
                 "$ref": "#/components/schemas/WorkerAppendTask"
               }
@@ -356,7 +356,7 @@
           "201": {
             "description": "successful creation",
             "content": {
-              "application/json": {
+              "application/json; charset=utf-8": {
                 "schema": {
                   "$ref": "#/components/schemas/UploadedChunk"
                 }
@@ -382,7 +382,7 @@
         ],
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/json; charset=utf-8": {
               "schema": {
                 "$ref": "#/components/schemas/WorkerCompleteTask"
               }
@@ -413,7 +413,7 @@
         ],
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/json; charset=utf-8": {
               "schema": {
                 "$ref": "#/components/schemas/WorkerAddOutput"
               }
@@ -435,7 +435,7 @@
           "200": {
             "description": "successful operation",
             "content": {
-              "application/json": {
+              "application/json; charset=utf-8": {
                 "schema": {
                   "$ref": "#/components/schemas/WorkersResult"
                 }


### PR DESCRIPTION
Right now, any component schemas with content types such as `application/json; charset=utf-8` aren't identified correctly by the client generator. This is problematic, because it leads to endpoints being generated that return `ResponseValue<ByteStream>` rather than the deserialized component type. To fix this, I've added some simple logic that ignores anything beyond a `;` in the content type.