### PR TITLE
remove generate_text

### DIFF
--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -504,11 +504,6 @@ impl Generator {
         Ok(out)
     }
 
-    /// Render text output.
-    pub fn generate_text(&mut self, spec: &OpenAPI) -> Result<String> {
-        Ok(self.generate_tokens(spec)?.to_string())
-    }
-
     // TODO deprecate?
     pub fn get_type_space(&self) -> &TypeSpace {
         &self.type_space

--- a/progenitor/src/main.rs
+++ b/progenitor/src/main.rs
@@ -120,7 +120,7 @@ fn main() -> Result<()> {
             .with_tag(args.tags.into()),
     );
 
-    match builder.generate_text(&api) {
+    match builder.generate_tokens(&api) {
         Ok(api_code) => {
             let type_space = builder.get_type_space();
 
@@ -188,7 +188,7 @@ fn main() -> Result<()> {
             let lib_code = if args.include_client {
                 format!("mod progenitor_client;\n\n{}", api_code)
             } else {
-                api_code
+                api_code.to_string()
             };
             let lib_code = reformat_code(lib_code);
 


### PR DESCRIPTION
This is breaking, and may break things, but I'm convinced that we just want to generate code and let the consumers figure out the right way to format it.