### PR TITLE
change handling of optional parameters

### DIFF
--- a/progenitor-impl/src/cli.rs
+++ b/progenitor-impl/src/cli.rs
@@ -301,22 +301,6 @@ impl Generator {
                 };
                 let arg_type = self.type_space.get_type(arg_type_id).unwrap();
 
-                let maybe_inner_type =
-                    if let typify::TypeDetails::Option(inner_type_id) =
-                        arg_type.details()
-                    {
-                        let inner_type =
-                            self.type_space.get_type(&inner_type_id).unwrap();
-                        Some(inner_type)
-                    } else {
-                        None
-                    };
-                let arg_type = if let Some(inner_type) = maybe_inner_type {
-                    inner_type
-                } else {
-                    arg_type
-                };
-
                 clap_arg(&arg_name, required, &param.description, &arg_type)
             });
 
@@ -376,18 +360,7 @@ impl Generator {
                     panic!()
                 };
                 let arg_type = self.type_space.get_type(arg_type_id).unwrap();
-
-                // TODO this really should be simpler.
-                let arg_details = arg_type.details();
-                let arg_type_name = match &arg_details{
-                    typify::TypeDetails::Option(opt_id) => {
-                        let inner_type = self.type_space.get_type(opt_id).unwrap();
-                        inner_type.ident()
-                    }
-                    _ => {
-                        arg_type.ident()
-                    }
-                };
+                let arg_type_name = arg_type.ident();
 
                 quote! {
                     if let Some(value) =

--- a/progenitor-impl/src/httpmock.rs
+++ b/progenitor-impl/src/httpmock.rs
@@ -160,20 +160,11 @@ impl Generator {
                  name, typ, kind, ..
              }| {
                 let arg_type_name = match typ {
-                    OperationParameterType::Type(arg_type_id) => {
-                        let arg_type =
-                            self.type_space.get_type(arg_type_id).unwrap();
-                        let arg_details = arg_type.details();
-                        let arg_type_name = match &arg_details {
-                            typify::TypeDetails::Option(opt_id) => {
-                                let inner_type =
-                                    self.type_space.get_type(opt_id).unwrap();
-                                inner_type.parameter_ident()
-                            }
-                            _ => arg_type.parameter_ident(),
-                        };
-                        arg_type_name
-                    }
+                    OperationParameterType::Type(arg_type_id) => self
+                        .type_space
+                        .get_type(arg_type_id)
+                        .unwrap()
+                        .parameter_ident(),
                     OperationParameterType::RawBody => quote! {
                         serde_json::Value
                     },


### PR DESCRIPTION
Prior to this change we represented optional parameters in the IR as a type from `typify` that was explicitly wrapped in an `Option<..>`:

https://github.com/oxidecomputer/progenitor/blob/6936ecc51a2d84e8adee21a003120a05513c6c20/progenitor-impl/src/method.rs#L2161-L2195

To summarize: we would create a JSON schema to make a type optional if it wasn't already. This caused many situations where we would then extract the inner type from that `Option` type.

With this change, the IR stores the raw type and we apply `Option` in the code generation if and when we want it.

Note that this should have no effect on the resulting output.