### PR TITLE
Support for `long_about` in `generated_cli`

### DIFF
--- a/progenitor-impl/src/cli.rs
+++ b/progenitor-impl/src/cli.rs
@@ -315,14 +315,14 @@ impl Generator {
         // TODO deal with all parameters?
 
         let about = method.summary.as_ref().map(|summary| {
-            let mut about_str = summary.clone();
-            if let Some(description) = &method.description {
-                about_str.push_str("\n\n");
-                about_str.push_str(description);
-            }
-
             quote! {
-                .about(#about_str)
+                .about(#summary)
+            }
+        });
+
+        let long_about = method.description.as_ref().map(|description| {
+            quote! {
+                .long_about(#description)
             }
         });
 
@@ -337,6 +337,7 @@ impl Generator {
                     .arg(#body_args)
                 )*
                 #about
+                #long_about
             }
         };
 

--- a/progenitor-impl/tests/output/nexus-cli.out
+++ b/progenitor-impl/tests/output/nexus-cli.out
@@ -225,7 +225,8 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(uuid::Uuid)),
             )
-            .about("Fetch a disk by id\n\nUse `GET /v1/disks/{disk}` instead")
+            .about("Fetch a disk by id")
+            .long_about("Use `GET /v1/disks/{disk}` instead")
     }
 
     pub fn cli_image_view_by_id() -> clap::Command {
@@ -269,9 +270,8 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(uuid::Uuid)),
             )
-            .about(
-                "Fetch an organization by id\n\nUse `GET /v1/organizations/{organization}` instead",
-            )
+            .about("Fetch an organization by id")
+            .long_about("Use `GET /v1/organizations/{organization}` instead")
     }
 
     pub fn cli_project_view_by_id() -> clap::Command {
@@ -282,7 +282,8 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(uuid::Uuid)),
             )
-            .about("Fetch a project by id\n\nUse `GET /v1/projects/{project}` instead")
+            .about("Fetch a project by id")
+            .long_about("Use `GET /v1/projects/{project}` instead")
     }
 
     pub fn cli_snapshot_view_by_id() -> clap::Command {
@@ -348,11 +349,11 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(uuid::Uuid)),
             )
-            .about(
-                "Start an OAuth 2.0 Device Authorization Grant\n\nThis endpoint is designed to be \
-                 accessed from an *unauthenticated* API client. It generates and records a \
-                 `device_code` and `user_code` which must be verified and confirmed prior to a \
-                 token being granted.",
+            .about("Start an OAuth 2.0 Device Authorization Grant")
+            .long_about(
+                "This endpoint is designed to be accessed from an *unauthenticated* API client. \
+                 It generates and records a `device_code` and `user_code` which must be verified \
+                 and confirmed prior to a token being granted.",
             )
     }
 
@@ -364,11 +365,11 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(String)),
             )
-            .about(
-                "Confirm an OAuth 2.0 Device Authorization Grant\n\nThis endpoint is designed to \
-                 be accessed by the user agent (browser), not the client requesting the token. So \
-                 we do not actually return the token here; it will be returned in response to the \
-                 poll on `/device/token`.",
+            .about("Confirm an OAuth 2.0 Device Authorization Grant")
+            .long_about(
+                "This endpoint is designed to be accessed by the user agent (browser), not the \
+                 client requesting the token. So we do not actually return the token here; it \
+                 will be returned in response to the poll on `/device/token`.",
             )
     }
 
@@ -392,9 +393,10 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(String)),
             )
-            .about(
-                "Request a device access token\n\nThis endpoint should be polled by the client \
-                 until the user code is verified and the grant is confirmed.",
+            .about("Request a device access token")
+            .long_about(
+                "This endpoint should be polled by the client until the user code is verified and \
+                 the grant is confirmed.",
             )
     }
 
@@ -467,9 +469,10 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(types::Name)),
             )
-            .about(
-                "Prompt user login\n\nEither display a page asking a user for their credentials, \
-                 or redirect them to their identity provider.",
+            .about("Prompt user login")
+            .long_about(
+                "Either display a page asking a user for their credentials, or redirect them to \
+                 their identity provider.",
             )
     }
 
@@ -516,7 +519,8 @@ impl Cli {
                         |s| types::NameOrIdSortMode::try_from(s).unwrap(),
                     )),
             )
-            .about("List organizations\n\nUse `GET /v1/organizations` instead")
+            .about("List organizations")
+            .long_about("Use `GET /v1/organizations` instead")
     }
 
     pub fn cli_organization_create() -> clap::Command {
@@ -533,7 +537,8 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(types::Name)),
             )
-            .about("Create an organization\n\nUse `POST /v1/organizations` instead")
+            .about("Create an organization")
+            .long_about("Use `POST /v1/organizations` instead")
     }
 
     pub fn cli_organization_view() -> clap::Command {
@@ -545,7 +550,8 @@ impl Cli {
                     .value_parser(clap::value_parser!(types::Name))
                     .help("The organization's unique name."),
             )
-            .about("Fetch an organization\n\nUse `GET /v1/organizations/{organization}` instead")
+            .about("Fetch an organization")
+            .long_about("Use `GET /v1/organizations/{organization}` instead")
     }
 
     pub fn cli_organization_update() -> clap::Command {
@@ -569,7 +575,8 @@ impl Cli {
                     .required(false)
                     .value_parser(clap::value_parser!(types::Name)),
             )
-            .about("Update an organization\n\nUse `PUT /v1/organizations/{organization}` instead")
+            .about("Update an organization")
+            .long_about("Use `PUT /v1/organizations/{organization}` instead")
     }
 
     pub fn cli_organization_delete() -> clap::Command {
@@ -581,9 +588,8 @@ impl Cli {
                     .value_parser(clap::value_parser!(types::Name))
                     .help("The organization's unique name."),
             )
-            .about(
-                "Delete an organization\n\nUse `DELETE /v1/organizations/{organization}` instead",
-            )
+            .about("Delete an organization")
+            .long_about("Use `DELETE /v1/organizations/{organization}` instead")
     }
 
     pub fn cli_organization_policy_view() -> clap::Command {
@@ -595,10 +601,8 @@ impl Cli {
                     .value_parser(clap::value_parser!(types::Name))
                     .help("The organization's unique name."),
             )
-            .about(
-                "Fetch an organization's IAM policy\n\nUse `GET \
-                 /v1/organizations/{organization}/policy` instead",
-            )
+            .about("Fetch an organization's IAM policy")
+            .long_about("Use `GET /v1/organizations/{organization}/policy` instead")
     }
 
     pub fn cli_organization_policy_update() -> clap::Command {
@@ -610,10 +614,8 @@ impl Cli {
                     .value_parser(clap::value_parser!(types::Name))
                     .help("The organization's unique name."),
             )
-            .about(
-                "Update an organization's IAM policy\n\nUse `PUT \
-                 /v1/organizations/{organization}/policy` instead",
-            )
+            .about("Update an organization's IAM policy")
+            .long_about("Use `PUT /v1/organizations/{organization}/policy` instead")
     }
 
     pub fn cli_project_list() -> clap::Command {
@@ -645,7 +647,8 @@ impl Cli {
                         |s| types::NameOrIdSortMode::try_from(s).unwrap(),
                     )),
             )
-            .about("List projects\n\nUse `GET /v1/projects` instead")
+            .about("List projects")
+            .long_about("Use `GET /v1/projects` instead")
     }
 
     pub fn cli_project_create() -> clap::Command {
@@ -669,7 +672,8 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(types::Name)),
             )
-            .about("Create a project\n\nUse `POST /v1/projects` instead")
+            .about("Create a project")
+            .long_about("Use `POST /v1/projects` instead")
     }
 
     pub fn cli_project_view() -> clap::Command {
@@ -688,7 +692,8 @@ impl Cli {
                     .value_parser(clap::value_parser!(types::Name))
                     .help("The project's unique name within the organization."),
             )
-            .about("Fetch a project\n\nUse `GET /v1/projects/{project}` instead")
+            .about("Fetch a project")
+            .long_about("Use `GET /v1/projects/{project}` instead")
     }
 
     pub fn cli_project_update() -> clap::Command {
@@ -719,7 +724,8 @@ impl Cli {
                     .required(false)
                     .value_parser(clap::value_parser!(types::Name)),
             )
-            .about("Update a project\n\nUse `PUT /v1/projects/{project}` instead")
+            .about("Update a project")
+            .long_about("Use `PUT /v1/projects/{project}` instead")
     }
 
     pub fn cli_project_delete() -> clap::Command {
@@ -738,7 +744,8 @@ impl Cli {
                     .value_parser(clap::value_parser!(types::Name))
                     .help("The project's unique name within the organization."),
             )
-            .about("Delete a project\n\nUse `DELETE /v1/projects/{project}` instead")
+            .about("Delete a project")
+            .long_about("Use `DELETE /v1/projects/{project}` instead")
     }
 
     pub fn cli_disk_list() -> clap::Command {
@@ -775,7 +782,8 @@ impl Cli {
                         |s| types::NameSortMode::try_from(s).unwrap(),
                     )),
             )
-            .about("List disks\n\nUse `GET /v1/disks` instead")
+            .about("List disks")
+            .long_about("Use `GET /v1/disks` instead")
     }
 
     pub fn cli_disk_create() -> clap::Command {
@@ -836,7 +844,8 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(types::Name)),
             )
-            .about("Fetch a disk\n\nUse `GET /v1/disks/{disk}` instead")
+            .about("Fetch a disk")
+            .long_about("Use `GET /v1/disks/{disk}` instead")
     }
 
     pub fn cli_disk_delete() -> clap::Command {
@@ -956,9 +965,10 @@ impl Cli {
                         |s| types::NameSortMode::try_from(s).unwrap(),
                     )),
             )
-            .about(
-                "List images\n\nList images in a project. The images are returned sorted by \
-                 creation date, with the most recent images appearing first.",
+            .about("List images")
+            .long_about(
+                "List images in a project. The images are returned sorted by creation date, with \
+                 the most recent images appearing first.",
             )
     }
 
@@ -990,7 +1000,8 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(types::Name)),
             )
-            .about("Create an image\n\nCreate a new image in a project.")
+            .about("Create an image")
+            .long_about("Create a new image in a project.")
     }
 
     pub fn cli_image_view() -> clap::Command {
@@ -1013,7 +1024,8 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(types::Name)),
             )
-            .about("Fetch an image\n\nFetch the details for a specific image in a project.")
+            .about("Fetch an image")
+            .long_about("Fetch the details for a specific image in a project.")
     }
 
     pub fn cli_image_delete() -> clap::Command {
@@ -1036,10 +1048,11 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(types::Name)),
             )
-            .about(
-                "Delete an image\n\nPermanently delete an image from a project. This operation \
-                 cannot be undone. Any instances in the project using the image will continue to \
-                 run, however new instances can not be created with this image.",
+            .about("Delete an image")
+            .long_about(
+                "Permanently delete an image from a project. This operation cannot be undone. Any \
+                 instances in the project using the image will continue to run, however new \
+                 instances can not be created with this image.",
             )
     }
 
@@ -1144,7 +1157,8 @@ impl Cli {
                          characters with padding). Maximum 32 KiB unencoded data.",
                     ),
             )
-            .about("Create an instance\n\nUse `POST /v1/instances` instead")
+            .about("Create an instance")
+            .long_about("Use `POST /v1/instances` instead")
     }
 
     pub fn cli_instance_view() -> clap::Command {
@@ -1167,7 +1181,8 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(types::Name)),
             )
-            .about("Fetch an instance\n\nUse `GET /v1/instances/{instance}` instead")
+            .about("Fetch an instance")
+            .long_about("Use `GET /v1/instances/{instance}` instead")
     }
 
     pub fn cli_instance_delete() -> clap::Command {
@@ -1231,7 +1246,8 @@ impl Cli {
                         |s| types::NameSortMode::try_from(s).unwrap(),
                     )),
             )
-            .about("List an instance's disks\n\nUse `GET /v1/instances/{instance}/disks` instead")
+            .about("List an instance's disks")
+            .long_about("Use `GET /v1/instances/{instance}/disks` instead")
     }
 
     pub fn cli_instance_disk_attach() -> clap::Command {
@@ -1260,10 +1276,8 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(types::Name)),
             )
-            .about(
-                "Attach a disk to an instance\n\nUse `POST /v1/instances/{instance}/disks/attach` \
-                 instead",
-            )
+            .about("Attach a disk to an instance")
+            .long_about("Use `POST /v1/instances/{instance}/disks/attach` instead")
     }
 
     pub fn cli_instance_disk_detach() -> clap::Command {
@@ -1292,7 +1306,8 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(types::Name)),
             )
-            .about("Detach a disk from an instance\n\nUse `POST /v1/disks/{disk}/detach` instead")
+            .about("Detach a disk from an instance")
+            .long_about("Use `POST /v1/disks/{disk}/detach` instead")
     }
 
     pub fn cli_instance_external_ip_list() -> clap::Command {
@@ -1344,7 +1359,8 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(uuid::Uuid)),
             )
-            .about("Migrate an instance\n\nUse `POST /v1/instances/{instance}/migrate` instead")
+            .about("Migrate an instance")
+            .long_about("Use `POST /v1/instances/{instance}/migrate` instead")
     }
 
     pub fn cli_instance_network_interface_list() -> clap::Command {
@@ -1559,11 +1575,11 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(types::Name)),
             )
-            .about(
-                "Delete a network interface\n\nNote that the primary interface for an instance \
-                 cannot be deleted if there are any secondary interfaces. A new primary interface \
-                 must be designated first. The primary interface can be deleted if there are no \
-                 secondary interfaces.",
+            .about("Delete a network interface")
+            .long_about(
+                "Note that the primary interface for an instance cannot be deleted if there are \
+                 any secondary interfaces. A new primary interface must be designated first. The \
+                 primary interface can be deleted if there are no secondary interfaces.",
             )
     }
 
@@ -1587,7 +1603,8 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(types::Name)),
             )
-            .about("Reboot an instance\n\nUse `POST /v1/instances/{instance}/reboot` instead")
+            .about("Reboot an instance")
+            .long_about("Use `POST /v1/instances/{instance}/reboot` instead")
     }
 
     pub fn cli_instance_serial_console() -> clap::Command {
@@ -1644,10 +1661,8 @@ impl Cli {
                          instance. (See note on `from_start` about mutual exclusivity)",
                     ),
             )
-            .about(
-                "Fetch an instance's serial console\n\nUse `GET \
-                 /v1/instances/{instance}/serial-console` instead",
-            )
+            .about("Fetch an instance's serial console")
+            .long_about("Use `GET /v1/instances/{instance}/serial-console` instead")
     }
 
     pub fn cli_instance_serial_console_stream() -> clap::Command {
@@ -1670,10 +1685,8 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(types::Name)),
             )
-            .about(
-                "Connect to an instance's serial console\n\nUse `GET \
-                 /v1/instances/{instance}/serial-console/stream` instead",
-            )
+            .about("Connect to an instance's serial console")
+            .long_about("Use `GET /v1/instances/{instance}/serial-console/stream` instead")
     }
 
     pub fn cli_instance_start() -> clap::Command {
@@ -1696,7 +1709,8 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(types::Name)),
             )
-            .about("Boot an instance\n\nUse `POST /v1/instances/{instance}/start` instead")
+            .about("Boot an instance")
+            .long_about("Use `POST /v1/instances/{instance}/start` instead")
     }
 
     pub fn cli_instance_stop() -> clap::Command {
@@ -1719,7 +1733,8 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(types::Name)),
             )
-            .about("Halt an instance\n\nUse `POST /v1/instances/{instance}/stop` instead")
+            .about("Halt an instance")
+            .long_about("Use `POST /v1/instances/{instance}/stop` instead")
     }
 
     pub fn cli_project_policy_view() -> clap::Command {
@@ -1738,9 +1753,8 @@ impl Cli {
                     .value_parser(clap::value_parser!(types::Name))
                     .help("The project's unique name within the organization."),
             )
-            .about(
-                "Fetch a project's IAM policy\n\nUse `GET /v1/projects/{project}/policy` instead",
-            )
+            .about("Fetch a project's IAM policy")
+            .long_about("Use `GET /v1/projects/{project}/policy` instead")
     }
 
     pub fn cli_project_policy_update() -> clap::Command {
@@ -1834,7 +1848,8 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(types::Name)),
             )
-            .about("Create a snapshot\n\nCreates a point-in-time snapshot from a disk.")
+            .about("Create a snapshot")
+            .long_about("Creates a point-in-time snapshot from a disk.")
     }
 
     pub fn cli_snapshot_view() -> clap::Command {
@@ -2321,7 +2336,8 @@ impl Cli {
                         |s| types::NameSortMode::try_from(s).unwrap(),
                     )),
             )
-            .about("List routes\n\nList the routes associated with a router in a particular VPC.")
+            .about("List routes")
+            .long_about("List the routes associated with a router in a particular VPC.")
     }
 
     pub fn cli_vpc_router_route_create() -> clap::Command {
@@ -2806,10 +2822,8 @@ impl Cli {
                         |s| types::NameSortMode::try_from(s).unwrap(),
                     )),
             )
-            .about(
-                "List SSH public keys\n\nLists SSH public keys for the currently authenticated \
-                 user.",
-            )
+            .about("List SSH public keys")
+            .long_about("Lists SSH public keys for the currently authenticated user.")
     }
 
     pub fn cli_session_sshkey_create() -> clap::Command {
@@ -2833,10 +2847,8 @@ impl Cli {
                     .value_parser(clap::value_parser!(String))
                     .help("SSH public key, e.g., `\"ssh-ed25519 AAAAC3NzaC...\"`"),
             )
-            .about(
-                "Create an SSH public key\n\nCreate an SSH public key for the currently \
-                 authenticated user.",
-            )
+            .about("Create an SSH public key")
+            .long_about("Create an SSH public key for the currently authenticated user.")
     }
 
     pub fn cli_session_sshkey_view() -> clap::Command {
@@ -2847,10 +2859,8 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(types::Name)),
             )
-            .about(
-                "Fetch an SSH public key\n\nFetch an SSH public key associated with the currently \
-                 authenticated user.",
-            )
+            .about("Fetch an SSH public key")
+            .long_about("Fetch an SSH public key associated with the currently authenticated user.")
     }
 
     pub fn cli_session_sshkey_delete() -> clap::Command {
@@ -2861,9 +2871,9 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(types::Name)),
             )
-            .about(
-                "Delete an SSH public key\n\nDelete an SSH public key associated with the \
-                 currently authenticated user.",
+            .about("Delete an SSH public key")
+            .long_about(
+                "Delete an SSH public key associated with the currently authenticated user.",
             )
     }
 
@@ -2920,10 +2930,11 @@ impl Cli {
                         |s| types::NameSortMode::try_from(s).unwrap(),
                     )),
             )
-            .about(
-                "List system-wide certificates\n\nReturns a list of all the system-wide \
-                 certificates. System-wide certificates are returned sorted by creation date, \
-                 with the most recent certificates appearing first.",
+            .about("List system-wide certificates")
+            .long_about(
+                "Returns a list of all the system-wide certificates. System-wide certificates are \
+                 returned sorted by creation date, with the most recent certificates appearing \
+                 first.",
             )
     }
 
@@ -2953,9 +2964,10 @@ impl Cli {
                     ))
                     .help("The service using this certificate"),
             )
-            .about(
-                "Create a new system-wide x.509 certificate.\n\nThis certificate is automatically \
-                 used by the Oxide Control plane to serve external connections.",
+            .about("Create a new system-wide x.509 certificate.")
+            .long_about(
+                "This certificate is automatically used by the Oxide Control plane to serve \
+                 external connections.",
             )
     }
 
@@ -2967,7 +2979,8 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(types::NameOrId)),
             )
-            .about("Fetch a certificate\n\nReturns the details of a specific certificate")
+            .about("Fetch a certificate")
+            .long_about("Returns the details of a specific certificate")
     }
 
     pub fn cli_certificate_delete() -> clap::Command {
@@ -2978,10 +2991,8 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(types::NameOrId)),
             )
-            .about(
-                "Delete a certificate\n\nPermanently delete a certificate. This operation cannot \
-                 be undone.",
-            )
+            .about("Delete a certificate")
+            .long_about("Permanently delete a certificate. This operation cannot be undone.")
     }
 
     pub fn cli_physical_disk_list() -> clap::Command {
@@ -3127,10 +3138,10 @@ impl Cli {
                         |s| types::NameSortMode::try_from(s).unwrap(),
                     )),
             )
-            .about(
-                "List system-wide images\n\nReturns a list of all the system-wide images. \
-                 System-wide images are returned sorted by creation date, with the most recent \
-                 images appearing first.",
+            .about("List system-wide images")
+            .long_about(
+                "Returns a list of all the system-wide images. System-wide images are returned \
+                 sorted by creation date, with the most recent images appearing first.",
             )
     }
 
@@ -3148,9 +3159,10 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(types::Name)),
             )
-            .about(
-                "Create a system-wide image\n\nCreate a new system-wide image. This image can \
-                 then be used by any user in any silo as a base for instances.",
+            .about("Create a system-wide image")
+            .long_about(
+                "Create a new system-wide image. This image can then be used by any user in any \
+                 silo as a base for instances.",
             )
     }
 
@@ -3162,9 +3174,8 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(types::Name)),
             )
-            .about(
-                "Fetch a system-wide image\n\nReturns the details of a specific system-wide image.",
-            )
+            .about("Fetch a system-wide image")
+            .long_about("Returns the details of a specific system-wide image.")
     }
 
     pub fn cli_system_image_delete() -> clap::Command {
@@ -3175,10 +3186,11 @@ impl Cli {
                     .required(true)
                     .value_parser(clap::value_parser!(types::Name)),
             )
-            .about(
-                "Delete a system-wide image\n\nPermanently delete a system-wide image. This \
-                 operation cannot be undone. Any instances using the system-wide image will \
-                 continue to run, however new instances can not be created with this image.",
+            .about("Delete a system-wide image")
+            .long_about(
+                "Permanently delete a system-wide image. This operation cannot be undone. Any \
+                 instances using the system-wide image will continue to run, however new \
+                 instances can not be created with this image.",
             )
     }
 
@@ -3284,7 +3296,8 @@ impl Cli {
                     .value_parser(clap::value_parser!(std::num::NonZeroU32))
                     .help("Maximum number of items returned by a single call"),
             )
-            .about("List ranges for an IP pool\n\nRanges are ordered by their first address.")
+            .about("List ranges for an IP pool")
+            .long_about("Ranges are ordered by their first address.")
     }
 
     pub fn cli_ip_pool_range_add() -> clap::Command {
@@ -3322,10 +3335,8 @@ impl Cli {
                     .value_parser(clap::value_parser!(std::num::NonZeroU32))
                     .help("Maximum number of items returned by a single call"),
             )
-            .about(
-                "List ranges for the IP pool used for Oxide services.\n\nRanges are ordered by \
-                 their first address.",
-            )
+            .about("List ranges for the IP pool used for Oxide services.")
+            .long_about("Ranges are ordered by their first address.")
     }
 
     pub fn cli_ip_pool_service_range_add() -> clap::Command {
@@ -3453,9 +3464,8 @@ impl Cli {
                         |s| types::NameOrIdSortMode::try_from(s).unwrap(),
                     )),
             )
-            .about(
-                "List silos\n\nLists silos that are discoverable based on the current permissions.",
-            )
+            .about("List silos")
+            .long_about("Lists silos that are discoverable based on the current permissions.")
     }
 
     pub fn cli_silo_create() -> clap::Command {
@@ -3516,7 +3526,8 @@ impl Cli {
                     .value_parser(clap::value_parser!(types::Name))
                     .help("The silo's unique name."),
             )
-            .about("Fetch a silo\n\nFetch a silo by name.")
+            .about("Fetch a silo")
+            .long_about("Fetch a silo by name.")
     }
 
     pub fn cli_silo_delete() -> clap::Command {
@@ -3528,7 +3539,8 @@ impl Cli {
                     .value_parser(clap::value_parser!(types::Name))
                     .help("The silo's unique name."),
             )
-            .about("Delete a silo\n\nDelete a silo by name.")
+            .about("Delete a silo")
+            .long_about("Delete a silo by name.")
     }
 
     pub fn cli_silo_identity_provider_list() -> clap::Command {
@@ -3577,10 +3589,11 @@ impl Cli {
                     .value_parser(clap::value_parser!(types::UserId))
                     .help("username used to log in"),
             )
-            .about(
-                "Create a user\n\nUsers can only be created in Silos with `provision_type` == \
-                 `Fixed`. Otherwise, Silo users are just-in-time (JIT) provisioned when a user \
-                 first logs in using an external Identity Provider.",
+            .about("Create a user")
+            .long_about(
+                "Users can only be created in Silos with `provision_type` == `Fixed`. Otherwise, \
+                 Silo users are just-in-time (JIT) provisioned when a user first logs in using an \
+                 external Identity Provider.",
             )
     }
 
@@ -3619,9 +3632,9 @@ impl Cli {
                     .value_parser(clap::value_parser!(uuid::Uuid))
                     .help("The user's internal id"),
             )
-            .about(
-                "Set or invalidate a user's password\n\nPasswords can only be updated for users \
-                 in Silos with identity mode `LocalOnly`.",
+            .about("Set or invalidate a user's password")
+            .long_about(
+                "Passwords can only be updated for users in Silos with identity mode `LocalOnly`.",
             )
     }
 
@@ -4737,7 +4750,8 @@ impl Cli {
 
     pub fn cli_system_update_stop() -> clap::Command {
         clap::Command::new("")
-            .about("Stop system update\n\nIf there is no update in progress, do nothing.")
+            .about("Stop system update")
+            .long_about("If there is no update in progress, do nothing.")
     }
 
     pub fn cli_system_update_list() -> clap::Command {

--- a/progenitor-impl/tests/output/param-overrides-cli.out
+++ b/progenitor-impl/tests/output/param-overrides-cli.out
@@ -30,6 +30,7 @@ impl Cli {
                     .value_parser(clap::value_parser!(String))
                     .help("A key parameter that will not be overridden by the path spec"),
             )
+            .long_about("Gets a key")
     }
 }
 


### PR DESCRIPTION
Currently the generator is combining the `summary` and `description` in `about`.

This PR maps `summary` -> `about` and `description` to `long_about` to more closely reflect the OpenAPI schema.