### PR TITLE
allow request mutation and async code in prehooks

### DIFF
--- a/example-macro/src/main.rs
+++ b/example-macro/src/main.rs
@@ -8,9 +8,26 @@ generate_api!(
     pre_hook = (|_, request| {
         println!("doing this {:?}", request);
     }),
+    pre_hook_async = crate::add_auth_headers,
     post_hook = crate::all_done,
     derives = [schemars::JsonSchema],
 );
+
+async fn add_auth_headers(
+    _: &(),
+    req: &mut reqwest::Request,
+) -> Result<(), reqwest::header::InvalidHeaderValue> {
+    // You can perform asynchronous, fallible work in a request hook, then
+    // modify the request right before it is transmitted to the server; e.g.,
+    // for generating an authenticaiton signature based on the complete set of
+    // request header values:
+    req.headers_mut().insert(
+        reqwest::header::AUTHORIZATION,
+        reqwest::header::HeaderValue::from_str("legitimate")?,
+    );
+
+    Ok(())
+}
 
 fn all_done(_: &(), _result: &reqwest::Result<reqwest::Response>) {}
 

--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -249,6 +249,9 @@ pub enum Error<E = ()> {
     /// A response not listed in the API description. This may represent a
     /// success or failure response; check `status().is_success()`.
     UnexpectedResponse(reqwest::Response),
+
+    /// An error occurred in the processing of a request pre-hook.
+    PreHookError(String),
 }
 
 impl<E> Error<E> {
@@ -256,6 +259,7 @@ impl<E> Error<E> {
     pub fn status(&self) -> Option<reqwest::StatusCode> {
         match self {
             Error::InvalidRequest(_) => None,
+            Error::PreHookError(_) => None,
             Error::CommunicationError(e) => e.status(),
             Error::ErrorResponse(rv) => Some(rv.status()),
             Error::InvalidUpgrade(e) => e.status(),
@@ -272,6 +276,7 @@ impl<E> Error<E> {
     pub fn into_untyped(self) -> Error {
         match self {
             Error::InvalidRequest(s) => Error::InvalidRequest(s),
+            Error::PreHookError(s) => Error::PreHookError(s),
             Error::CommunicationError(e) => Error::CommunicationError(e),
             Error::ErrorResponse(ResponseValue {
                 inner: _,
@@ -331,6 +336,9 @@ where
             }
             Error::UnexpectedResponse(r) => {
                 write!(f, "Unexpected Response: {:?}", r)
+            }
+            Error::PreHookError(s) => {
+                write!(f, "Pre-hook Error: {}", s)
             }
         }
     }

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -60,6 +60,7 @@ pub struct GenerationSettings {
     tag: TagStyle,
     inner_type: Option<TokenStream>,
     pre_hook: Option<TokenStream>,
+    pre_hook_async: Option<TokenStream>,
     post_hook: Option<TokenStream>,
     extra_derives: Vec<String>,
 
@@ -125,6 +126,12 @@ impl GenerationSettings {
     /// Hook invoked before issuing the HTTP request.
     pub fn with_pre_hook(&mut self, pre_hook: TokenStream) -> &mut Self {
         self.pre_hook = Some(pre_hook);
+        self
+    }
+
+    /// Hook invoked before issuing the HTTP request.
+    pub fn with_pre_hook_async(&mut self, pre_hook: TokenStream) -> &mut Self {
+        self.pre_hook_async = Some(pre_hook);
         self
     }
 

--- a/progenitor-impl/tests/output/src/buildomat_builder.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder.rs
@@ -2404,7 +2404,8 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/control/hold", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -2438,7 +2439,8 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/control/resume", client.baseurl,);
-            let request = client.client.post(url).build()?;
+            #[allow(unused_mut)]
+            let mut request = client.client.post(url).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -2484,7 +2486,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -2518,7 +2521,8 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<Vec<types::Task>>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/tasks", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -2579,7 +2583,8 @@ pub mod builder {
                 .and_then(|v| types::TaskSubmit::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/tasks", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -2655,7 +2660,8 @@ pub mod builder {
             if let Some(v) = &minseq {
                 query.push(("minseq", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -2709,7 +2715,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -2780,7 +2787,8 @@ pub mod builder {
                 encode_path(&task.to_string()),
                 encode_path(&output.to_string()),
             );
-            let request = client.client.get(url).build()?;
+            #[allow(unused_mut)]
+            let mut request = client.client.get(url).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -2834,7 +2842,8 @@ pub mod builder {
                 .and_then(|v| types::UserCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/users", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -2869,7 +2878,8 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/whoami", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -2919,7 +2929,8 @@ pub mod builder {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/whoami/name", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -2981,7 +2992,8 @@ pub mod builder {
                 .and_then(|v| types::WorkerBootstrap::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/worker/bootstrap", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -3016,7 +3028,8 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/worker/ping", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -3096,7 +3109,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let request = client.client.post(url).json(&body).build()?;
+            #[allow(unused_mut)]
+            let mut request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -3155,7 +3169,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -3240,7 +3255,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let request = client.client.post(url).json(&body).build()?;
+            #[allow(unused_mut)]
+            let mut request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -3311,7 +3327,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let request = client.client.post(url).json(&body).build()?;
+            #[allow(unused_mut)]
+            let mut request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -3338,7 +3355,8 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/workers", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -3372,7 +3390,8 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/workers/recycle", client.baseurl,);
-            let request = client.client.post(url).build()?;
+            #[allow(unused_mut)]
+            let mut request = client.client.post(url).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {

--- a/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
@@ -2404,7 +2404,8 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/control/hold", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -2438,7 +2439,8 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/control/resume", client.baseurl,);
-            let request = client.client.post(url).build()?;
+            #[allow(unused_mut)]
+            let mut request = client.client.post(url).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -2484,7 +2486,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -2518,7 +2521,8 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<Vec<types::Task>>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/tasks", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -2579,7 +2583,8 @@ pub mod builder {
                 .and_then(|v| types::TaskSubmit::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/tasks", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -2655,7 +2660,8 @@ pub mod builder {
             if let Some(v) = &minseq {
                 query.push(("minseq", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -2709,7 +2715,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -2780,7 +2787,8 @@ pub mod builder {
                 encode_path(&task.to_string()),
                 encode_path(&output.to_string()),
             );
-            let request = client.client.get(url).build()?;
+            #[allow(unused_mut)]
+            let mut request = client.client.get(url).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -2834,7 +2842,8 @@ pub mod builder {
                 .and_then(|v| types::UserCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/users", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -2869,7 +2878,8 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/whoami", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -2919,7 +2929,8 @@ pub mod builder {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/whoami/name", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -2981,7 +2992,8 @@ pub mod builder {
                 .and_then(|v| types::WorkerBootstrap::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/worker/bootstrap", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -3016,7 +3028,8 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/worker/ping", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -3096,7 +3109,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let request = client.client.post(url).json(&body).build()?;
+            #[allow(unused_mut)]
+            let mut request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -3155,7 +3169,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -3240,7 +3255,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let request = client.client.post(url).json(&body).build()?;
+            #[allow(unused_mut)]
+            let mut request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -3311,7 +3327,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let request = client.client.post(url).json(&body).build()?;
+            #[allow(unused_mut)]
+            let mut request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -3338,7 +3355,8 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/workers", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -3372,7 +3390,8 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
             let url = format!("{}/v1/workers/recycle", client.baseurl,);
-            let request = client.client.post(url).build()?;
+            #[allow(unused_mut)]
+            let mut request = client.client.post(url).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {

--- a/progenitor-impl/tests/output/src/buildomat_positional.rs
+++ b/progenitor-impl/tests/output/src/buildomat_positional.rs
@@ -827,7 +827,8 @@ impl Client {
     ///Sends a `POST` request to `/v1/control/hold`
     pub async fn control_hold<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/v1/control/hold", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -846,7 +847,8 @@ impl Client {
     ///Sends a `POST` request to `/v1/control/resume`
     pub async fn control_resume<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/v1/control/resume", self.baseurl,);
-        let request = self.client.post(url).build()?;
+        #[allow(unused_mut)]
+        let mut request = self.client.post(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -865,7 +867,8 @@ impl Client {
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -884,7 +887,8 @@ impl Client {
     ///Sends a `GET` request to `/v1/tasks`
     pub async fn tasks_get<'a>(&'a self) -> Result<ResponseValue<Vec<types::Task>>, Error<()>> {
         let url = format!("{}/v1/tasks", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -906,7 +910,8 @@ impl Client {
         body: &'a types::TaskSubmit,
     ) -> Result<ResponseValue<types::TaskSubmitResult>, Error<()>> {
         let url = format!("{}/v1/tasks", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -939,7 +944,8 @@ impl Client {
             query.push(("minseq", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -966,7 +972,8 @@ impl Client {
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -994,7 +1001,8 @@ impl Client {
             encode_path(&task.to_string()),
             encode_path(&output.to_string()),
         );
-        let request = self.client.get(url).build()?;
+        #[allow(unused_mut)]
+        let mut request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -1009,7 +1017,8 @@ impl Client {
         body: &'a types::UserCreate,
     ) -> Result<ResponseValue<types::UserCreateResult>, Error<()>> {
         let url = format!("{}/v1/users", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -1029,7 +1038,8 @@ impl Client {
     ///Sends a `GET` request to `/v1/whoami`
     pub async fn whoami<'a>(&'a self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
         let url = format!("{}/v1/whoami", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -1051,7 +1061,8 @@ impl Client {
         body: String,
     ) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/v1/whoami/name", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .put(url)
             .header(
@@ -1074,7 +1085,8 @@ impl Client {
         body: &'a types::WorkerBootstrap,
     ) -> Result<ResponseValue<types::WorkerBootstrapResult>, Error<()>> {
         let url = format!("{}/v1/worker/bootstrap", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -1096,7 +1108,8 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
         let url = format!("{}/v1/worker/ping", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -1123,7 +1136,8 @@ impl Client {
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let request = self.client.post(url).json(&body).build()?;
+        #[allow(unused_mut)]
+        let mut request = self.client.post(url).json(&body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -1143,7 +1157,8 @@ impl Client {
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -1175,7 +1190,8 @@ impl Client {
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let request = self.client.post(url).json(&body).build()?;
+        #[allow(unused_mut)]
+        let mut request = self.client.post(url).json(&body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -1195,7 +1211,8 @@ impl Client {
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let request = self.client.post(url).json(&body).build()?;
+        #[allow(unused_mut)]
+        let mut request = self.client.post(url).json(&body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -1209,7 +1226,8 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
         let url = format!("{}/v1/workers", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -1228,7 +1246,8 @@ impl Client {
     ///Sends a `POST` request to `/v1/workers/recycle`
     pub async fn workers_recycle<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/v1/workers/recycle", self.baseurl,);
-        let request = self.client.post(url).build()?;
+        #[allow(unused_mut)]
+        let mut request = self.client.post(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {

--- a/progenitor-impl/tests/output/src/keeper_builder.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder.rs
@@ -1436,7 +1436,8 @@ pub mod builder {
             let url = format!("{}/enrol", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .json(&body)
@@ -1488,7 +1489,8 @@ pub mod builder {
             let url = format!("{}/global/jobs", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -1543,7 +1545,8 @@ pub mod builder {
             let url = format!("{}/ping", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -1626,7 +1629,8 @@ pub mod builder {
             let url = format!("{}/report/finish", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -1710,7 +1714,8 @@ pub mod builder {
             let url = format!("{}/report/output", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -1792,7 +1797,8 @@ pub mod builder {
             let url = format!("{}/report/start", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(

--- a/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
@@ -1436,7 +1436,8 @@ pub mod builder {
             let url = format!("{}/enrol", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .json(&body)
@@ -1488,7 +1489,8 @@ pub mod builder {
             let url = format!("{}/global/jobs", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -1543,7 +1545,8 @@ pub mod builder {
             let url = format!("{}/ping", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -1626,7 +1629,8 @@ pub mod builder {
             let url = format!("{}/report/finish", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -1710,7 +1714,8 @@ pub mod builder {
             let url = format!("{}/report/output", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -1792,7 +1797,8 @@ pub mod builder {
             let url = format!("{}/report/start", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(

--- a/progenitor-impl/tests/output/src/keeper_positional.rs
+++ b/progenitor-impl/tests/output/src/keeper_positional.rs
@@ -524,7 +524,8 @@ impl Client {
         let url = format!("{}/enrol", self.baseurl,);
         let mut header_map = HeaderMap::with_capacity(1usize);
         header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .json(&body)
@@ -549,7 +550,8 @@ impl Client {
         let url = format!("{}/global/jobs", self.baseurl,);
         let mut header_map = HeaderMap::with_capacity(1usize);
         header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -577,7 +579,8 @@ impl Client {
         let url = format!("{}/ping", self.baseurl,);
         let mut header_map = HeaderMap::with_capacity(1usize);
         header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -607,7 +610,8 @@ impl Client {
         let url = format!("{}/report/finish", self.baseurl,);
         let mut header_map = HeaderMap::with_capacity(1usize);
         header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -638,7 +642,8 @@ impl Client {
         let url = format!("{}/report/output", self.baseurl,);
         let mut header_map = HeaderMap::with_capacity(1usize);
         header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -669,7 +674,8 @@ impl Client {
         let url = format!("{}/report/start", self.baseurl,);
         let mut header_map = HeaderMap::with_capacity(1usize);
         header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(

--- a/progenitor-impl/tests/output/src/nexus_builder.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder.rs
@@ -28713,7 +28713,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -28772,7 +28773,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -28831,7 +28833,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -28892,7 +28895,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -28951,7 +28955,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -29010,7 +29015,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -29069,7 +29075,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -29128,7 +29135,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -29187,7 +29195,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -29246,7 +29255,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -29305,7 +29315,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -29374,7 +29385,8 @@ pub mod builder {
                 .and_then(|v| types::DeviceAuthRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/device/auth", client.baseurl,);
-            let request = client.client.post(url).form_urlencoded(&body)?.build()?;
+            #[allow(unused_mut)]
+            let mut request = client.client.post(url).form_urlencoded(&body)?.build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -29430,7 +29442,8 @@ pub mod builder {
                 .and_then(|v| types::DeviceAuthVerify::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/device/confirm", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -29504,7 +29517,8 @@ pub mod builder {
                 })
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/device/token", client.baseurl,);
-            let request = client.client.post(url).form_urlencoded(&body)?.build()?;
+            #[allow(unused_mut)]
+            let mut request = client.client.post(url).form_urlencoded(&body)?.build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -29591,7 +29605,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -29715,7 +29730,8 @@ pub mod builder {
                 .and_then(|v| types::SpoofLoginBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/login", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -29811,7 +29827,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let request = client.client.post(url).json(&body).build()?;
+            #[allow(unused_mut)]
+            let mut request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -29881,7 +29898,8 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let request = client.client.get(url).build()?;
+            #[allow(unused_mut)]
+            let mut request = client.client.get(url).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -29965,7 +29983,8 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -30006,7 +30025,8 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/logout", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -30106,7 +30126,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -30232,7 +30253,8 @@ pub mod builder {
                 .and_then(|v| types::OrganizationCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/organizations", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -30295,7 +30317,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -30385,7 +30408,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -30448,7 +30472,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -30512,7 +30537,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -30606,7 +30632,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -30726,7 +30753,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -30873,7 +30901,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -30952,7 +30981,8 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -31056,7 +31086,8 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -31135,7 +31166,8 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -31269,7 +31301,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -31431,7 +31464,8 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -31526,7 +31560,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -31620,7 +31655,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -31804,7 +31840,8 @@ pub mod builder {
             if let Some(v) = &start_time {
                 query.push(("start_time", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -31998,7 +32035,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -32160,7 +32198,8 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -32255,7 +32294,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -32349,7 +32389,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -32484,7 +32525,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -32648,7 +32690,8 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -32743,7 +32786,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -32837,7 +32881,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -32987,7 +33032,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -33166,7 +33212,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -33287,7 +33334,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -33384,7 +33432,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -33504,7 +33553,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -33656,7 +33706,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -33841,7 +33892,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -33953,7 +34005,8 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -34094,7 +34147,8 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -34204,7 +34258,8 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -34298,7 +34353,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -34449,7 +34505,8 @@ pub mod builder {
             if let Some(v) = &most_recent {
                 query.push(("most_recent", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -34546,7 +34603,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(reqwest::header::CONNECTION, "Upgrade")
@@ -34641,7 +34699,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -34735,7 +34794,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -34815,7 +34875,8 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -34923,7 +34984,8 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -35059,7 +35121,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -35223,7 +35286,8 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -35318,7 +35382,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -35412,7 +35477,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -35546,7 +35612,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -35708,7 +35775,8 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -35803,7 +35871,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -35923,7 +35992,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -36018,7 +36088,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -36114,7 +36185,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -36243,7 +36315,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -36394,7 +36467,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -36573,7 +36647,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -36683,7 +36758,8 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -36818,7 +36894,8 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -36928,7 +37005,8 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -37093,7 +37171,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -37293,7 +37372,8 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -37418,7 +37498,8 @@ pub mod builder {
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -37574,7 +37655,8 @@ pub mod builder {
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -37699,7 +37781,8 @@ pub mod builder {
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -37849,7 +37932,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -38028,7 +38112,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -38138,7 +38223,8 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -38273,7 +38359,8 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -38383,7 +38470,8 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -38549,7 +38637,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -38650,7 +38739,8 @@ pub mod builder {
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/policy", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -38719,7 +38809,8 @@ pub mod builder {
                 .and_then(|v| types::SiloRolePolicy::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/policy", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -38802,7 +38893,8 @@ pub mod builder {
             if let Some(v) = &page_token {
                 query.push(("page_token", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -38917,7 +39009,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&role_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -38957,7 +39050,8 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/session/me", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -39057,7 +39151,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -39214,7 +39309,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -39338,7 +39434,8 @@ pub mod builder {
                 .and_then(|v| types::SshKeyCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/sshkeys", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -39401,7 +39498,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -39463,7 +39561,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -39522,7 +39621,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -39581,7 +39681,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -39640,7 +39741,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -39740,7 +39842,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -39866,7 +39969,8 @@ pub mod builder {
                 .and_then(|v| types::CertificateCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/certificates", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -39929,7 +40033,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&certificate.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -39991,7 +40096,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&certificate.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -40091,7 +40197,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -40248,7 +40355,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -40364,7 +40472,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&rack_id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -40464,7 +40573,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -40580,7 +40690,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&sled_id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -40698,7 +40809,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -40855,7 +40967,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -40981,7 +41094,8 @@ pub mod builder {
                 .and_then(|v| types::GlobalImageCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/images", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -41041,7 +41155,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&image_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -41100,7 +41215,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&image_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -41200,7 +41316,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -41324,7 +41441,8 @@ pub mod builder {
                 .and_then(|v| types::IpPoolCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -41384,7 +41502,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -41472,7 +41591,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -41532,7 +41652,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -41632,7 +41753,8 @@ pub mod builder {
             if let Some(v) = &page_token {
                 query.push(("page_token", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -41764,7 +41886,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -41842,7 +41965,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -41883,7 +42007,8 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/system/ip-pools-service", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -41965,7 +42090,8 @@ pub mod builder {
             if let Some(v) = &page_token {
                 query.push(("page_token", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -42076,7 +42202,8 @@ pub mod builder {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools-service/ranges/add", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -42132,7 +42259,8 @@ pub mod builder {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools-service/ranges/remove", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -42285,7 +42413,8 @@ pub mod builder {
             if let Some(v) = &start_time {
                 query.push(("start_time", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -42328,7 +42457,8 @@ pub mod builder {
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/system/policy", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -42397,7 +42527,8 @@ pub mod builder {
                 .and_then(|v| types::FleetRolePolicy::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/policy", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -42498,7 +42629,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -42614,7 +42746,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&saga_id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -42714,7 +42847,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -42838,7 +42972,8 @@ pub mod builder {
                 .and_then(|v| types::SiloCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/silos", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -42898,7 +43033,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -42957,7 +43093,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -43077,7 +43214,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -43224,7 +43362,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -43303,7 +43442,8 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -43396,7 +43536,8 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -43495,7 +43636,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -43576,7 +43718,8 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -43637,7 +43780,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -43727,7 +43871,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -43846,7 +43991,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -43981,7 +44127,8 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -44081,7 +44228,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -44197,7 +44345,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&user_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -44280,7 +44429,8 @@ pub mod builder {
             if let Some(v) = &page_token {
                 query.push(("page_token", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -44436,7 +44586,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -44629,7 +44780,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -44792,7 +44944,8 @@ pub mod builder {
                 query.push(("organization", v.to_string()));
             }
             query.push(("project", project.to_string()));
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -44893,7 +45046,8 @@ pub mod builder {
             if let Some(v) = &project {
                 query.push(("project", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -44993,7 +45147,8 @@ pub mod builder {
             if let Some(v) = &project {
                 query.push(("project", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -45130,7 +45285,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -45293,7 +45449,8 @@ pub mod builder {
                 query.push(("organization", v.to_string()));
             }
             query.push(("project", project.to_string()));
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -45394,7 +45551,8 @@ pub mod builder {
             if let Some(v) = &project {
                 query.push(("project", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -45494,7 +45652,8 @@ pub mod builder {
             if let Some(v) = &project {
                 query.push(("project", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -45649,7 +45808,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -45833,7 +45993,8 @@ pub mod builder {
             if let Some(v) = &project {
                 query.push(("project", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -45960,7 +46121,8 @@ pub mod builder {
             if let Some(v) = &project {
                 query.push(("project", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -46087,7 +46249,8 @@ pub mod builder {
             if let Some(v) = &project {
                 query.push(("project", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -46188,7 +46351,8 @@ pub mod builder {
             if let Some(v) = &project {
                 query.push(("project", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -46344,7 +46508,8 @@ pub mod builder {
             if let Some(v) = &project {
                 query.push(("project", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -46447,7 +46612,8 @@ pub mod builder {
             if let Some(v) = &project {
                 query.push(("project", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .query(&query)
@@ -46548,7 +46714,8 @@ pub mod builder {
             if let Some(v) = &project {
                 query.push(("project", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -46648,7 +46815,8 @@ pub mod builder {
             if let Some(v) = &project {
                 query.push(("project", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -46749,7 +46917,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -46875,7 +47044,8 @@ pub mod builder {
                 .and_then(|v| types::OrganizationCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/organizations", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -46938,7 +47108,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -47028,7 +47199,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -47091,7 +47263,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -47155,7 +47328,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -47249,7 +47423,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -47368,7 +47543,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -47512,7 +47688,8 @@ pub mod builder {
             let url = format!("{}/v1/projects", client.baseurl,);
             let mut query = Vec::with_capacity(1usize);
             query.push(("organization", organization.to_string()));
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -47595,7 +47772,8 @@ pub mod builder {
             if let Some(v) = &organization {
                 query.push(("organization", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -47703,7 +47881,8 @@ pub mod builder {
             if let Some(v) = &organization {
                 query.push(("organization", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -47786,7 +47965,8 @@ pub mod builder {
             if let Some(v) = &organization {
                 query.push(("organization", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -47870,7 +48050,8 @@ pub mod builder {
             if let Some(v) = &organization {
                 query.push(("organization", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -47982,7 +48163,8 @@ pub mod builder {
             if let Some(v) = &organization {
                 query.push(("organization", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -48085,7 +48267,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -48244,7 +48427,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -48362,7 +48546,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -48402,7 +48587,8 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/v1/system/update/refresh", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -48473,7 +48659,8 @@ pub mod builder {
                 .and_then(|v| types::SystemUpdateStart::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/start", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -48514,7 +48701,8 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/v1/system/update/stop", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -48614,7 +48802,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -48730,7 +48919,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&version.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -48792,7 +48982,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&version.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -48834,7 +49025,8 @@ pub mod builder {
         ) -> Result<ResponseValue<types::SystemVersion>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/v1/system/update/version", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(

--- a/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
@@ -28632,7 +28632,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -28691,7 +28692,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -28750,7 +28752,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -28812,7 +28815,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -28871,7 +28875,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -28930,7 +28935,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -28989,7 +28995,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -29048,7 +29055,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -29107,7 +29115,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -29166,7 +29175,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -29225,7 +29235,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -29294,7 +29305,8 @@ pub mod builder {
                 .and_then(|v| types::DeviceAuthRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/device/auth", client.baseurl,);
-            let request = client.client.post(url).form_urlencoded(&body)?.build()?;
+            #[allow(unused_mut)]
+            let mut request = client.client.post(url).form_urlencoded(&body)?.build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -29350,7 +29362,8 @@ pub mod builder {
                 .and_then(|v| types::DeviceAuthVerify::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/device/confirm", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -29424,7 +29437,8 @@ pub mod builder {
                 })
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/device/token", client.baseurl,);
-            let request = client.client.post(url).form_urlencoded(&body)?.build()?;
+            #[allow(unused_mut)]
+            let mut request = client.client.post(url).form_urlencoded(&body)?.build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -29511,7 +29525,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -29635,7 +29650,8 @@ pub mod builder {
                 .and_then(|v| types::SpoofLoginBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/login", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -29731,7 +29747,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let request = client.client.post(url).json(&body).build()?;
+            #[allow(unused_mut)]
+            let mut request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -29801,7 +29818,8 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let request = client.client.get(url).build()?;
+            #[allow(unused_mut)]
+            let mut request = client.client.get(url).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {
@@ -29885,7 +29903,8 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -29926,7 +29945,8 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/logout", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -30026,7 +30046,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -30152,7 +30173,8 @@ pub mod builder {
                 .and_then(|v| types::OrganizationCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/organizations", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -30215,7 +30237,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -30305,7 +30328,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -30368,7 +30392,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -30432,7 +30457,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -30526,7 +30552,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -30646,7 +30673,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -30793,7 +30821,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -30872,7 +30901,8 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -30976,7 +31006,8 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -31055,7 +31086,8 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -31189,7 +31221,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -31351,7 +31384,8 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -31446,7 +31480,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -31540,7 +31575,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -31724,7 +31760,8 @@ pub mod builder {
             if let Some(v) = &start_time {
                 query.push(("start_time", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -31918,7 +31955,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -32080,7 +32118,8 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -32175,7 +32214,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -32269,7 +32309,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -32404,7 +32445,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -32568,7 +32610,8 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -32663,7 +32706,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -32757,7 +32801,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -32907,7 +32952,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -33086,7 +33132,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -33207,7 +33254,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -33304,7 +33352,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -33424,7 +33473,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -33576,7 +33626,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -33761,7 +33812,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -33873,7 +33925,8 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -34014,7 +34067,8 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -34124,7 +34178,8 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -34218,7 +34273,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -34369,7 +34425,8 @@ pub mod builder {
             if let Some(v) = &most_recent {
                 query.push(("most_recent", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -34466,7 +34523,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(reqwest::header::CONNECTION, "Upgrade")
@@ -34561,7 +34619,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -34655,7 +34714,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -34735,7 +34795,8 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -34843,7 +34904,8 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -34979,7 +35041,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -35143,7 +35206,8 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -35238,7 +35302,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -35332,7 +35397,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -35466,7 +35532,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -35628,7 +35695,8 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -35723,7 +35791,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -35843,7 +35912,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -35938,7 +36008,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -36034,7 +36105,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -36163,7 +36235,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -36314,7 +36387,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -36493,7 +36567,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -36603,7 +36678,8 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -36738,7 +36814,8 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -36848,7 +36925,8 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -37013,7 +37091,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -37213,7 +37292,8 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -37338,7 +37418,8 @@ pub mod builder {
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -37494,7 +37575,8 @@ pub mod builder {
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -37619,7 +37701,8 @@ pub mod builder {
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -37769,7 +37852,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -37948,7 +38032,8 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -38058,7 +38143,8 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -38193,7 +38279,8 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -38303,7 +38390,8 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -38469,7 +38557,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -38570,7 +38659,8 @@ pub mod builder {
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/policy", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -38639,7 +38729,8 @@ pub mod builder {
                 .and_then(|v| types::SiloRolePolicy::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/policy", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -38722,7 +38813,8 @@ pub mod builder {
             if let Some(v) = &page_token {
                 query.push(("page_token", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -38837,7 +38929,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&role_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -38877,7 +38970,8 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/session/me", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -38977,7 +39071,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -39134,7 +39229,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -39258,7 +39354,8 @@ pub mod builder {
                 .and_then(|v| types::SshKeyCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/sshkeys", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -39321,7 +39418,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -39383,7 +39481,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -39442,7 +39541,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -39501,7 +39601,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -39560,7 +39661,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -39660,7 +39762,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -39786,7 +39889,8 @@ pub mod builder {
                 .and_then(|v| types::CertificateCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/certificates", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -39849,7 +39953,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&certificate.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -39911,7 +40016,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&certificate.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -40011,7 +40117,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -40168,7 +40275,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -40284,7 +40392,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&rack_id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -40384,7 +40493,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -40500,7 +40610,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&sled_id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -40618,7 +40729,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -40775,7 +40887,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -40901,7 +41014,8 @@ pub mod builder {
                 .and_then(|v| types::GlobalImageCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/images", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -40961,7 +41075,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&image_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -41020,7 +41135,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&image_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -41120,7 +41236,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -41244,7 +41361,8 @@ pub mod builder {
                 .and_then(|v| types::IpPoolCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -41304,7 +41422,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -41392,7 +41511,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -41452,7 +41572,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -41552,7 +41673,8 @@ pub mod builder {
             if let Some(v) = &page_token {
                 query.push(("page_token", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -41684,7 +41806,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -41762,7 +41885,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -41803,7 +41927,8 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/system/ip-pools-service", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -41885,7 +42010,8 @@ pub mod builder {
             if let Some(v) = &page_token {
                 query.push(("page_token", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -41996,7 +42122,8 @@ pub mod builder {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools-service/ranges/add", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -42052,7 +42179,8 @@ pub mod builder {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools-service/ranges/remove", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -42205,7 +42333,8 @@ pub mod builder {
             if let Some(v) = &start_time {
                 query.push(("start_time", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -42248,7 +42377,8 @@ pub mod builder {
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/system/policy", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -42317,7 +42447,8 @@ pub mod builder {
                 .and_then(|v| types::FleetRolePolicy::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/policy", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -42418,7 +42549,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -42534,7 +42666,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&saga_id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -42634,7 +42767,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -42758,7 +42892,8 @@ pub mod builder {
                 .and_then(|v| types::SiloCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/silos", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -42818,7 +42953,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -42877,7 +43013,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -42997,7 +43134,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -43144,7 +43282,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -43223,7 +43362,8 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -43316,7 +43456,8 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -43415,7 +43556,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -43496,7 +43638,8 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -43557,7 +43700,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -43647,7 +43791,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -43766,7 +43911,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -43901,7 +44047,8 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -44001,7 +44148,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -44117,7 +44265,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&user_name.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -44200,7 +44349,8 @@ pub mod builder {
             if let Some(v) = &page_token {
                 query.push(("page_token", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -44356,7 +44506,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -44549,7 +44700,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -44712,7 +44864,8 @@ pub mod builder {
                 query.push(("organization", v.to_string()));
             }
             query.push(("project", project.to_string()));
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -44813,7 +44966,8 @@ pub mod builder {
             if let Some(v) = &project {
                 query.push(("project", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -44913,7 +45067,8 @@ pub mod builder {
             if let Some(v) = &project {
                 query.push(("project", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -45050,7 +45205,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -45213,7 +45369,8 @@ pub mod builder {
                 query.push(("organization", v.to_string()));
             }
             query.push(("project", project.to_string()));
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -45314,7 +45471,8 @@ pub mod builder {
             if let Some(v) = &project {
                 query.push(("project", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -45414,7 +45572,8 @@ pub mod builder {
             if let Some(v) = &project {
                 query.push(("project", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -45569,7 +45728,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -45753,7 +45913,8 @@ pub mod builder {
             if let Some(v) = &project {
                 query.push(("project", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -45880,7 +46041,8 @@ pub mod builder {
             if let Some(v) = &project {
                 query.push(("project", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -46007,7 +46169,8 @@ pub mod builder {
             if let Some(v) = &project {
                 query.push(("project", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -46108,7 +46271,8 @@ pub mod builder {
             if let Some(v) = &project {
                 query.push(("project", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -46264,7 +46428,8 @@ pub mod builder {
             if let Some(v) = &project {
                 query.push(("project", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -46367,7 +46532,8 @@ pub mod builder {
             if let Some(v) = &project {
                 query.push(("project", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .query(&query)
@@ -46468,7 +46634,8 @@ pub mod builder {
             if let Some(v) = &project {
                 query.push(("project", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -46568,7 +46735,8 @@ pub mod builder {
             if let Some(v) = &project {
                 query.push(("project", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -46669,7 +46837,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -46795,7 +46964,8 @@ pub mod builder {
                 .and_then(|v| types::OrganizationCreate::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/organizations", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -46858,7 +47028,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -46948,7 +47119,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -47011,7 +47183,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -47075,7 +47248,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -47169,7 +47343,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -47288,7 +47463,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -47432,7 +47608,8 @@ pub mod builder {
             let url = format!("{}/v1/projects", client.baseurl,);
             let mut query = Vec::with_capacity(1usize);
             query.push(("organization", organization.to_string()));
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -47515,7 +47692,8 @@ pub mod builder {
             if let Some(v) = &organization {
                 query.push(("organization", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -47623,7 +47801,8 @@ pub mod builder {
             if let Some(v) = &organization {
                 query.push(("organization", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -47706,7 +47885,8 @@ pub mod builder {
             if let Some(v) = &organization {
                 query.push(("organization", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .delete(url)
                 .header(
@@ -47790,7 +47970,8 @@ pub mod builder {
             if let Some(v) = &organization {
                 query.push(("organization", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -47902,7 +48083,8 @@ pub mod builder {
             if let Some(v) = &organization {
                 query.push(("organization", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -48005,7 +48187,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -48164,7 +48347,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -48282,7 +48466,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -48322,7 +48507,8 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/v1/system/update/refresh", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -48393,7 +48579,8 @@ pub mod builder {
                 .and_then(|v| types::SystemUpdateStart::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/start", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -48434,7 +48621,8 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/v1/system/update/stop", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -48534,7 +48722,8 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -48650,7 +48839,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&version.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -48712,7 +48902,8 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&version.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -48754,7 +48945,8 @@ pub mod builder {
         ) -> Result<ResponseValue<types::SystemVersion>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/v1/system/update/version", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(

--- a/progenitor-impl/tests/output/src/nexus_positional.rs
+++ b/progenitor-impl/tests/output/src/nexus_positional.rs
@@ -13436,7 +13436,8 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -13470,7 +13471,8 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -13504,7 +13506,8 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -13538,7 +13541,8 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -13574,7 +13578,8 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -13610,7 +13615,8 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -13644,7 +13650,8 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -13678,7 +13685,8 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -13712,7 +13720,8 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -13746,7 +13755,8 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -13780,7 +13790,8 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -13814,7 +13825,8 @@ impl Client {
         body: &'a types::DeviceAuthRequest,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
         let url = format!("{}/device/auth", self.baseurl,);
-        let request = self.client.post(url).form_urlencoded(&body)?.build()?;
+        #[allow(unused_mut)]
+        let mut request = self.client.post(url).form_urlencoded(&body)?.build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -13836,7 +13848,8 @@ impl Client {
         body: &'a types::DeviceAuthVerify,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!("{}/device/confirm", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -13870,7 +13883,8 @@ impl Client {
         body: &'a types::DeviceAccessTokenRequest,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
         let url = format!("{}/device/token", self.baseurl,);
-        let request = self.client.post(url).form_urlencoded(&body)?.build()?;
+        #[allow(unused_mut)]
+        let mut request = self.client.post(url).form_urlencoded(&body)?.build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -13908,7 +13922,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -13982,7 +13997,8 @@ impl Client {
         body: &'a types::SpoofLoginBody,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!("{}/login", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -14018,7 +14034,8 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let request = self.client.post(url).json(&body).build()?;
+        #[allow(unused_mut)]
+        let mut request = self.client.post(url).json(&body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -14050,7 +14067,8 @@ impl Client {
             encode_path(&silo_name.to_string()),
             encode_path(&provider_name.to_string()),
         );
-        let request = self.client.get(url).build()?;
+        #[allow(unused_mut)]
+        let mut request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {
@@ -14080,7 +14098,8 @@ impl Client {
             encode_path(&silo_name.to_string()),
             encode_path(&provider_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -14106,7 +14125,8 @@ impl Client {
     ///Sends a `POST` request to `/logout`
     pub async fn logout<'a>(&'a self) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!("{}/logout", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -14159,7 +14179,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -14240,7 +14261,8 @@ impl Client {
         body: &'a types::OrganizationCreate,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
         let url = format!("{}/organizations", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -14280,7 +14302,8 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -14321,7 +14344,8 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .put(url)
             .header(
@@ -14361,7 +14385,8 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .delete(url)
             .header(
@@ -14400,7 +14425,8 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -14441,7 +14467,8 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .put(url)
             .header(
@@ -14501,7 +14528,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -14593,7 +14621,8 @@ impl Client {
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -14637,7 +14666,8 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -14682,7 +14712,8 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .put(url)
             .header(
@@ -14726,7 +14757,8 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .delete(url)
             .header(
@@ -14789,7 +14821,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -14891,7 +14924,8 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -14934,7 +14968,8 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&disk_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -14974,7 +15009,8 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&disk_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .delete(url)
             .header(
@@ -15048,7 +15084,8 @@ impl Client {
             query.push(("start_time", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -15188,7 +15225,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -15293,7 +15331,8 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -15336,7 +15375,8 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&image_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -15380,7 +15420,8 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&image_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .delete(url)
             .header(
@@ -15441,7 +15482,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -15544,7 +15586,8 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -15587,7 +15630,8 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -15627,7 +15671,8 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .delete(url)
             .header(
@@ -15694,7 +15739,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -15806,7 +15852,8 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -15850,7 +15897,8 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -15891,7 +15939,8 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -15934,7 +15983,8 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -16000,7 +16050,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -16109,7 +16160,8 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -16152,7 +16204,8 @@ impl Client {
             encode_path(&instance_name.to_string()),
             encode_path(&interface_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -16195,7 +16248,8 @@ impl Client {
             encode_path(&instance_name.to_string()),
             encode_path(&interface_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .put(url)
             .header(
@@ -16243,7 +16297,8 @@ impl Client {
             encode_path(&instance_name.to_string()),
             encode_path(&interface_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .delete(url)
             .header(
@@ -16285,7 +16340,8 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -16359,7 +16415,8 @@ impl Client {
             query.push(("most_recent", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -16402,7 +16459,8 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(reqwest::header::CONNECTION, "Upgrade")
@@ -16445,7 +16503,8 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -16487,7 +16546,8 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -16530,7 +16590,8 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -16573,7 +16634,8 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .put(url)
             .header(
@@ -16635,7 +16697,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -16738,7 +16801,8 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -16779,7 +16843,8 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&snapshot_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -16819,7 +16884,8 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&snapshot_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .delete(url)
             .header(
@@ -16880,7 +16946,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -16980,7 +17047,8 @@ impl Client {
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -17021,7 +17089,8 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -17062,7 +17131,8 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .put(url)
             .header(
@@ -17103,7 +17173,8 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .delete(url)
             .header(
@@ -17143,7 +17214,8 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -17184,7 +17256,8 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .put(url)
             .header(
@@ -17250,7 +17323,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -17359,7 +17433,8 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -17402,7 +17477,8 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -17445,7 +17521,8 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .put(url)
             .header(
@@ -17488,7 +17565,8 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .delete(url)
             .header(
@@ -17558,7 +17636,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -17676,7 +17755,8 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -17721,7 +17801,8 @@ impl Client {
             encode_path(&router_name.to_string()),
             encode_path(&route_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -17766,7 +17847,8 @@ impl Client {
             encode_path(&router_name.to_string()),
             encode_path(&route_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .put(url)
             .header(
@@ -17811,7 +17893,8 @@ impl Client {
             encode_path(&router_name.to_string()),
             encode_path(&route_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .delete(url)
             .header(
@@ -17876,7 +17959,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -17985,7 +18069,8 @@ impl Client {
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -18028,7 +18113,8 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&subnet_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -18071,7 +18157,8 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&subnet_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .put(url)
             .header(
@@ -18114,7 +18201,8 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&subnet_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .delete(url)
             .header(
@@ -18182,7 +18270,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -18284,7 +18373,8 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
         let url = format!("{}/policy", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -18314,7 +18404,8 @@ impl Client {
         body: &'a types::SiloRolePolicy,
     ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
         let url = format!("{}/policy", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .put(url)
             .header(
@@ -18360,7 +18451,8 @@ impl Client {
             query.push(("page_token", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -18441,7 +18533,8 @@ impl Client {
             self.baseurl,
             encode_path(&role_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -18470,7 +18563,8 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<types::User>, Error<types::Error>> {
         let url = format!("{}/session/me", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -18521,7 +18615,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -18620,7 +18715,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -18700,7 +18796,8 @@ impl Client {
         body: &'a types::SshKeyCreate,
     ) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
         let url = format!("{}/session/me/sshkeys", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -18738,7 +18835,8 @@ impl Client {
             self.baseurl,
             encode_path(&ssh_key_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -18775,7 +18873,8 @@ impl Client {
             self.baseurl,
             encode_path(&ssh_key_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .delete(url)
             .header(
@@ -18809,7 +18908,8 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -18843,7 +18943,8 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -18877,7 +18978,8 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -18932,7 +19034,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -19016,7 +19119,8 @@ impl Client {
         body: &'a types::CertificateCreate,
     ) -> Result<ResponseValue<types::Certificate>, Error<types::Error>> {
         let url = format!("{}/system/certificates", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -19053,7 +19157,8 @@ impl Client {
             self.baseurl,
             encode_path(&certificate.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -19089,7 +19194,8 @@ impl Client {
             self.baseurl,
             encode_path(&certificate.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .delete(url)
             .header(
@@ -19140,7 +19246,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -19238,7 +19345,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -19321,7 +19429,8 @@ impl Client {
             self.baseurl,
             encode_path(&rack_id.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -19372,7 +19481,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -19455,7 +19565,8 @@ impl Client {
             self.baseurl,
             encode_path(&sled_id.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -19512,7 +19623,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -19617,7 +19729,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -19701,7 +19814,8 @@ impl Client {
         body: &'a types::GlobalImageCreate,
     ) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
         let url = format!("{}/system/images", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -19738,7 +19852,8 @@ impl Client {
             self.baseurl,
             encode_path(&image_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -19776,7 +19891,8 @@ impl Client {
             self.baseurl,
             encode_path(&image_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .delete(url)
             .header(
@@ -19827,7 +19943,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -19903,7 +20020,8 @@ impl Client {
         body: &'a types::IpPoolCreate,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
         let url = format!("{}/system/ip-pools", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -19938,7 +20056,8 @@ impl Client {
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -19973,7 +20092,8 @@ impl Client {
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .put(url)
             .header(
@@ -20008,7 +20128,8 @@ impl Client {
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .delete(url)
             .header(
@@ -20061,7 +20182,8 @@ impl Client {
             query.push(("page_token", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -20145,7 +20267,8 @@ impl Client {
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -20181,7 +20304,8 @@ impl Client {
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -20211,7 +20335,8 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
         let url = format!("{}/system/ip-pools-service", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -20258,7 +20383,8 @@ impl Client {
             query.push(("page_token", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -20335,7 +20461,8 @@ impl Client {
         body: &'a types::IpRange,
     ) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
         let url = format!("{}/system/ip-pools-service/ranges/add", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -20366,7 +20493,8 @@ impl Client {
         body: &'a types::IpRange,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!("{}/system/ip-pools-service/ranges/remove", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -20433,7 +20561,8 @@ impl Client {
             query.push(("start_time", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -20463,7 +20592,8 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
         let url = format!("{}/system/policy", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -20493,7 +20623,8 @@ impl Client {
         body: &'a types::FleetRolePolicy,
     ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
         let url = format!("{}/system/policy", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .put(url)
             .header(
@@ -20545,7 +20676,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -20625,7 +20757,8 @@ impl Client {
             self.baseurl,
             encode_path(&saga_id.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -20678,7 +20811,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -20756,7 +20890,8 @@ impl Client {
         body: &'a types::SiloCreate,
     ) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
         let url = format!("{}/system/silos", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -20796,7 +20931,8 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -20835,7 +20971,8 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .delete(url)
             .header(
@@ -20892,7 +21029,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -20986,7 +21124,8 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -21028,7 +21167,8 @@ impl Client {
             encode_path(&silo_name.to_string()),
             encode_path(&user_id.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .delete(url)
             .header(
@@ -21075,7 +21215,8 @@ impl Client {
             encode_path(&silo_name.to_string()),
             encode_path(&user_id.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -21116,7 +21257,8 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -21158,7 +21300,8 @@ impl Client {
             encode_path(&silo_name.to_string()),
             encode_path(&provider_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -21195,7 +21338,8 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -21234,7 +21378,8 @@ impl Client {
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .put(url)
             .header(
@@ -21292,7 +21437,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -21380,7 +21526,8 @@ impl Client {
             encode_path(&silo_name.to_string()),
             encode_path(&user_id.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -21431,7 +21578,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -21515,7 +21663,8 @@ impl Client {
             self.baseurl,
             encode_path(&user_name.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -21560,7 +21709,8 @@ impl Client {
             query.push(("page_token", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -21656,7 +21806,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -21765,7 +21916,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -21853,7 +22005,8 @@ impl Client {
         }
 
         query.push(("project", project.to_string()));
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -21900,7 +22053,8 @@ impl Client {
             query.push(("project", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -21946,7 +22100,8 @@ impl Client {
             query.push(("project", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .delete(url)
             .header(
@@ -22010,7 +22165,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -22099,7 +22255,8 @@ impl Client {
         }
 
         query.push(("project", project.to_string()));
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -22146,7 +22303,8 @@ impl Client {
             query.push(("project", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -22192,7 +22350,8 @@ impl Client {
             query.push(("project", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .delete(url)
             .header(
@@ -22262,7 +22421,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -22367,7 +22527,8 @@ impl Client {
             query.push(("project", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -22415,7 +22576,8 @@ impl Client {
             query.push(("project", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -22463,7 +22625,8 @@ impl Client {
             query.push(("project", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -22510,7 +22673,8 @@ impl Client {
             query.push(("project", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -22587,7 +22751,8 @@ impl Client {
             query.push(("project", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -22634,7 +22799,8 @@ impl Client {
             query.push(("project", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .query(&query)
@@ -22681,7 +22847,8 @@ impl Client {
             query.push(("project", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -22727,7 +22894,8 @@ impl Client {
             query.push(("project", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -22779,7 +22947,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -22856,7 +23025,8 @@ impl Client {
         body: &'a types::OrganizationCreate,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
         let url = format!("{}/v1/organizations", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -22891,7 +23061,8 @@ impl Client {
             self.baseurl,
             encode_path(&organization.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -22926,7 +23097,8 @@ impl Client {
             self.baseurl,
             encode_path(&organization.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .put(url)
             .header(
@@ -22961,7 +23133,8 @@ impl Client {
             self.baseurl,
             encode_path(&organization.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .delete(url)
             .header(
@@ -22995,7 +23168,8 @@ impl Client {
             self.baseurl,
             encode_path(&organization.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -23030,7 +23204,8 @@ impl Client {
             self.baseurl,
             encode_path(&organization.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .put(url)
             .header(
@@ -23088,7 +23263,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -23169,7 +23345,8 @@ impl Client {
         let url = format!("{}/v1/projects", self.baseurl,);
         let mut query = Vec::with_capacity(1usize);
         query.push(("organization", organization.to_string()));
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -23211,7 +23388,8 @@ impl Client {
             query.push(("organization", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -23253,7 +23431,8 @@ impl Client {
             query.push(("organization", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .put(url)
             .header(
@@ -23295,7 +23474,8 @@ impl Client {
             query.push(("organization", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .delete(url)
             .header(
@@ -23336,7 +23516,8 @@ impl Client {
             query.push(("organization", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -23378,7 +23559,8 @@ impl Client {
             query.push(("organization", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .put(url)
             .header(
@@ -23431,7 +23613,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -23529,7 +23712,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -23610,7 +23794,8 @@ impl Client {
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -23639,7 +23824,8 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!("{}/v1/system/update/refresh", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -23669,7 +23855,8 @@ impl Client {
         body: &'a types::SystemUpdateStart,
     ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
         let url = format!("{}/v1/system/update/start", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -23701,7 +23888,8 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!("{}/v1/system/update/stop", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -23752,7 +23940,8 @@ impl Client {
             query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -23833,7 +24022,8 @@ impl Client {
             self.baseurl,
             encode_path(&version.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -23868,7 +24058,8 @@ impl Client {
             self.baseurl,
             encode_path(&version.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -23897,7 +24088,8 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<types::SystemVersion>, Error<types::Error>> {
         let url = format!("{}/v1/system/update/version", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(

--- a/progenitor-impl/tests/output/src/param_collision_builder.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder.rs
@@ -253,7 +253,8 @@ pub mod builder {
             _query.push(("response", response.to_string()));
             _query.push(("result", result.to_string()));
             _query.push(("url", url.to_string()));
-            let _request = _client.client.get(_url).query(&_query).build()?;
+            #[allow(unused_mut)]
+            let mut _request = _client.client.get(_url).query(&_query).build()?;
             let _result = _client.client.execute(_request).await;
             let _response = _result?;
             match _response.status().as_u16() {

--- a/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
@@ -253,7 +253,8 @@ pub mod builder {
             _query.push(("response", response.to_string()));
             _query.push(("result", result.to_string()));
             _query.push(("url", url.to_string()));
-            let _request = _client.client.get(_url).query(&_query).build()?;
+            #[allow(unused_mut)]
+            let mut _request = _client.client.get(_url).query(&_query).build()?;
             let _result = _client.client.execute(_request).await;
             let _response = _result?;
             match _response.status().as_u16() {

--- a/progenitor-impl/tests/output/src/param_collision_positional.rs
+++ b/progenitor-impl/tests/output/src/param_collision_positional.rs
@@ -131,7 +131,8 @@ impl Client {
         _query.push(("response", response.to_string()));
         _query.push(("result", result.to_string()));
         _query.push(("url", url.to_string()));
-        let _request = self.client.get(_url).query(&_query).build()?;
+        #[allow(unused_mut)]
+        let mut _request = self.client.get(_url).query(&_query).build()?;
         let _result = self.client.execute(_request).await;
         let _response = _result?;
         match _response.status().as_u16() {

--- a/progenitor-impl/tests/output/src/param_overrides_builder.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder.rs
@@ -190,7 +190,8 @@ pub mod builder {
             if let Some(v) = &unique_key {
                 query.push(("uniqueKey", v.to_string()));
             }
-            let request = client.client.get(url).query(&query).build()?;
+            #[allow(unused_mut)]
+            let mut request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {

--- a/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
@@ -190,7 +190,8 @@ pub mod builder {
             if let Some(v) = &unique_key {
                 query.push(("uniqueKey", v.to_string()));
             }
-            let request = client.client.get(url).query(&query).build()?;
+            #[allow(unused_mut)]
+            let mut request = client.client.get(url).query(&query).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {

--- a/progenitor-impl/tests/output/src/param_overrides_positional.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_positional.rs
@@ -128,7 +128,8 @@ impl Client {
             query.push(("uniqueKey", v.to_string()));
         }
 
-        let request = self.client.get(url).query(&query).build()?;
+        #[allow(unused_mut)]
+        let mut request = self.client.get(url).query(&query).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {

--- a/progenitor-impl/tests/output/src/propolis_server_builder.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder.rs
@@ -3002,7 +3002,8 @@ pub mod builder {
         ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/instance", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -3075,7 +3076,8 @@ pub mod builder {
                 .and_then(|v| types::InstanceEnsureRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/instance", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -3154,7 +3156,8 @@ pub mod builder {
                 encode_path(&id.to_string()),
                 encode_path(&snapshot_id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -3231,7 +3234,8 @@ pub mod builder {
                 })
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/instance/migrate/status", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -3274,7 +3278,8 @@ pub mod builder {
         ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
             let Self { client } = self;
             let url = format!("{}/instance/serial", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(reqwest::header::CONNECTION, "Upgrade")
@@ -3330,7 +3335,8 @@ pub mod builder {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/instance/state", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -3408,7 +3414,8 @@ pub mod builder {
                 })
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/instance/state-monitor", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(

--- a/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
@@ -2966,7 +2966,8 @@ pub mod builder {
         ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
             let Self { client } = self;
             let url = format!("{}/instance", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -3039,7 +3040,8 @@ pub mod builder {
                 .and_then(|v| types::InstanceEnsureRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/instance", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -3118,7 +3120,8 @@ pub mod builder {
                 encode_path(&id.to_string()),
                 encode_path(&snapshot_id.to_string()),
             );
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .post(url)
                 .header(
@@ -3195,7 +3198,8 @@ pub mod builder {
                 })
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/instance/migrate/status", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(
@@ -3238,7 +3242,8 @@ pub mod builder {
         ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
             let Self { client } = self;
             let url = format!("{}/instance/serial", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(reqwest::header::CONNECTION, "Upgrade")
@@ -3294,7 +3299,8 @@ pub mod builder {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/instance/state", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .put(url)
                 .header(
@@ -3372,7 +3378,8 @@ pub mod builder {
                 })
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/instance/state-monitor", client.baseurl,);
-            let request = client
+            #[allow(unused_mut)]
+            let mut request = client
                 .client
                 .get(url)
                 .header(

--- a/progenitor-impl/tests/output/src/propolis_server_positional.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_positional.rs
@@ -1491,7 +1491,8 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
         let url = format!("{}/instance", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -1519,7 +1520,8 @@ impl Client {
         body: &'a types::InstanceEnsureRequest,
     ) -> Result<ResponseValue<types::InstanceEnsureResponse>, Error<types::Error>> {
         let url = format!("{}/instance", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .put(url)
             .header(
@@ -1556,7 +1558,8 @@ impl Client {
             encode_path(&id.to_string()),
             encode_path(&snapshot_id.to_string()),
         );
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .post(url)
             .header(
@@ -1584,7 +1587,8 @@ impl Client {
         body: &'a types::InstanceMigrateStatusRequest,
     ) -> Result<ResponseValue<types::InstanceMigrateStatusResponse>, Error<types::Error>> {
         let url = format!("{}/instance/migrate/status", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(
@@ -1612,7 +1616,8 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
         let url = format!("{}/instance/serial", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(reqwest::header::CONNECTION, "Upgrade")
@@ -1641,7 +1646,8 @@ impl Client {
         body: types::InstanceStateRequested,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
         let url = format!("{}/instance/state", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .put(url)
             .header(
@@ -1670,7 +1676,8 @@ impl Client {
         body: &'a types::InstanceStateMonitorRequest,
     ) -> Result<ResponseValue<types::InstanceStateMonitorResponse>, Error<types::Error>> {
         let url = format!("{}/instance/state-monitor", self.baseurl,);
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(

--- a/progenitor-impl/tests/output/src/test_default_params_builder.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_builder.rs
@@ -446,7 +446,8 @@ pub mod builder {
                 .and_then(|v| types::BodyWithDefaults::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
+            #[allow(unused_mut)]
+            let mut request = client.client.post(url).json(&body).build()?;
             let result = client.client.execute(request).await;
             let response = result?;
             match response.status().as_u16() {

--- a/progenitor-impl/tests/output/src/test_default_params_positional.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_positional.rs
@@ -215,7 +215,8 @@ impl Client {
         body: &'a types::BodyWithDefaults,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
         let url = format!("{}/", self.baseurl,);
-        let request = self.client.post(url).json(&body).build()?;
+        #[allow(unused_mut)]
+        let mut request = self.client.post(url).json(&body).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {

--- a/progenitor-impl/tests/output/src/test_freeform_response.rs
+++ b/progenitor-impl/tests/output/src/test_freeform_response.rs
@@ -147,7 +147,8 @@ impl Client {
         &'a self,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
         let url = format!("{}/", self.baseurl,);
-        let request = self.client.get(url).build()?;
+        #[allow(unused_mut)]
+        let mut request = self.client.get(url).build()?;
         let result = self.client.execute(request).await;
         let response = result?;
         match response.status().as_u16() {

--- a/progenitor-impl/tests/output/src/test_renamed_parameters.rs
+++ b/progenitor-impl/tests/output/src/test_renamed_parameters.rs
@@ -163,7 +163,8 @@ impl Client {
         query.push(("if", if_.to_string()));
         query.push(("in", in_.to_string()));
         query.push(("use", use_.to_string()));
-        let request = self
+        #[allow(unused_mut)]
+        let mut request = self
             .client
             .get(url)
             .header(

--- a/progenitor-macro/src/lib.rs
+++ b/progenitor-macro/src/lib.rs
@@ -91,6 +91,7 @@ struct MacroSettings {
 
     inner_type: Option<ParseWrapper<syn::Type>>,
     pre_hook: Option<ParseWrapper<ClosureOrPath>>,
+    pre_hook_async: Option<ParseWrapper<ClosureOrPath>>,
     post_hook: Option<ParseWrapper<ClosureOrPath>>,
 
     #[serde(default)]
@@ -193,6 +194,7 @@ fn do_generate_api(item: TokenStream) -> Result<TokenStream, syn::Error> {
             tags,
             inner_type,
             pre_hook,
+            pre_hook_async,
             post_hook,
             derives,
             patch,
@@ -207,6 +209,9 @@ fn do_generate_api(item: TokenStream) -> Result<TokenStream, syn::Error> {
         });
         pre_hook
             .map(|pre_hook| settings.with_pre_hook(pre_hook.into_inner().0));
+        pre_hook_async.map(|pre_hook_async| {
+            settings.with_pre_hook_async(pre_hook_async.into_inner().0)
+        });
         post_hook
             .map(|post_hook| settings.with_post_hook(post_hook.into_inner().0));
 


### PR DESCRIPTION
This allows one to call asynchronous code in a prehook for a request, and to mutate the request in place before it is sent.  I use this to collect various bits of the request (e.g., the URL path, the Date header, etc) to produce an intermediate blob that I can then pass to an SSH agent (over asynchronous sockets I/O to another process) and then add that signature as a request header for authentication in the outgoing request.  This operation is also fallible: communications might fail, or the agent might be unable or unwilling to sign the intermediate blob, etc.