### PR TITLE
Fix broken README link

### DIFF
--- a/progenitor/src/lib.rs
+++ b/progenitor/src/lib.rs
@@ -8,7 +8,7 @@
 //! operations specified in the OpenAPI document.
 //!
 //! For details see the [repo
-//! README](https://github.com/oxidecomputer/progenitor/README.md)
+//! README](https://github.com/oxidecomputer/progenitor/blob/main/README.md)
 
 pub use progenitor_client;
 pub use progenitor_impl::Error;


### PR DESCRIPTION
It was pointing at a HTTP 404. Fixed it :)