### PR TITLE
Restructure argument processing

### DIFF
--- a/progenitor-impl/tests/output/buildomat-cli.out
+++ b/progenitor-impl/tests/output/buildomat-cli.out
@@ -85,16 +85,16 @@ impl Cli {
     pub fn cli_task_events_get() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("task")
-                    .long("task")
-                    .value_parser(clap::value_parser!(String))
-                    .required(true),
-            )
-            .arg(
                 clap::Arg::new("minseq")
                     .long("minseq")
                     .value_parser(clap::value_parser!(u32))
                     .required(false),
+            )
+            .arg(
+                clap::Arg::new("task")
+                    .long("task")
+                    .value_parser(clap::value_parser!(String))
+                    .required(true),
             )
     }
 
@@ -110,14 +110,14 @@ impl Cli {
     pub fn cli_task_output_download() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("task")
-                    .long("task")
+                clap::Arg::new("output")
+                    .long("output")
                     .value_parser(clap::value_parser!(String))
                     .required(true),
             )
             .arg(
-                clap::Arg::new("output")
-                    .long("output")
+                clap::Arg::new("task")
+                    .long("task")
                     .value_parser(clap::value_parser!(String))
                     .required(true),
             )
@@ -188,12 +188,6 @@ impl Cli {
     pub fn cli_worker_task_append() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("task")
-                    .long("task")
-                    .value_parser(clap::value_parser!(String))
-                    .required(true),
-            )
-            .arg(
                 clap::Arg::new("payload")
                     .long("payload")
                     .value_parser(clap::value_parser!(String))
@@ -204,6 +198,12 @@ impl Cli {
                     .long("stream")
                     .value_parser(clap::value_parser!(String))
                     .required_unless_present("json-body"),
+            )
+            .arg(
+                clap::Arg::new("task")
+                    .long("task")
+                    .value_parser(clap::value_parser!(String))
+                    .required(true),
             )
             .arg(
                 clap::Arg::new("time")
@@ -239,16 +239,16 @@ impl Cli {
     pub fn cli_worker_task_complete() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("task")
-                    .long("task")
-                    .value_parser(clap::value_parser!(String))
-                    .required(true),
-            )
-            .arg(
                 clap::Arg::new("failed")
                     .long("failed")
                     .value_parser(clap::value_parser!(bool))
                     .required_unless_present("json-body"),
+            )
+            .arg(
+                clap::Arg::new("task")
+                    .long("task")
+                    .value_parser(clap::value_parser!(String))
+                    .required(true),
             )
             .arg(
                 clap::Arg::new("json-body")
@@ -269,12 +269,6 @@ impl Cli {
     pub fn cli_worker_task_add_output() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("task")
-                    .long("task")
-                    .value_parser(clap::value_parser!(String))
-                    .required(true),
-            )
-            .arg(
                 clap::Arg::new("path")
                     .long("path")
                     .value_parser(clap::value_parser!(String))
@@ -285,6 +279,12 @@ impl Cli {
                     .long("size")
                     .value_parser(clap::value_parser!(i64))
                     .required_unless_present("json-body"),
+            )
+            .arg(
+                clap::Arg::new("task")
+                    .long("task")
+                    .value_parser(clap::value_parser!(String))
+                    .required(true),
             )
             .arg(
                 clap::Arg::new("json-body")
@@ -441,18 +441,18 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_task_submit(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.task_submit();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::TaskSubmit>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
         if let Some(value) = matches.get_one::<String>("name") {
             request = request.body_map(|body| body.name(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<String>("script") {
             request = request.body_map(|body| body.script(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::TaskSubmit>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -471,12 +471,12 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_task_events_get(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.task_events_get();
-        if let Some(value) = matches.get_one::<String>("task") {
-            request = request.task(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<u32>("minseq") {
             request = request.minseq(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<String>("task") {
+            request = request.task(value.clone());
         }
 
         self.over
@@ -515,12 +515,12 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_task_output_download(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.task_output_download();
-        if let Some(value) = matches.get_one::<String>("task") {
-            request = request.task(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<String>("output") {
             request = request.output(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<String>("task") {
+            request = request.task(value.clone());
         }
 
         self.over
@@ -539,14 +539,14 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_user_create(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.user_create();
+        if let Some(value) = matches.get_one::<String>("name") {
+            request = request.body_map(|body| body.name(value.clone()))
+        }
+
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
             let body_txt = std::fs::read_to_string(value).unwrap();
             let body_value = serde_json::from_str::<types::UserCreate>(&body_txt).unwrap();
             request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<String>("name") {
-            request = request.body_map(|body| body.name(value.clone()))
         }
 
         self.over
@@ -579,18 +579,18 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_worker_bootstrap(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.worker_bootstrap();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::WorkerBootstrap>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
         if let Some(value) = matches.get_one::<String>("bootstrap") {
             request = request.body_map(|body| body.bootstrap(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<String>("token") {
             request = request.body_map(|body| body.token(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::WorkerBootstrap>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -625,16 +625,6 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_worker_task_append(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.worker_task_append();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::WorkerAppendTask>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<String>("task") {
-            request = request.task(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<String>("payload") {
             request = request.body_map(|body| body.payload(value.clone()))
         }
@@ -643,8 +633,18 @@ impl<T: CliOverride> Cli<T> {
             request = request.body_map(|body| body.stream(value.clone()))
         }
 
+        if let Some(value) = matches.get_one::<String>("task") {
+            request = request.task(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<chrono::DateTime<chrono::offset::Utc>>("time") {
             request = request.body_map(|body| body.time(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::WorkerAppendTask>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -683,18 +683,18 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_worker_task_complete(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.worker_task_complete();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::WorkerCompleteTask>(&body_txt).unwrap();
-            request = request.body(body_value);
+        if let Some(value) = matches.get_one::<bool>("failed") {
+            request = request.body_map(|body| body.failed(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<String>("task") {
             request = request.task(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<bool>("failed") {
-            request = request.body_map(|body| body.failed(value.clone()))
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::WorkerCompleteTask>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -713,22 +713,22 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_worker_task_add_output(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.worker_task_add_output();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::WorkerAddOutput>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<String>("task") {
-            request = request.task(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<String>("path") {
             request = request.body_map(|body| body.path(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<i64>("size") {
             request = request.body_map(|body| body.size(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<String>("task") {
+            request = request.task(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::WorkerAddOutput>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over

--- a/progenitor-impl/tests/output/keeper-cli.out
+++ b/progenitor-impl/tests/output/keeper-cli.out
@@ -212,12 +212,6 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_enrol(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.enrol();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::EnrolBody>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
         if let Some(value) = matches.get_one::<String>("authorization") {
             request = request.authorization(value.clone());
         }
@@ -228,6 +222,12 @@ impl<T: CliOverride> Cli<T> {
 
         if let Some(value) = matches.get_one::<String>("key") {
             request = request.body_map(|body| body.key(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::EnrolBody>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over.execute_enrol(matches, &mut request).unwrap();
@@ -282,12 +282,6 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_report_finish(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.report_finish();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::ReportFinishBody>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
         if let Some(value) = matches.get_one::<String>("authorization") {
             request = request.authorization(value.clone());
         }
@@ -302,6 +296,12 @@ impl<T: CliOverride> Cli<T> {
 
         if let Some(value) = matches.get_one::<i32>("exit-status") {
             request = request.body_map(|body| body.exit_status(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::ReportFinishBody>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -320,14 +320,14 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_report_output(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.report_output();
+        if let Some(value) = matches.get_one::<String>("authorization") {
+            request = request.authorization(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
             let body_txt = std::fs::read_to_string(value).unwrap();
             let body_value = serde_json::from_str::<types::ReportOutputBody>(&body_txt).unwrap();
             request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<String>("authorization") {
-            request = request.authorization(value.clone());
         }
 
         self.over
@@ -346,12 +346,6 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_report_start(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.report_start();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::ReportStartBody>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
         if let Some(value) = matches.get_one::<String>("authorization") {
             request = request.authorization(value.clone());
         }
@@ -363,6 +357,12 @@ impl<T: CliOverride> Cli<T> {
         if let Some(value) = matches.get_one::<chrono::DateTime<chrono::offset::Utc>>("start-time")
         {
             request = request.body_map(|body| body.start_time(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::ReportStartBody>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over

--- a/progenitor-impl/tests/output/nexus-cli.out
+++ b/progenitor-impl/tests/output/nexus-cli.out
@@ -492,16 +492,16 @@ impl Cli {
     pub fn cli_login_local() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("silo-name")
-                    .long("silo-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
                 clap::Arg::new("password")
                     .long("password")
                     .value_parser(clap::value_parser!(types::Password))
                     .required_unless_present("json-body"),
+            )
+            .arg(
+                clap::Arg::new("silo-name")
+                    .long("silo-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
             )
             .arg(
                 clap::Arg::new("username")
@@ -529,14 +529,14 @@ impl Cli {
     pub fn cli_login_saml_begin() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("silo-name")
-                    .long("silo-name")
+                clap::Arg::new("provider-name")
+                    .long("provider-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
             .arg(
-                clap::Arg::new("provider-name")
-                    .long("provider-name")
+                clap::Arg::new("silo-name")
+                    .long("silo-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
@@ -550,14 +550,14 @@ impl Cli {
     pub fn cli_login_saml() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("silo-name")
-                    .long("silo-name")
+                clap::Arg::new("provider-name")
+                    .long("provider-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
             .arg(
-                clap::Arg::new("provider-name")
-                    .long("provider-name")
+                clap::Arg::new("silo-name")
+                    .long("silo-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
@@ -642,13 +642,6 @@ impl Cli {
     pub fn cli_organization_update() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("organization-name")
-                    .long("organization-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true)
-                    .help("The organization's unique name."),
-            )
-            .arg(
                 clap::Arg::new("description")
                     .long("description")
                     .value_parser(clap::value_parser!(String))
@@ -659,6 +652,13 @@ impl Cli {
                     .long("name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(false),
+            )
+            .arg(
+                clap::Arg::new("organization-name")
+                    .long("organization-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true)
+                    .help("The organization's unique name."),
             )
             .arg(
                 clap::Arg::new("json-body")
@@ -734,18 +734,18 @@ impl Cli {
     pub fn cli_project_list() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("organization-name")
-                    .long("organization-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true)
-                    .help("The organization's unique name."),
-            )
-            .arg(
                 clap::Arg::new("limit")
                     .long("limit")
                     .value_parser(clap::value_parser!(std::num::NonZeroU32))
                     .required(false)
                     .help("Maximum number of items returned by a single call"),
+            )
+            .arg(
+                clap::Arg::new("organization-name")
+                    .long("organization-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true)
+                    .help("The organization's unique name."),
             )
             .arg(
                 clap::Arg::new("sort-by")
@@ -767,13 +767,6 @@ impl Cli {
     pub fn cli_project_create() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("organization-name")
-                    .long("organization-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true)
-                    .help("The organization's unique name."),
-            )
-            .arg(
                 clap::Arg::new("description")
                     .long("description")
                     .value_parser(clap::value_parser!(String))
@@ -784,6 +777,13 @@ impl Cli {
                     .long("name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required_unless_present("json-body"),
+            )
+            .arg(
+                clap::Arg::new("organization-name")
+                    .long("organization-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true)
+                    .help("The organization's unique name."),
             )
             .arg(
                 clap::Arg::new("json-body")
@@ -826,6 +826,18 @@ impl Cli {
     pub fn cli_project_update() -> clap::Command {
         clap::Command::new("")
             .arg(
+                clap::Arg::new("description")
+                    .long("description")
+                    .value_parser(clap::value_parser!(String))
+                    .required(false),
+            )
+            .arg(
+                clap::Arg::new("name")
+                    .long("name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(false),
+            )
+            .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
                     .value_parser(clap::value_parser!(types::Name))
@@ -838,18 +850,6 @@ impl Cli {
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true)
                     .help("The project's unique name within the organization."),
-            )
-            .arg(
-                clap::Arg::new("description")
-                    .long("description")
-                    .value_parser(clap::value_parser!(String))
-                    .required(false),
-            )
-            .arg(
-                clap::Arg::new("name")
-                    .long("name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(false),
             )
             .arg(
                 clap::Arg::new("json-body")
@@ -892,6 +892,13 @@ impl Cli {
     pub fn cli_disk_list() -> clap::Command {
         clap::Command::new("")
             .arg(
+                clap::Arg::new("limit")
+                    .long("limit")
+                    .value_parser(clap::value_parser!(std::num::NonZeroU32))
+                    .required(false)
+                    .help("Maximum number of items returned by a single call"),
+            )
+            .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
                     .value_parser(clap::value_parser!(types::Name))
@@ -904,13 +911,6 @@ impl Cli {
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true)
                     .help("The project's unique name within the organization."),
-            )
-            .arg(
-                clap::Arg::new("limit")
-                    .long("limit")
-                    .value_parser(clap::value_parser!(std::num::NonZeroU32))
-                    .required(false)
-                    .help("Maximum number of items returned by a single call"),
             )
             .arg(
                 clap::Arg::new("sort-by")
@@ -930,6 +930,18 @@ impl Cli {
     pub fn cli_disk_create() -> clap::Command {
         clap::Command::new("")
             .arg(
+                clap::Arg::new("description")
+                    .long("description")
+                    .value_parser(clap::value_parser!(String))
+                    .required_unless_present("json-body"),
+            )
+            .arg(
+                clap::Arg::new("name")
+                    .long("name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required_unless_present("json-body"),
+            )
+            .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
                     .value_parser(clap::value_parser!(types::Name))
@@ -942,18 +954,6 @@ impl Cli {
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true)
                     .help("The project's unique name within the organization."),
-            )
-            .arg(
-                clap::Arg::new("description")
-                    .long("description")
-                    .value_parser(clap::value_parser!(String))
-                    .required_unless_present("json-body"),
-            )
-            .arg(
-                clap::Arg::new("name")
-                    .long("name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required_unless_present("json-body"),
             )
             .arg(
                 clap::Arg::new("size")
@@ -982,6 +982,12 @@ impl Cli {
     pub fn cli_disk_view() -> clap::Command {
         clap::Command::new("")
             .arg(
+                clap::Arg::new("disk-name")
+                    .long("disk-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
+            .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
                     .value_parser(clap::value_parser!(types::Name))
@@ -990,12 +996,6 @@ impl Cli {
             .arg(
                 clap::Arg::new("project-name")
                     .long("project-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("disk-name")
-                    .long("disk-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
@@ -1006,6 +1006,12 @@ impl Cli {
     pub fn cli_disk_delete() -> clap::Command {
         clap::Command::new("")
             .arg(
+                clap::Arg::new("disk-name")
+                    .long("disk-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
+            .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
                     .value_parser(clap::value_parser!(types::Name))
@@ -1014,12 +1020,6 @@ impl Cli {
             .arg(
                 clap::Arg::new("project-name")
                     .long("project-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("disk-name")
-                    .long("disk-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
@@ -1029,22 +1029,24 @@ impl Cli {
     pub fn cli_disk_metrics_list() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("organization-name")
-                    .long("organization-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("project-name")
-                    .long("project-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
                 clap::Arg::new("disk-name")
                     .long("disk-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
+            )
+            .arg(
+                clap::Arg::new("end-time")
+                    .long("end-time")
+                    .value_parser(clap::value_parser!(chrono::DateTime<chrono::offset::Utc>))
+                    .required(true)
+                    .help("An exclusive end time of metrics."),
+            )
+            .arg(
+                clap::Arg::new("limit")
+                    .long("limit")
+                    .value_parser(clap::value_parser!(std::num::NonZeroU32))
+                    .required(false)
+                    .help("Maximum number of items returned by a single call"),
             )
             .arg(
                 clap::Arg::new("metric-name")
@@ -1063,18 +1065,16 @@ impl Cli {
                     .required(true),
             )
             .arg(
-                clap::Arg::new("end-time")
-                    .long("end-time")
-                    .value_parser(clap::value_parser!(chrono::DateTime<chrono::offset::Utc>))
-                    .required(true)
-                    .help("An exclusive end time of metrics."),
+                clap::Arg::new("organization-name")
+                    .long("organization-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
             )
             .arg(
-                clap::Arg::new("limit")
-                    .long("limit")
-                    .value_parser(clap::value_parser!(std::num::NonZeroU32))
-                    .required(false)
-                    .help("Maximum number of items returned by a single call"),
+                clap::Arg::new("project-name")
+                    .long("project-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
             )
             .arg(
                 clap::Arg::new("start-time")
@@ -1089,6 +1089,13 @@ impl Cli {
     pub fn cli_image_list() -> clap::Command {
         clap::Command::new("")
             .arg(
+                clap::Arg::new("limit")
+                    .long("limit")
+                    .value_parser(clap::value_parser!(std::num::NonZeroU32))
+                    .required(false)
+                    .help("Maximum number of items returned by a single call"),
+            )
+            .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
                     .value_parser(clap::value_parser!(types::Name))
@@ -1101,13 +1108,6 @@ impl Cli {
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true)
                     .help("The project's unique name within the organization."),
-            )
-            .arg(
-                clap::Arg::new("limit")
-                    .long("limit")
-                    .value_parser(clap::value_parser!(std::num::NonZeroU32))
-                    .required(false)
-                    .help("Maximum number of items returned by a single call"),
             )
             .arg(
                 clap::Arg::new("sort-by")
@@ -1130,6 +1130,18 @@ impl Cli {
     pub fn cli_image_create() -> clap::Command {
         clap::Command::new("")
             .arg(
+                clap::Arg::new("description")
+                    .long("description")
+                    .value_parser(clap::value_parser!(String))
+                    .required_unless_present("json-body"),
+            )
+            .arg(
+                clap::Arg::new("name")
+                    .long("name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required_unless_present("json-body"),
+            )
+            .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
                     .value_parser(clap::value_parser!(types::Name))
@@ -1142,18 +1154,6 @@ impl Cli {
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true)
                     .help("The project's unique name within the organization."),
-            )
-            .arg(
-                clap::Arg::new("description")
-                    .long("description")
-                    .value_parser(clap::value_parser!(String))
-                    .required_unless_present("json-body"),
-            )
-            .arg(
-                clap::Arg::new("name")
-                    .long("name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required_unless_present("json-body"),
             )
             .arg(
                 clap::Arg::new("json-body")
@@ -1176,6 +1176,12 @@ impl Cli {
     pub fn cli_image_view() -> clap::Command {
         clap::Command::new("")
             .arg(
+                clap::Arg::new("image-name")
+                    .long("image-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
+            .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
                     .value_parser(clap::value_parser!(types::Name))
@@ -1184,12 +1190,6 @@ impl Cli {
             .arg(
                 clap::Arg::new("project-name")
                     .long("project-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("image-name")
-                    .long("image-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
@@ -1200,6 +1200,12 @@ impl Cli {
     pub fn cli_image_delete() -> clap::Command {
         clap::Command::new("")
             .arg(
+                clap::Arg::new("image-name")
+                    .long("image-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
+            .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
                     .value_parser(clap::value_parser!(types::Name))
@@ -1208,12 +1214,6 @@ impl Cli {
             .arg(
                 clap::Arg::new("project-name")
                     .long("project-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("image-name")
-                    .long("image-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
@@ -1228,6 +1228,13 @@ impl Cli {
     pub fn cli_instance_list() -> clap::Command {
         clap::Command::new("")
             .arg(
+                clap::Arg::new("limit")
+                    .long("limit")
+                    .value_parser(clap::value_parser!(std::num::NonZeroU32))
+                    .required(false)
+                    .help("Maximum number of items returned by a single call"),
+            )
+            .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
                     .value_parser(clap::value_parser!(types::Name))
@@ -1240,13 +1247,6 @@ impl Cli {
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true)
                     .help("The project's unique name within the organization."),
-            )
-            .arg(
-                clap::Arg::new("limit")
-                    .long("limit")
-                    .value_parser(clap::value_parser!(std::num::NonZeroU32))
-                    .required(false)
-                    .help("Maximum number of items returned by a single call"),
             )
             .arg(
                 clap::Arg::new("sort-by")
@@ -1264,20 +1264,6 @@ impl Cli {
 
     pub fn cli_instance_create() -> clap::Command {
         clap::Command::new("")
-            .arg(
-                clap::Arg::new("organization-name")
-                    .long("organization-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true)
-                    .help("The organization's unique name."),
-            )
-            .arg(
-                clap::Arg::new("project-name")
-                    .long("project-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true)
-                    .help("The project's unique name within the organization."),
-            )
             .arg(
                 clap::Arg::new("description")
                     .long("description")
@@ -1307,6 +1293,20 @@ impl Cli {
                     .long("ncpus")
                     .value_parser(clap::value_parser!(types::InstanceCpuCount))
                     .required_unless_present("json-body"),
+            )
+            .arg(
+                clap::Arg::new("organization-name")
+                    .long("organization-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true)
+                    .help("The organization's unique name."),
+            )
+            .arg(
+                clap::Arg::new("project-name")
+                    .long("project-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true)
+                    .help("The project's unique name within the organization."),
             )
             .arg(
                 clap::Arg::new("start")
@@ -1347,6 +1347,12 @@ impl Cli {
     pub fn cli_instance_view() -> clap::Command {
         clap::Command::new("")
             .arg(
+                clap::Arg::new("instance-name")
+                    .long("instance-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
+            .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
                     .value_parser(clap::value_parser!(types::Name))
@@ -1355,12 +1361,6 @@ impl Cli {
             .arg(
                 clap::Arg::new("project-name")
                     .long("project-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("instance-name")
-                    .long("instance-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
@@ -1371,6 +1371,12 @@ impl Cli {
     pub fn cli_instance_delete() -> clap::Command {
         clap::Command::new("")
             .arg(
+                clap::Arg::new("instance-name")
+                    .long("instance-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
+            .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
                     .value_parser(clap::value_parser!(types::Name))
@@ -1379,12 +1385,6 @@ impl Cli {
             .arg(
                 clap::Arg::new("project-name")
                     .long("project-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("instance-name")
-                    .long("instance-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
@@ -1393,18 +1393,6 @@ impl Cli {
 
     pub fn cli_instance_disk_list() -> clap::Command {
         clap::Command::new("")
-            .arg(
-                clap::Arg::new("organization-name")
-                    .long("organization-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("project-name")
-                    .long("project-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
             .arg(
                 clap::Arg::new("instance-name")
                     .long("instance-name")
@@ -1417,6 +1405,18 @@ impl Cli {
                     .value_parser(clap::value_parser!(std::num::NonZeroU32))
                     .required(false)
                     .help("Maximum number of items returned by a single call"),
+            )
+            .arg(
+                clap::Arg::new("organization-name")
+                    .long("organization-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
+            .arg(
+                clap::Arg::new("project-name")
+                    .long("project-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
             )
             .arg(
                 clap::Arg::new("sort-by")
@@ -1436,18 +1436,6 @@ impl Cli {
     pub fn cli_instance_disk_attach() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("organization-name")
-                    .long("organization-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("project-name")
-                    .long("project-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
                 clap::Arg::new("instance-name")
                     .long("instance-name")
                     .value_parser(clap::value_parser!(types::Name))
@@ -1458,6 +1446,18 @@ impl Cli {
                     .long("name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required_unless_present("json-body"),
+            )
+            .arg(
+                clap::Arg::new("organization-name")
+                    .long("organization-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
+            .arg(
+                clap::Arg::new("project-name")
+                    .long("project-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
             )
             .arg(
                 clap::Arg::new("json-body")
@@ -1480,18 +1480,6 @@ impl Cli {
     pub fn cli_instance_disk_detach() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("organization-name")
-                    .long("organization-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("project-name")
-                    .long("project-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
                 clap::Arg::new("instance-name")
                     .long("instance-name")
                     .value_parser(clap::value_parser!(types::Name))
@@ -1502,6 +1490,18 @@ impl Cli {
                     .long("name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required_unless_present("json-body"),
+            )
+            .arg(
+                clap::Arg::new("organization-name")
+                    .long("organization-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
+            .arg(
+                clap::Arg::new("project-name")
+                    .long("project-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
             )
             .arg(
                 clap::Arg::new("json-body")
@@ -1524,6 +1524,12 @@ impl Cli {
     pub fn cli_instance_external_ip_list() -> clap::Command {
         clap::Command::new("")
             .arg(
+                clap::Arg::new("instance-name")
+                    .long("instance-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
+            .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
                     .value_parser(clap::value_parser!(types::Name))
@@ -1532,12 +1538,6 @@ impl Cli {
             .arg(
                 clap::Arg::new("project-name")
                     .long("project-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("instance-name")
-                    .long("instance-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
@@ -1547,6 +1547,18 @@ impl Cli {
     pub fn cli_instance_migrate() -> clap::Command {
         clap::Command::new("")
             .arg(
+                clap::Arg::new("dst-sled-id")
+                    .long("dst-sled-id")
+                    .value_parser(clap::value_parser!(uuid::Uuid))
+                    .required_unless_present("json-body"),
+            )
+            .arg(
+                clap::Arg::new("instance-name")
+                    .long("instance-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
+            .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
                     .value_parser(clap::value_parser!(types::Name))
@@ -1557,18 +1569,6 @@ impl Cli {
                     .long("project-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
-            )
-            .arg(
-                clap::Arg::new("instance-name")
-                    .long("instance-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("dst-sled-id")
-                    .long("dst-sled-id")
-                    .value_parser(clap::value_parser!(uuid::Uuid))
-                    .required_unless_present("json-body"),
             )
             .arg(
                 clap::Arg::new("json-body")
@@ -1591,18 +1591,6 @@ impl Cli {
     pub fn cli_instance_network_interface_list() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("organization-name")
-                    .long("organization-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("project-name")
-                    .long("project-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
                 clap::Arg::new("instance-name")
                     .long("instance-name")
                     .value_parser(clap::value_parser!(types::Name))
@@ -1614,6 +1602,18 @@ impl Cli {
                     .value_parser(clap::value_parser!(std::num::NonZeroU32))
                     .required(false)
                     .help("Maximum number of items returned by a single call"),
+            )
+            .arg(
+                clap::Arg::new("organization-name")
+                    .long("organization-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
+            .arg(
+                clap::Arg::new("project-name")
+                    .long("project-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
             )
             .arg(
                 clap::Arg::new("sort-by")
@@ -1632,28 +1632,16 @@ impl Cli {
     pub fn cli_instance_network_interface_create() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("organization-name")
-                    .long("organization-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("project-name")
-                    .long("project-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
+                clap::Arg::new("description")
+                    .long("description")
+                    .value_parser(clap::value_parser!(String))
+                    .required_unless_present("json-body"),
             )
             .arg(
                 clap::Arg::new("instance-name")
                     .long("instance-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
-            )
-            .arg(
-                clap::Arg::new("description")
-                    .long("description")
-                    .value_parser(clap::value_parser!(String))
-                    .required_unless_present("json-body"),
             )
             .arg(
                 clap::Arg::new("ip")
@@ -1670,6 +1658,18 @@ impl Cli {
                     .long("name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required_unless_present("json-body"),
+            )
+            .arg(
+                clap::Arg::new("organization-name")
+                    .long("organization-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
+            .arg(
+                clap::Arg::new("project-name")
+                    .long("project-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
             )
             .arg(
                 clap::Arg::new("subnet-name")
@@ -1705,18 +1705,6 @@ impl Cli {
     pub fn cli_instance_network_interface_view() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("organization-name")
-                    .long("organization-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("project-name")
-                    .long("project-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
                 clap::Arg::new("instance-name")
                     .long("instance-name")
                     .value_parser(clap::value_parser!(types::Name))
@@ -1725,6 +1713,18 @@ impl Cli {
             .arg(
                 clap::Arg::new("interface-name")
                     .long("interface-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
+            .arg(
+                clap::Arg::new("organization-name")
+                    .long("organization-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
+            .arg(
+                clap::Arg::new("project-name")
+                    .long("project-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
@@ -1734,16 +1734,10 @@ impl Cli {
     pub fn cli_instance_network_interface_update() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("organization-name")
-                    .long("organization-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("project-name")
-                    .long("project-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
+                clap::Arg::new("description")
+                    .long("description")
+                    .value_parser(clap::value_parser!(String))
+                    .required(false),
             )
             .arg(
                 clap::Arg::new("instance-name")
@@ -1758,16 +1752,16 @@ impl Cli {
                     .required(true),
             )
             .arg(
-                clap::Arg::new("description")
-                    .long("description")
-                    .value_parser(clap::value_parser!(String))
-                    .required(false),
-            )
-            .arg(
                 clap::Arg::new("name")
                     .long("name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(false),
+            )
+            .arg(
+                clap::Arg::new("organization-name")
+                    .long("organization-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
             )
             .arg(
                 clap::Arg::new("primary")
@@ -1784,6 +1778,12 @@ impl Cli {
                          Requests to change the primary interface into a secondary will return an \
                          error.",
                     ),
+            )
+            .arg(
+                clap::Arg::new("project-name")
+                    .long("project-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
             )
             .arg(
                 clap::Arg::new("json-body")
@@ -1805,18 +1805,6 @@ impl Cli {
     pub fn cli_instance_network_interface_delete() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("organization-name")
-                    .long("organization-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("project-name")
-                    .long("project-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
                 clap::Arg::new("instance-name")
                     .long("instance-name")
                     .value_parser(clap::value_parser!(types::Name))
@@ -1825,6 +1813,18 @@ impl Cli {
             .arg(
                 clap::Arg::new("interface-name")
                     .long("interface-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
+            .arg(
+                clap::Arg::new("organization-name")
+                    .long("organization-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
+            .arg(
+                clap::Arg::new("project-name")
+                    .long("project-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
@@ -1839,6 +1839,12 @@ impl Cli {
     pub fn cli_instance_reboot() -> clap::Command {
         clap::Command::new("")
             .arg(
+                clap::Arg::new("instance-name")
+                    .long("instance-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
+            .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
                     .value_parser(clap::value_parser!(types::Name))
@@ -1847,12 +1853,6 @@ impl Cli {
             .arg(
                 clap::Arg::new("project-name")
                     .long("project-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("instance-name")
-                    .long("instance-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
@@ -1862,24 +1862,6 @@ impl Cli {
 
     pub fn cli_instance_serial_console() -> clap::Command {
         clap::Command::new("")
-            .arg(
-                clap::Arg::new("organization-name")
-                    .long("organization-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("project-name")
-                    .long("project-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("instance-name")
-                    .long("instance-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
             .arg(
                 clap::Arg::new("from-start")
                     .long("from-start")
@@ -1891,6 +1873,12 @@ impl Cli {
                          `most_recent` must be provided, and if this *is* provided, `most_recent` \
                          must *not* be provided.",
                     ),
+            )
+            .arg(
+                clap::Arg::new("instance-name")
+                    .long("instance-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
             )
             .arg(
                 clap::Arg::new("max-bytes")
@@ -1914,12 +1902,6 @@ impl Cli {
                          instance. (See note on `from_start` about mutual exclusivity)",
                     ),
             )
-            .about("Fetch an instance's serial console")
-            .long_about("Use `GET /v1/instances/{instance}/serial-console` instead")
-    }
-
-    pub fn cli_instance_serial_console_stream() -> clap::Command {
-        clap::Command::new("")
             .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
@@ -1932,9 +1914,27 @@ impl Cli {
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
+            .about("Fetch an instance's serial console")
+            .long_about("Use `GET /v1/instances/{instance}/serial-console` instead")
+    }
+
+    pub fn cli_instance_serial_console_stream() -> clap::Command {
+        clap::Command::new("")
             .arg(
                 clap::Arg::new("instance-name")
                     .long("instance-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
+            .arg(
+                clap::Arg::new("organization-name")
+                    .long("organization-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
+            .arg(
+                clap::Arg::new("project-name")
+                    .long("project-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
@@ -1945,6 +1945,12 @@ impl Cli {
     pub fn cli_instance_start() -> clap::Command {
         clap::Command::new("")
             .arg(
+                clap::Arg::new("instance-name")
+                    .long("instance-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
+            .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
                     .value_parser(clap::value_parser!(types::Name))
@@ -1953,12 +1959,6 @@ impl Cli {
             .arg(
                 clap::Arg::new("project-name")
                     .long("project-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("instance-name")
-                    .long("instance-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
@@ -1969,6 +1969,12 @@ impl Cli {
     pub fn cli_instance_stop() -> clap::Command {
         clap::Command::new("")
             .arg(
+                clap::Arg::new("instance-name")
+                    .long("instance-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
+            .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
                     .value_parser(clap::value_parser!(types::Name))
@@ -1977,12 +1983,6 @@ impl Cli {
             .arg(
                 clap::Arg::new("project-name")
                     .long("project-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("instance-name")
-                    .long("instance-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
@@ -2046,6 +2046,13 @@ impl Cli {
     pub fn cli_snapshot_list() -> clap::Command {
         clap::Command::new("")
             .arg(
+                clap::Arg::new("limit")
+                    .long("limit")
+                    .value_parser(clap::value_parser!(std::num::NonZeroU32))
+                    .required(false)
+                    .help("Maximum number of items returned by a single call"),
+            )
+            .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
                     .value_parser(clap::value_parser!(types::Name))
@@ -2058,13 +2065,6 @@ impl Cli {
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true)
                     .help("The project's unique name within the organization."),
-            )
-            .arg(
-                clap::Arg::new("limit")
-                    .long("limit")
-                    .value_parser(clap::value_parser!(std::num::NonZeroU32))
-                    .required(false)
-                    .help("Maximum number of items returned by a single call"),
             )
             .arg(
                 clap::Arg::new("sort-by")
@@ -2083,20 +2083,6 @@ impl Cli {
     pub fn cli_snapshot_create() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("organization-name")
-                    .long("organization-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true)
-                    .help("The organization's unique name."),
-            )
-            .arg(
-                clap::Arg::new("project-name")
-                    .long("project-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true)
-                    .help("The project's unique name within the organization."),
-            )
-            .arg(
                 clap::Arg::new("description")
                     .long("description")
                     .value_parser(clap::value_parser!(String))
@@ -2114,6 +2100,20 @@ impl Cli {
                     .long("name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required_unless_present("json-body"),
+            )
+            .arg(
+                clap::Arg::new("organization-name")
+                    .long("organization-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true)
+                    .help("The organization's unique name."),
+            )
+            .arg(
+                clap::Arg::new("project-name")
+                    .long("project-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true)
+                    .help("The project's unique name within the organization."),
             )
             .arg(
                 clap::Arg::new("json-body")
@@ -2182,6 +2182,13 @@ impl Cli {
     pub fn cli_vpc_list() -> clap::Command {
         clap::Command::new("")
             .arg(
+                clap::Arg::new("limit")
+                    .long("limit")
+                    .value_parser(clap::value_parser!(std::num::NonZeroU32))
+                    .required(false)
+                    .help("Maximum number of items returned by a single call"),
+            )
+            .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
                     .value_parser(clap::value_parser!(types::Name))
@@ -2194,13 +2201,6 @@ impl Cli {
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true)
                     .help("The project's unique name within the organization."),
-            )
-            .arg(
-                clap::Arg::new("limit")
-                    .long("limit")
-                    .value_parser(clap::value_parser!(std::num::NonZeroU32))
-                    .required(false)
-                    .help("Maximum number of items returned by a single call"),
             )
             .arg(
                 clap::Arg::new("sort-by")
@@ -2218,20 +2218,6 @@ impl Cli {
 
     pub fn cli_vpc_create() -> clap::Command {
         clap::Command::new("")
-            .arg(
-                clap::Arg::new("organization-name")
-                    .long("organization-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true)
-                    .help("The organization's unique name."),
-            )
-            .arg(
-                clap::Arg::new("project-name")
-                    .long("project-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true)
-                    .help("The project's unique name within the organization."),
-            )
             .arg(
                 clap::Arg::new("description")
                     .long("description")
@@ -2261,6 +2247,20 @@ impl Cli {
                     .long("name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required_unless_present("json-body"),
+            )
+            .arg(
+                clap::Arg::new("organization-name")
+                    .long("organization-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true)
+                    .help("The organization's unique name."),
+            )
+            .arg(
+                clap::Arg::new("project-name")
+                    .long("project-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true)
+                    .help("The project's unique name within the organization."),
             )
             .arg(
                 clap::Arg::new("json-body")
@@ -2305,24 +2305,6 @@ impl Cli {
     pub fn cli_vpc_update() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("organization-name")
-                    .long("organization-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("project-name")
-                    .long("project-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("vpc-name")
-                    .long("vpc-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
                 clap::Arg::new("description")
                     .long("description")
                     .value_parser(clap::value_parser!(String))
@@ -2339,6 +2321,24 @@ impl Cli {
                     .long("name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(false),
+            )
+            .arg(
+                clap::Arg::new("organization-name")
+                    .long("organization-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
+            .arg(
+                clap::Arg::new("project-name")
+                    .long("project-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
+            .arg(
+                clap::Arg::new("vpc-name")
+                    .long("vpc-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
             )
             .arg(
                 clap::Arg::new("json-body")
@@ -2443,6 +2443,13 @@ impl Cli {
     pub fn cli_vpc_router_list() -> clap::Command {
         clap::Command::new("")
             .arg(
+                clap::Arg::new("limit")
+                    .long("limit")
+                    .value_parser(clap::value_parser!(std::num::NonZeroU32))
+                    .required(false)
+                    .help("Maximum number of items returned by a single call"),
+            )
+            .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
                     .value_parser(clap::value_parser!(types::Name))
@@ -2453,19 +2460,6 @@ impl Cli {
                     .long("project-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
-            )
-            .arg(
-                clap::Arg::new("vpc-name")
-                    .long("vpc-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("limit")
-                    .long("limit")
-                    .value_parser(clap::value_parser!(std::num::NonZeroU32))
-                    .required(false)
-                    .help("Maximum number of items returned by a single call"),
             )
             .arg(
                 clap::Arg::new("sort-by")
@@ -2478,11 +2472,29 @@ impl Cli {
                     ))
                     .required(false),
             )
+            .arg(
+                clap::Arg::new("vpc-name")
+                    .long("vpc-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
             .about("List routers")
     }
 
     pub fn cli_vpc_router_create() -> clap::Command {
         clap::Command::new("")
+            .arg(
+                clap::Arg::new("description")
+                    .long("description")
+                    .value_parser(clap::value_parser!(String))
+                    .required_unless_present("json-body"),
+            )
+            .arg(
+                clap::Arg::new("name")
+                    .long("name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required_unless_present("json-body"),
+            )
             .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
@@ -2500,18 +2512,6 @@ impl Cli {
                     .long("vpc-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
-            )
-            .arg(
-                clap::Arg::new("description")
-                    .long("description")
-                    .value_parser(clap::value_parser!(String))
-                    .required_unless_present("json-body"),
-            )
-            .arg(
-                clap::Arg::new("name")
-                    .long("name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required_unless_present("json-body"),
             )
             .arg(
                 clap::Arg::new("json-body")
@@ -2545,14 +2545,14 @@ impl Cli {
                     .required(true),
             )
             .arg(
-                clap::Arg::new("vpc-name")
-                    .long("vpc-name")
+                clap::Arg::new("router-name")
+                    .long("router-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
             .arg(
-                clap::Arg::new("router-name")
-                    .long("router-name")
+                clap::Arg::new("vpc-name")
+                    .long("vpc-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
@@ -2561,6 +2561,18 @@ impl Cli {
 
     pub fn cli_vpc_router_update() -> clap::Command {
         clap::Command::new("")
+            .arg(
+                clap::Arg::new("description")
+                    .long("description")
+                    .value_parser(clap::value_parser!(String))
+                    .required(false),
+            )
+            .arg(
+                clap::Arg::new("name")
+                    .long("name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(false),
+            )
             .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
@@ -2574,28 +2586,16 @@ impl Cli {
                     .required(true),
             )
             .arg(
-                clap::Arg::new("vpc-name")
-                    .long("vpc-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
                 clap::Arg::new("router-name")
                     .long("router-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
             .arg(
-                clap::Arg::new("description")
-                    .long("description")
-                    .value_parser(clap::value_parser!(String))
-                    .required(false),
-            )
-            .arg(
-                clap::Arg::new("name")
-                    .long("name")
+                clap::Arg::new("vpc-name")
+                    .long("vpc-name")
                     .value_parser(clap::value_parser!(types::Name))
-                    .required(false),
+                    .required(true),
             )
             .arg(
                 clap::Arg::new("json-body")
@@ -2629,14 +2629,14 @@ impl Cli {
                     .required(true),
             )
             .arg(
-                clap::Arg::new("vpc-name")
-                    .long("vpc-name")
+                clap::Arg::new("router-name")
+                    .long("router-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
             .arg(
-                clap::Arg::new("router-name")
-                    .long("router-name")
+                clap::Arg::new("vpc-name")
+                    .long("vpc-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
@@ -2645,6 +2645,13 @@ impl Cli {
 
     pub fn cli_vpc_router_route_list() -> clap::Command {
         clap::Command::new("")
+            .arg(
+                clap::Arg::new("limit")
+                    .long("limit")
+                    .value_parser(clap::value_parser!(std::num::NonZeroU32))
+                    .required(false)
+                    .help("Maximum number of items returned by a single call"),
+            )
             .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
@@ -2658,23 +2665,10 @@ impl Cli {
                     .required(true),
             )
             .arg(
-                clap::Arg::new("vpc-name")
-                    .long("vpc-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
                 clap::Arg::new("router-name")
                     .long("router-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
-            )
-            .arg(
-                clap::Arg::new("limit")
-                    .long("limit")
-                    .value_parser(clap::value_parser!(std::num::NonZeroU32))
-                    .required(false)
-                    .help("Maximum number of items returned by a single call"),
             )
             .arg(
                 clap::Arg::new("sort-by")
@@ -2687,12 +2681,30 @@ impl Cli {
                     ))
                     .required(false),
             )
+            .arg(
+                clap::Arg::new("vpc-name")
+                    .long("vpc-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
             .about("List routes")
             .long_about("List the routes associated with a router in a particular VPC.")
     }
 
     pub fn cli_vpc_router_route_create() -> clap::Command {
         clap::Command::new("")
+            .arg(
+                clap::Arg::new("description")
+                    .long("description")
+                    .value_parser(clap::value_parser!(String))
+                    .required_unless_present("json-body"),
+            )
+            .arg(
+                clap::Arg::new("name")
+                    .long("name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required_unless_present("json-body"),
+            )
             .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
@@ -2706,28 +2718,16 @@ impl Cli {
                     .required(true),
             )
             .arg(
-                clap::Arg::new("vpc-name")
-                    .long("vpc-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
                 clap::Arg::new("router-name")
                     .long("router-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
             .arg(
-                clap::Arg::new("description")
-                    .long("description")
-                    .value_parser(clap::value_parser!(String))
-                    .required_unless_present("json-body"),
-            )
-            .arg(
-                clap::Arg::new("name")
-                    .long("name")
+                clap::Arg::new("vpc-name")
+                    .long("vpc-name")
                     .value_parser(clap::value_parser!(types::Name))
-                    .required_unless_present("json-body"),
+                    .required(true),
             )
             .arg(
                 clap::Arg::new("json-body")
@@ -2761,8 +2761,8 @@ impl Cli {
                     .required(true),
             )
             .arg(
-                clap::Arg::new("vpc-name")
-                    .long("vpc-name")
+                clap::Arg::new("route-name")
+                    .long("route-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
@@ -2773,8 +2773,8 @@ impl Cli {
                     .required(true),
             )
             .arg(
-                clap::Arg::new("route-name")
-                    .long("route-name")
+                clap::Arg::new("vpc-name")
+                    .long("vpc-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
@@ -2783,6 +2783,18 @@ impl Cli {
 
     pub fn cli_vpc_router_route_update() -> clap::Command {
         clap::Command::new("")
+            .arg(
+                clap::Arg::new("description")
+                    .long("description")
+                    .value_parser(clap::value_parser!(String))
+                    .required(false),
+            )
+            .arg(
+                clap::Arg::new("name")
+                    .long("name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(false),
+            )
             .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
@@ -2796,8 +2808,8 @@ impl Cli {
                     .required(true),
             )
             .arg(
-                clap::Arg::new("vpc-name")
-                    .long("vpc-name")
+                clap::Arg::new("route-name")
+                    .long("route-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
@@ -2808,22 +2820,10 @@ impl Cli {
                     .required(true),
             )
             .arg(
-                clap::Arg::new("route-name")
-                    .long("route-name")
+                clap::Arg::new("vpc-name")
+                    .long("vpc-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
-            )
-            .arg(
-                clap::Arg::new("description")
-                    .long("description")
-                    .value_parser(clap::value_parser!(String))
-                    .required(false),
-            )
-            .arg(
-                clap::Arg::new("name")
-                    .long("name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(false),
             )
             .arg(
                 clap::Arg::new("json-body")
@@ -2857,8 +2857,8 @@ impl Cli {
                     .required(true),
             )
             .arg(
-                clap::Arg::new("vpc-name")
-                    .long("vpc-name")
+                clap::Arg::new("route-name")
+                    .long("route-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
@@ -2869,8 +2869,8 @@ impl Cli {
                     .required(true),
             )
             .arg(
-                clap::Arg::new("route-name")
-                    .long("route-name")
+                clap::Arg::new("vpc-name")
+                    .long("vpc-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
@@ -2879,6 +2879,13 @@ impl Cli {
 
     pub fn cli_vpc_subnet_list() -> clap::Command {
         clap::Command::new("")
+            .arg(
+                clap::Arg::new("limit")
+                    .long("limit")
+                    .value_parser(clap::value_parser!(std::num::NonZeroU32))
+                    .required(false)
+                    .help("Maximum number of items returned by a single call"),
+            )
             .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
@@ -2890,19 +2897,6 @@ impl Cli {
                     .long("project-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
-            )
-            .arg(
-                clap::Arg::new("vpc-name")
-                    .long("vpc-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("limit")
-                    .long("limit")
-                    .value_parser(clap::value_parser!(std::num::NonZeroU32))
-                    .required(false)
-                    .help("Maximum number of items returned by a single call"),
             )
             .arg(
                 clap::Arg::new("sort-by")
@@ -2915,29 +2909,17 @@ impl Cli {
                     ))
                     .required(false),
             )
-            .about("List subnets")
-    }
-
-    pub fn cli_vpc_subnet_create() -> clap::Command {
-        clap::Command::new("")
-            .arg(
-                clap::Arg::new("organization-name")
-                    .long("organization-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("project-name")
-                    .long("project-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
             .arg(
                 clap::Arg::new("vpc-name")
                     .long("vpc-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
+            .about("List subnets")
+    }
+
+    pub fn cli_vpc_subnet_create() -> clap::Command {
+        clap::Command::new("")
             .arg(
                 clap::Arg::new("description")
                     .long("description")
@@ -2974,6 +2956,24 @@ impl Cli {
                     .required_unless_present("json-body"),
             )
             .arg(
+                clap::Arg::new("organization-name")
+                    .long("organization-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
+            .arg(
+                clap::Arg::new("project-name")
+                    .long("project-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
+            .arg(
+                clap::Arg::new("vpc-name")
+                    .long("vpc-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
+            .arg(
                 clap::Arg::new("json-body")
                     .long("json-body")
                     .value_name("JSON-FILE")
@@ -3005,14 +3005,14 @@ impl Cli {
                     .required(true),
             )
             .arg(
-                clap::Arg::new("vpc-name")
-                    .long("vpc-name")
+                clap::Arg::new("subnet-name")
+                    .long("subnet-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
             .arg(
-                clap::Arg::new("subnet-name")
-                    .long("subnet-name")
+                clap::Arg::new("vpc-name")
+                    .long("vpc-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
@@ -3021,6 +3021,18 @@ impl Cli {
 
     pub fn cli_vpc_subnet_update() -> clap::Command {
         clap::Command::new("")
+            .arg(
+                clap::Arg::new("description")
+                    .long("description")
+                    .value_parser(clap::value_parser!(String))
+                    .required(false),
+            )
+            .arg(
+                clap::Arg::new("name")
+                    .long("name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(false),
+            )
             .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
@@ -3034,28 +3046,16 @@ impl Cli {
                     .required(true),
             )
             .arg(
-                clap::Arg::new("vpc-name")
-                    .long("vpc-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
                 clap::Arg::new("subnet-name")
                     .long("subnet-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
             .arg(
-                clap::Arg::new("description")
-                    .long("description")
-                    .value_parser(clap::value_parser!(String))
-                    .required(false),
-            )
-            .arg(
-                clap::Arg::new("name")
-                    .long("name")
+                clap::Arg::new("vpc-name")
+                    .long("vpc-name")
                     .value_parser(clap::value_parser!(types::Name))
-                    .required(false),
+                    .required(true),
             )
             .arg(
                 clap::Arg::new("json-body")
@@ -3089,14 +3089,14 @@ impl Cli {
                     .required(true),
             )
             .arg(
-                clap::Arg::new("vpc-name")
-                    .long("vpc-name")
+                clap::Arg::new("subnet-name")
+                    .long("subnet-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
             .arg(
-                clap::Arg::new("subnet-name")
-                    .long("subnet-name")
+                clap::Arg::new("vpc-name")
+                    .long("vpc-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true),
             )
@@ -3105,6 +3105,13 @@ impl Cli {
 
     pub fn cli_vpc_subnet_list_network_interfaces() -> clap::Command {
         clap::Command::new("")
+            .arg(
+                clap::Arg::new("limit")
+                    .long("limit")
+                    .value_parser(clap::value_parser!(std::num::NonZeroU32))
+                    .required(false)
+                    .help("Maximum number of items returned by a single call"),
+            )
             .arg(
                 clap::Arg::new("organization-name")
                     .long("organization-name")
@@ -3118,25 +3125,6 @@ impl Cli {
                     .required(true),
             )
             .arg(
-                clap::Arg::new("vpc-name")
-                    .long("vpc-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("subnet-name")
-                    .long("subnet-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("limit")
-                    .long("limit")
-                    .value_parser(clap::value_parser!(std::num::NonZeroU32))
-                    .required(false)
-                    .help("Maximum number of items returned by a single call"),
-            )
-            .arg(
                 clap::Arg::new("sort-by")
                     .long("sort-by")
                     .value_parser(clap::builder::TypedValueParser::map(
@@ -3146,6 +3134,18 @@ impl Cli {
                         |s| types::NameSortMode::try_from(s).unwrap(),
                     ))
                     .required(false),
+            )
+            .arg(
+                clap::Arg::new("subnet-name")
+                    .long("subnet-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
+            )
+            .arg(
+                clap::Arg::new("vpc-name")
+                    .long("vpc-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
             )
             .about("List network interfaces")
     }
@@ -3541,18 +3541,18 @@ impl Cli {
     pub fn cli_sled_physical_disk_list() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("sled-id")
-                    .long("sled-id")
-                    .value_parser(clap::value_parser!(uuid::Uuid))
-                    .required(true)
-                    .help("The sled's unique ID."),
-            )
-            .arg(
                 clap::Arg::new("limit")
                     .long("limit")
                     .value_parser(clap::value_parser!(std::num::NonZeroU32))
                     .required(false)
                     .help("Maximum number of items returned by a single call"),
+            )
+            .arg(
+                clap::Arg::new("sled-id")
+                    .long("sled-id")
+                    .value_parser(clap::value_parser!(uuid::Uuid))
+                    .required(true)
+                    .help("The sled's unique ID."),
             )
             .arg(
                 clap::Arg::new("sort-by")
@@ -3728,12 +3728,6 @@ impl Cli {
     pub fn cli_ip_pool_update() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("pool-name")
-                    .long("pool-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
                 clap::Arg::new("description")
                     .long("description")
                     .value_parser(clap::value_parser!(String))
@@ -3744,6 +3738,12 @@ impl Cli {
                     .long("name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(false),
+            )
+            .arg(
+                clap::Arg::new("pool-name")
+                    .long("pool-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
             )
             .arg(
                 clap::Arg::new("json-body")
@@ -3776,17 +3776,17 @@ impl Cli {
     pub fn cli_ip_pool_range_list() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("pool-name")
-                    .long("pool-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true),
-            )
-            .arg(
                 clap::Arg::new("limit")
                     .long("limit")
                     .value_parser(clap::value_parser!(std::num::NonZeroU32))
                     .required(false)
                     .help("Maximum number of items returned by a single call"),
+            )
+            .arg(
+                clap::Arg::new("pool-name")
+                    .long("pool-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true),
             )
             .about("List ranges for an IP pool")
             .long_about("Ranges are ordered by their first address.")
@@ -3804,7 +3804,7 @@ impl Cli {
                 clap::Arg::new("json-body")
                     .long("json-body")
                     .value_name("JSON-FILE")
-                    .required(false)
+                    .required(true)
                     .value_parser(clap::value_parser!(std::path::PathBuf))
                     .help("Path to a file that contains the full json body."),
             )
@@ -3829,7 +3829,7 @@ impl Cli {
                 clap::Arg::new("json-body")
                     .long("json-body")
                     .value_name("JSON-FILE")
-                    .required(false)
+                    .required(true)
                     .value_parser(clap::value_parser!(std::path::PathBuf))
                     .help("Path to a file that contains the full json body."),
             )
@@ -3865,7 +3865,7 @@ impl Cli {
                 clap::Arg::new("json-body")
                     .long("json-body")
                     .value_name("JSON-FILE")
-                    .required(false)
+                    .required(true)
                     .value_parser(clap::value_parser!(std::path::PathBuf))
                     .help("Path to a file that contains the full json body."),
             )
@@ -3884,7 +3884,7 @@ impl Cli {
                 clap::Arg::new("json-body")
                     .long("json-body")
                     .value_name("JSON-FILE")
-                    .required(false)
+                    .required(true)
                     .value_parser(clap::value_parser!(std::path::PathBuf))
                     .help("Path to a file that contains the full json body."),
             )
@@ -3899,19 +3899,6 @@ impl Cli {
 
     pub fn cli_system_metric() -> clap::Command {
         clap::Command::new("")
-            .arg(
-                clap::Arg::new("metric-name")
-                    .long("metric-name")
-                    .value_parser(clap::builder::TypedValueParser::map(
-                        clap::builder::PossibleValuesParser::new([
-                            types::SystemMetricName::VirtualDiskSpaceProvisioned.to_string(),
-                            types::SystemMetricName::CpusProvisioned.to_string(),
-                            types::SystemMetricName::RamProvisioned.to_string(),
-                        ]),
-                        |s| types::SystemMetricName::try_from(s).unwrap(),
-                    ))
-                    .required(true),
-            )
             .arg(
                 clap::Arg::new("end-time")
                     .long("end-time")
@@ -3932,6 +3919,19 @@ impl Cli {
                     .value_parser(clap::value_parser!(std::num::NonZeroU32))
                     .required(false)
                     .help("Maximum number of items returned by a single call"),
+            )
+            .arg(
+                clap::Arg::new("metric-name")
+                    .long("metric-name")
+                    .value_parser(clap::builder::TypedValueParser::map(
+                        clap::builder::PossibleValuesParser::new([
+                            types::SystemMetricName::VirtualDiskSpaceProvisioned.to_string(),
+                            types::SystemMetricName::CpusProvisioned.to_string(),
+                            types::SystemMetricName::RamProvisioned.to_string(),
+                        ]),
+                        |s| types::SystemMetricName::try_from(s).unwrap(),
+                    ))
+                    .required(true),
             )
             .arg(
                 clap::Arg::new("page-token")
@@ -4125,18 +4125,18 @@ impl Cli {
     pub fn cli_silo_identity_provider_list() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("silo-name")
-                    .long("silo-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true)
-                    .help("The silo's unique name."),
-            )
-            .arg(
                 clap::Arg::new("limit")
                     .long("limit")
                     .value_parser(clap::value_parser!(std::num::NonZeroU32))
                     .required(false)
                     .help("Maximum number of items returned by a single call"),
+            )
+            .arg(
+                clap::Arg::new("silo-name")
+                    .long("silo-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true)
+                    .help("The silo's unique name."),
             )
             .arg(
                 clap::Arg::new("sort-by")
@@ -4155,18 +4155,18 @@ impl Cli {
     pub fn cli_local_idp_user_create() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("silo-name")
-                    .long("silo-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true)
-                    .help("The silo's unique name."),
-            )
-            .arg(
                 clap::Arg::new("external-id")
                     .long("external-id")
                     .value_parser(clap::value_parser!(types::UserId))
                     .required_unless_present("json-body")
                     .help("username used to log in"),
+            )
+            .arg(
+                clap::Arg::new("silo-name")
+                    .long("silo-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true)
+                    .help("The silo's unique name."),
             )
             .arg(
                 clap::Arg::new("json-body")
@@ -4229,7 +4229,7 @@ impl Cli {
                 clap::Arg::new("json-body")
                     .long("json-body")
                     .value_name("JSON-FILE")
-                    .required(false)
+                    .required(true)
                     .value_parser(clap::value_parser!(std::path::PathBuf))
                     .help("Path to a file that contains the full json body."),
             )
@@ -4247,13 +4247,6 @@ impl Cli {
 
     pub fn cli_saml_identity_provider_create() -> clap::Command {
         clap::Command::new("")
-            .arg(
-                clap::Arg::new("silo-name")
-                    .long("silo-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true)
-                    .help("The silo's unique name."),
-            )
             .arg(
                 clap::Arg::new("acs-url")
                     .long("acs-url")
@@ -4290,6 +4283,13 @@ impl Cli {
                     .long("name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required_unless_present("json-body"),
+            )
+            .arg(
+                clap::Arg::new("silo-name")
+                    .long("silo-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true)
+                    .help("The silo's unique name."),
             )
             .arg(
                 clap::Arg::new("slo-url")
@@ -4332,18 +4332,18 @@ impl Cli {
     pub fn cli_saml_identity_provider_view() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("silo-name")
-                    .long("silo-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true)
-                    .help("The silo's unique name."),
-            )
-            .arg(
                 clap::Arg::new("provider-name")
                     .long("provider-name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(true)
                     .help("The SAML identity provider's name"),
+            )
+            .arg(
+                clap::Arg::new("silo-name")
+                    .long("silo-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true)
+                    .help("The silo's unique name."),
             )
             .about("Fetch a SAML IDP")
     }
@@ -4389,18 +4389,18 @@ impl Cli {
     pub fn cli_silo_users_list() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("silo-name")
-                    .long("silo-name")
-                    .value_parser(clap::value_parser!(types::Name))
-                    .required(true)
-                    .help("The silo's unique name."),
-            )
-            .arg(
                 clap::Arg::new("limit")
                     .long("limit")
                     .value_parser(clap::value_parser!(std::num::NonZeroU32))
                     .required(false)
                     .help("Maximum number of items returned by a single call"),
+            )
+            .arg(
+                clap::Arg::new("silo-name")
+                    .long("silo-name")
+                    .value_parser(clap::value_parser!(types::Name))
+                    .required(true)
+                    .help("The silo's unique name."),
             )
             .arg(
                 clap::Arg::new("sort-by")
@@ -4545,18 +4545,6 @@ impl Cli {
     pub fn cli_disk_create_v1() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("organization")
-                    .long("organization")
-                    .value_parser(clap::value_parser!(types::NameOrId))
-                    .required(false),
-            )
-            .arg(
-                clap::Arg::new("project")
-                    .long("project")
-                    .value_parser(clap::value_parser!(types::NameOrId))
-                    .required(true),
-            )
-            .arg(
                 clap::Arg::new("description")
                     .long("description")
                     .value_parser(clap::value_parser!(String))
@@ -4567,6 +4555,18 @@ impl Cli {
                     .long("name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required_unless_present("json-body"),
+            )
+            .arg(
+                clap::Arg::new("organization")
+                    .long("organization")
+                    .value_parser(clap::value_parser!(types::NameOrId))
+                    .required(false),
+            )
+            .arg(
+                clap::Arg::new("project")
+                    .long("project")
+                    .value_parser(clap::value_parser!(types::NameOrId))
+                    .required(true),
             )
             .arg(
                 clap::Arg::new("size")
@@ -4678,18 +4678,6 @@ impl Cli {
     pub fn cli_instance_create_v1() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("organization")
-                    .long("organization")
-                    .value_parser(clap::value_parser!(types::NameOrId))
-                    .required(false),
-            )
-            .arg(
-                clap::Arg::new("project")
-                    .long("project")
-                    .value_parser(clap::value_parser!(types::NameOrId))
-                    .required(true),
-            )
-            .arg(
                 clap::Arg::new("description")
                     .long("description")
                     .value_parser(clap::value_parser!(String))
@@ -4718,6 +4706,18 @@ impl Cli {
                     .long("ncpus")
                     .value_parser(clap::value_parser!(types::InstanceCpuCount))
                     .required_unless_present("json-body"),
+            )
+            .arg(
+                clap::Arg::new("organization")
+                    .long("organization")
+                    .value_parser(clap::value_parser!(types::NameOrId))
+                    .required(false),
+            )
+            .arg(
+                clap::Arg::new("project")
+                    .long("project")
+                    .value_parser(clap::value_parser!(types::NameOrId))
+                    .required(true),
             )
             .arg(
                 clap::Arg::new("start")
@@ -4846,6 +4846,12 @@ impl Cli {
     pub fn cli_instance_disk_attach_v1() -> clap::Command {
         clap::Command::new("")
             .arg(
+                clap::Arg::new("disk")
+                    .long("disk")
+                    .value_parser(clap::value_parser!(types::NameOrId))
+                    .required_unless_present("json-body"),
+            )
+            .arg(
                 clap::Arg::new("instance")
                     .long("instance")
                     .value_parser(clap::value_parser!(types::NameOrId))
@@ -4862,12 +4868,6 @@ impl Cli {
                     .long("project")
                     .value_parser(clap::value_parser!(types::NameOrId))
                     .required(false),
-            )
-            .arg(
-                clap::Arg::new("disk")
-                    .long("disk")
-                    .value_parser(clap::value_parser!(types::NameOrId))
-                    .required_unless_present("json-body"),
             )
             .arg(
                 clap::Arg::new("json-body")
@@ -4889,6 +4889,12 @@ impl Cli {
     pub fn cli_instance_disk_detach_v1() -> clap::Command {
         clap::Command::new("")
             .arg(
+                clap::Arg::new("disk")
+                    .long("disk")
+                    .value_parser(clap::value_parser!(types::NameOrId))
+                    .required_unless_present("json-body"),
+            )
+            .arg(
                 clap::Arg::new("instance")
                     .long("instance")
                     .value_parser(clap::value_parser!(types::NameOrId))
@@ -4905,12 +4911,6 @@ impl Cli {
                     .long("project")
                     .value_parser(clap::value_parser!(types::NameOrId))
                     .required(false),
-            )
-            .arg(
-                clap::Arg::new("disk")
-                    .long("disk")
-                    .value_parser(clap::value_parser!(types::NameOrId))
-                    .required_unless_present("json-body"),
             )
             .arg(
                 clap::Arg::new("json-body")
@@ -4932,6 +4932,12 @@ impl Cli {
     pub fn cli_instance_migrate_v1() -> clap::Command {
         clap::Command::new("")
             .arg(
+                clap::Arg::new("dst-sled-id")
+                    .long("dst-sled-id")
+                    .value_parser(clap::value_parser!(uuid::Uuid))
+                    .required_unless_present("json-body"),
+            )
+            .arg(
                 clap::Arg::new("instance")
                     .long("instance")
                     .value_parser(clap::value_parser!(types::NameOrId))
@@ -4948,12 +4954,6 @@ impl Cli {
                     .long("project")
                     .value_parser(clap::value_parser!(types::NameOrId))
                     .required(false),
-            )
-            .arg(
-                clap::Arg::new("dst-sled-id")
-                    .long("dst-sled-id")
-                    .value_parser(clap::value_parser!(uuid::Uuid))
-                    .required_unless_present("json-body"),
             )
             .arg(
                 clap::Arg::new("json-body")
@@ -4998,12 +4998,6 @@ impl Cli {
     pub fn cli_instance_serial_console_v1() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("instance")
-                    .long("instance")
-                    .value_parser(clap::value_parser!(types::NameOrId))
-                    .required(true),
-            )
-            .arg(
                 clap::Arg::new("from-start")
                     .long("from-start")
                     .value_parser(clap::value_parser!(u64))
@@ -5014,6 +5008,12 @@ impl Cli {
                          `most_recent` must be provided, and if this *is* provided, `most_recent` \
                          must *not* be provided.",
                     ),
+            )
+            .arg(
+                clap::Arg::new("instance")
+                    .long("instance")
+                    .value_parser(clap::value_parser!(types::NameOrId))
+                    .required(true),
             )
             .arg(
                 clap::Arg::new("max-bytes")
@@ -5191,12 +5191,6 @@ impl Cli {
     pub fn cli_organization_update_v1() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("organization")
-                    .long("organization")
-                    .value_parser(clap::value_parser!(types::NameOrId))
-                    .required(true),
-            )
-            .arg(
                 clap::Arg::new("description")
                     .long("description")
                     .value_parser(clap::value_parser!(String))
@@ -5207,6 +5201,12 @@ impl Cli {
                     .long("name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(false),
+            )
+            .arg(
+                clap::Arg::new("organization")
+                    .long("organization")
+                    .value_parser(clap::value_parser!(types::NameOrId))
+                    .required(true),
             )
             .arg(
                 clap::Arg::new("json-body")
@@ -5306,12 +5306,6 @@ impl Cli {
     pub fn cli_project_create_v1() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("organization")
-                    .long("organization")
-                    .value_parser(clap::value_parser!(types::NameOrId))
-                    .required(true),
-            )
-            .arg(
                 clap::Arg::new("description")
                     .long("description")
                     .value_parser(clap::value_parser!(String))
@@ -5322,6 +5316,12 @@ impl Cli {
                     .long("name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required_unless_present("json-body"),
+            )
+            .arg(
+                clap::Arg::new("organization")
+                    .long("organization")
+                    .value_parser(clap::value_parser!(types::NameOrId))
+                    .required(true),
             )
             .arg(
                 clap::Arg::new("json-body")
@@ -5343,34 +5343,22 @@ impl Cli {
     pub fn cli_project_view_v1() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("project")
-                    .long("project")
-                    .value_parser(clap::value_parser!(types::NameOrId))
-                    .required(true),
-            )
-            .arg(
                 clap::Arg::new("organization")
                     .long("organization")
                     .value_parser(clap::value_parser!(types::NameOrId))
                     .required(false),
+            )
+            .arg(
+                clap::Arg::new("project")
+                    .long("project")
+                    .value_parser(clap::value_parser!(types::NameOrId))
+                    .required(true),
             )
             .about("Fetch a project")
     }
 
     pub fn cli_project_update_v1() -> clap::Command {
         clap::Command::new("")
-            .arg(
-                clap::Arg::new("project")
-                    .long("project")
-                    .value_parser(clap::value_parser!(types::NameOrId))
-                    .required(true),
-            )
-            .arg(
-                clap::Arg::new("organization")
-                    .long("organization")
-                    .value_parser(clap::value_parser!(types::NameOrId))
-                    .required(false),
-            )
             .arg(
                 clap::Arg::new("description")
                     .long("description")
@@ -5382,6 +5370,18 @@ impl Cli {
                     .long("name")
                     .value_parser(clap::value_parser!(types::Name))
                     .required(false),
+            )
+            .arg(
+                clap::Arg::new("organization")
+                    .long("organization")
+                    .value_parser(clap::value_parser!(types::NameOrId))
+                    .required(false),
+            )
+            .arg(
+                clap::Arg::new("project")
+                    .long("project")
+                    .value_parser(clap::value_parser!(types::NameOrId))
+                    .required(true),
             )
             .arg(
                 clap::Arg::new("json-body")
@@ -5403,16 +5403,16 @@ impl Cli {
     pub fn cli_project_delete_v1() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("project")
-                    .long("project")
-                    .value_parser(clap::value_parser!(types::NameOrId))
-                    .required(true),
-            )
-            .arg(
                 clap::Arg::new("organization")
                     .long("organization")
                     .value_parser(clap::value_parser!(types::NameOrId))
                     .required(false),
+            )
+            .arg(
+                clap::Arg::new("project")
+                    .long("project")
+                    .value_parser(clap::value_parser!(types::NameOrId))
+                    .required(true),
             )
             .about("Delete a project")
     }
@@ -5420,16 +5420,16 @@ impl Cli {
     pub fn cli_project_policy_view_v1() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("project")
-                    .long("project")
-                    .value_parser(clap::value_parser!(types::NameOrId))
-                    .required(true),
-            )
-            .arg(
                 clap::Arg::new("organization")
                     .long("organization")
                     .value_parser(clap::value_parser!(types::NameOrId))
                     .required(false),
+            )
+            .arg(
+                clap::Arg::new("project")
+                    .long("project")
+                    .value_parser(clap::value_parser!(types::NameOrId))
+                    .required(true),
             )
             .about("Fetch a project's IAM policy")
     }
@@ -5437,16 +5437,16 @@ impl Cli {
     pub fn cli_project_policy_update_v1() -> clap::Command {
         clap::Command::new("")
             .arg(
-                clap::Arg::new("project")
-                    .long("project")
-                    .value_parser(clap::value_parser!(types::NameOrId))
-                    .required(true),
-            )
-            .arg(
                 clap::Arg::new("organization")
                     .long("organization")
                     .value_parser(clap::value_parser!(types::NameOrId))
                     .required(false),
+            )
+            .arg(
+                clap::Arg::new("project")
+                    .long("project")
+                    .value_parser(clap::value_parser!(types::NameOrId))
+                    .required(true),
             )
             .arg(
                 clap::Arg::new("json-body")
@@ -6421,14 +6421,14 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_device_auth_request(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.device_auth_request();
+        if let Some(value) = matches.get_one::<uuid::Uuid>("client-id") {
+            request = request.body_map(|body| body.client_id(value.clone()))
+        }
+
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
             let body_txt = std::fs::read_to_string(value).unwrap();
             let body_value = serde_json::from_str::<types::DeviceAuthRequest>(&body_txt).unwrap();
             request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<uuid::Uuid>("client-id") {
-            request = request.body_map(|body| body.client_id(value.clone()))
         }
 
         self.over
@@ -6447,14 +6447,14 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_device_auth_confirm(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.device_auth_confirm();
+        if let Some(value) = matches.get_one::<String>("user-code") {
+            request = request.body_map(|body| body.user_code(value.clone()))
+        }
+
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
             let body_txt = std::fs::read_to_string(value).unwrap();
             let body_value = serde_json::from_str::<types::DeviceAuthVerify>(&body_txt).unwrap();
             request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<String>("user-code") {
-            request = request.body_map(|body| body.user_code(value.clone()))
         }
 
         self.over
@@ -6473,13 +6473,6 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_device_access_token(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.device_access_token();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value =
-                serde_json::from_str::<types::DeviceAccessTokenRequest>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
         if let Some(value) = matches.get_one::<uuid::Uuid>("client-id") {
             request = request.body_map(|body| body.client_id(value.clone()))
         }
@@ -6490,6 +6483,13 @@ impl<T: CliOverride> Cli<T> {
 
         if let Some(value) = matches.get_one::<String>("grant-type") {
             request = request.body_map(|body| body.grant_type(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value =
+                serde_json::from_str::<types::DeviceAccessTokenRequest>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -6536,14 +6536,14 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_login_spoof(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.login_spoof();
+        if let Some(value) = matches.get_one::<String>("username") {
+            request = request.body_map(|body| body.username(value.clone()))
+        }
+
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
             let body_txt = std::fs::read_to_string(value).unwrap();
             let body_value = serde_json::from_str::<types::SpoofLoginBody>(&body_txt).unwrap();
             request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<String>("username") {
-            request = request.body_map(|body| body.username(value.clone()))
         }
 
         self.over
@@ -6562,23 +6562,23 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_login_local(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.login_local();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value =
-                serde_json::from_str::<types::UsernamePasswordCredentials>(&body_txt).unwrap();
-            request = request.body(body_value);
+        if let Some(value) = matches.get_one::<types::Password>("password") {
+            request = request.body_map(|body| body.password(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::Name>("silo-name") {
             request = request.silo_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<types::Password>("password") {
-            request = request.body_map(|body| body.password(value.clone()))
-        }
-
         if let Some(value) = matches.get_one::<types::UserId>("username") {
             request = request.body_map(|body| body.username(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value =
+                serde_json::from_str::<types::UsernamePasswordCredentials>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -6597,12 +6597,12 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_login_saml_begin(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.login_saml_begin();
-        if let Some(value) = matches.get_one::<types::Name>("silo-name") {
-            request = request.silo_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<types::Name>("provider-name") {
             request = request.provider_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("silo-name") {
+            request = request.silo_name(value.clone());
         }
 
         self.over
@@ -6621,12 +6621,12 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_login_saml(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.login_saml();
-        if let Some(value) = matches.get_one::<types::Name>("silo-name") {
-            request = request.silo_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<types::Name>("provider-name") {
             request = request.provider_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("silo-name") {
+            request = request.silo_name(value.clone());
         }
 
         self.over.execute_login_saml(matches, &mut request).unwrap();
@@ -6687,18 +6687,18 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_organization_create(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.organization_create();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::OrganizationCreate>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
         if let Some(value) = matches.get_one::<String>("description") {
             request = request.body_map(|body| body.description(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::Name>("name") {
             request = request.body_map(|body| body.name(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::OrganizationCreate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -6737,22 +6737,22 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_organization_update(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.organization_update();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::OrganizationUpdate>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
-            request = request.organization_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<String>("description") {
             request = request.body_map(|body| body.description(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::Name>("name") {
             request = request.body_map(|body| body.name(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
+            request = request.organization_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::OrganizationUpdate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -6811,15 +6811,15 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_organization_policy_update(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.organization_policy_update();
+        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
+            request = request.organization_name(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
             let body_txt = std::fs::read_to_string(value).unwrap();
             let body_value =
                 serde_json::from_str::<types::OrganizationRolePolicy>(&body_txt).unwrap();
             request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
-            request = request.organization_name(value.clone());
         }
 
         self.over
@@ -6838,12 +6838,12 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_project_list(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.project_list();
-        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
-            request = request.organization_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
             request = request.limit(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
+            request = request.organization_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::NameOrIdSortMode>("sort-by") {
@@ -6872,22 +6872,22 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_project_create(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.project_create();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::ProjectCreate>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
-            request = request.organization_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<String>("description") {
             request = request.body_map(|body| body.description(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::Name>("name") {
             request = request.body_map(|body| body.name(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
+            request = request.organization_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::ProjectCreate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -6930,10 +6930,12 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_project_update(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.project_update();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::ProjectUpdate>(&body_txt).unwrap();
-            request = request.body(body_value);
+        if let Some(value) = matches.get_one::<String>("description") {
+            request = request.body_map(|body| body.description(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("name") {
+            request = request.body_map(|body| body.name(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
@@ -6944,12 +6946,10 @@ impl<T: CliOverride> Cli<T> {
             request = request.project_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<String>("description") {
-            request = request.body_map(|body| body.description(value.clone()))
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("name") {
-            request = request.body_map(|body| body.name(value.clone()))
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::ProjectUpdate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -6992,16 +6992,16 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_disk_list(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.disk_list();
+        if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
+            request = request.limit(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
             request = request.organization_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::Name>("project-name") {
             request = request.project_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
-            request = request.limit(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::NameSortMode>("sort-by") {
@@ -7028,10 +7028,12 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_disk_create(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.disk_create();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::DiskCreate>(&body_txt).unwrap();
-            request = request.body(body_value);
+        if let Some(value) = matches.get_one::<String>("description") {
+            request = request.body_map(|body| body.description(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("name") {
+            request = request.body_map(|body| body.name(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
@@ -7042,16 +7044,14 @@ impl<T: CliOverride> Cli<T> {
             request = request.project_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<String>("description") {
-            request = request.body_map(|body| body.description(value.clone()))
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("name") {
-            request = request.body_map(|body| body.name(value.clone()))
-        }
-
         if let Some(value) = matches.get_one::<types::ByteCount>("size") {
             request = request.body_map(|body| body.size(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::DiskCreate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -7070,16 +7070,16 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_disk_view(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.disk_view();
+        if let Some(value) = matches.get_one::<types::Name>("disk-name") {
+            request = request.disk_name(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
             request = request.organization_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::Name>("project-name") {
             request = request.project_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("disk-name") {
-            request = request.disk_name(value.clone());
         }
 
         self.over.execute_disk_view(matches, &mut request).unwrap();
@@ -7096,16 +7096,16 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_disk_delete(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.disk_delete();
+        if let Some(value) = matches.get_one::<types::Name>("disk-name") {
+            request = request.disk_name(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
             request = request.organization_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::Name>("project-name") {
             request = request.project_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("disk-name") {
-            request = request.disk_name(value.clone());
         }
 
         self.over
@@ -7124,20 +7124,8 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_disk_metrics_list(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.disk_metrics_list();
-        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
-            request = request.organization_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("project-name") {
-            request = request.project_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<types::Name>("disk-name") {
             request = request.disk_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::DiskMetricName>("metric-name") {
-            request = request.metric_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<chrono::DateTime<chrono::offset::Utc>>("end-time") {
@@ -7146,6 +7134,18 @@ impl<T: CliOverride> Cli<T> {
 
         if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
             request = request.limit(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::DiskMetricName>("metric-name") {
+            request = request.metric_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
+            request = request.organization_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("project-name") {
+            request = request.project_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<chrono::DateTime<chrono::offset::Utc>>("start-time")
@@ -7175,16 +7175,16 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_image_list(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.image_list();
+        if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
+            request = request.limit(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
             request = request.organization_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::Name>("project-name") {
             request = request.project_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
-            request = request.limit(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::NameSortMode>("sort-by") {
@@ -7211,10 +7211,12 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_image_create(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.image_create();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::ImageCreate>(&body_txt).unwrap();
-            request = request.body(body_value);
+        if let Some(value) = matches.get_one::<String>("description") {
+            request = request.body_map(|body| body.description(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("name") {
+            request = request.body_map(|body| body.name(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
@@ -7225,12 +7227,10 @@ impl<T: CliOverride> Cli<T> {
             request = request.project_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<String>("description") {
-            request = request.body_map(|body| body.description(value.clone()))
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("name") {
-            request = request.body_map(|body| body.name(value.clone()))
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::ImageCreate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -7249,16 +7249,16 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_image_view(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.image_view();
+        if let Some(value) = matches.get_one::<types::Name>("image-name") {
+            request = request.image_name(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
             request = request.organization_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::Name>("project-name") {
             request = request.project_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("image-name") {
-            request = request.image_name(value.clone());
         }
 
         self.over.execute_image_view(matches, &mut request).unwrap();
@@ -7275,16 +7275,16 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_image_delete(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.image_delete();
+        if let Some(value) = matches.get_one::<types::Name>("image-name") {
+            request = request.image_name(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
             request = request.organization_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::Name>("project-name") {
             request = request.project_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("image-name") {
-            request = request.image_name(value.clone());
         }
 
         self.over
@@ -7303,16 +7303,16 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_instance_list(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.instance_list();
+        if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
+            request = request.limit(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
             request = request.organization_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::Name>("project-name") {
             request = request.project_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
-            request = request.limit(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::NameSortMode>("sort-by") {
@@ -7341,20 +7341,6 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_instance_create(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.instance_create();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::InstanceCreate>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
-            request = request.organization_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("project-name") {
-            request = request.project_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<String>("description") {
             request = request.body_map(|body| body.description(value.clone()))
         }
@@ -7375,12 +7361,26 @@ impl<T: CliOverride> Cli<T> {
             request = request.body_map(|body| body.ncpus(value.clone()))
         }
 
+        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
+            request = request.organization_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("project-name") {
+            request = request.project_name(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<bool>("start") {
             request = request.body_map(|body| body.start(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<String>("user-data") {
             request = request.body_map(|body| body.user_data(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::InstanceCreate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -7399,16 +7399,16 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_instance_view(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.instance_view();
+        if let Some(value) = matches.get_one::<types::Name>("instance-name") {
+            request = request.instance_name(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
             request = request.organization_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::Name>("project-name") {
             request = request.project_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("instance-name") {
-            request = request.instance_name(value.clone());
         }
 
         self.over
@@ -7427,16 +7427,16 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_instance_delete(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.instance_delete();
+        if let Some(value) = matches.get_one::<types::Name>("instance-name") {
+            request = request.instance_name(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
             request = request.organization_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::Name>("project-name") {
             request = request.project_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("instance-name") {
-            request = request.instance_name(value.clone());
         }
 
         self.over
@@ -7455,20 +7455,20 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_instance_disk_list(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.instance_disk_list();
-        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
-            request = request.organization_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("project-name") {
-            request = request.project_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<types::Name>("instance-name") {
             request = request.instance_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
             request = request.limit(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
+            request = request.organization_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("project-name") {
+            request = request.project_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::NameSortMode>("sort-by") {
@@ -7497,10 +7497,12 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_instance_disk_attach(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.instance_disk_attach();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::DiskIdentifier>(&body_txt).unwrap();
-            request = request.body(body_value);
+        if let Some(value) = matches.get_one::<types::Name>("instance-name") {
+            request = request.instance_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("name") {
+            request = request.body_map(|body| body.name(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
@@ -7511,12 +7513,10 @@ impl<T: CliOverride> Cli<T> {
             request = request.project_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<types::Name>("instance-name") {
-            request = request.instance_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("name") {
-            request = request.body_map(|body| body.name(value.clone()))
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::DiskIdentifier>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -7535,10 +7535,12 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_instance_disk_detach(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.instance_disk_detach();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::DiskIdentifier>(&body_txt).unwrap();
-            request = request.body(body_value);
+        if let Some(value) = matches.get_one::<types::Name>("instance-name") {
+            request = request.instance_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("name") {
+            request = request.body_map(|body| body.name(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
@@ -7549,12 +7551,10 @@ impl<T: CliOverride> Cli<T> {
             request = request.project_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<types::Name>("instance-name") {
-            request = request.instance_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("name") {
-            request = request.body_map(|body| body.name(value.clone()))
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::DiskIdentifier>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -7573,16 +7573,16 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_instance_external_ip_list(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.instance_external_ip_list();
+        if let Some(value) = matches.get_one::<types::Name>("instance-name") {
+            request = request.instance_name(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
             request = request.organization_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::Name>("project-name") {
             request = request.project_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("instance-name") {
-            request = request.instance_name(value.clone());
         }
 
         self.over
@@ -7601,10 +7601,12 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_instance_migrate(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.instance_migrate();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::InstanceMigrate>(&body_txt).unwrap();
-            request = request.body(body_value);
+        if let Some(value) = matches.get_one::<uuid::Uuid>("dst-sled-id") {
+            request = request.body_map(|body| body.dst_sled_id(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("instance-name") {
+            request = request.instance_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
@@ -7615,12 +7617,10 @@ impl<T: CliOverride> Cli<T> {
             request = request.project_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<types::Name>("instance-name") {
-            request = request.instance_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<uuid::Uuid>("dst-sled-id") {
-            request = request.body_map(|body| body.dst_sled_id(value.clone()))
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::InstanceMigrate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -7639,20 +7639,20 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_instance_network_interface_list(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.instance_network_interface_list();
-        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
-            request = request.organization_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("project-name") {
-            request = request.project_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<types::Name>("instance-name") {
             request = request.instance_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
             request = request.limit(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
+            request = request.organization_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("project-name") {
+            request = request.project_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::NameSortMode>("sort-by") {
@@ -7681,27 +7681,12 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_instance_network_interface_create(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.instance_network_interface_create();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value =
-                serde_json::from_str::<types::NetworkInterfaceCreate>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
-            request = request.organization_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("project-name") {
-            request = request.project_name(value.clone());
+        if let Some(value) = matches.get_one::<String>("description") {
+            request = request.body_map(|body| body.description(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::Name>("instance-name") {
             request = request.instance_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<String>("description") {
-            request = request.body_map(|body| body.description(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<std::net::IpAddr>("ip") {
@@ -7712,12 +7697,27 @@ impl<T: CliOverride> Cli<T> {
             request = request.body_map(|body| body.name(value.clone()))
         }
 
+        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
+            request = request.organization_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("project-name") {
+            request = request.project_name(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<types::Name>("subnet-name") {
             request = request.body_map(|body| body.subnet_name(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
             request = request.body_map(|body| body.vpc_name(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value =
+                serde_json::from_str::<types::NetworkInterfaceCreate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -7736,20 +7736,20 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_instance_network_interface_view(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.instance_network_interface_view();
-        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
-            request = request.organization_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("project-name") {
-            request = request.project_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<types::Name>("instance-name") {
             request = request.instance_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::Name>("interface-name") {
             request = request.interface_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
+            request = request.organization_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("project-name") {
+            request = request.project_name(value.clone());
         }
 
         self.over
@@ -7768,19 +7768,8 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_instance_network_interface_update(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.instance_network_interface_update();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value =
-                serde_json::from_str::<types::NetworkInterfaceUpdate>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
-            request = request.organization_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("project-name") {
-            request = request.project_name(value.clone());
+        if let Some(value) = matches.get_one::<String>("description") {
+            request = request.body_map(|body| body.description(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::Name>("instance-name") {
@@ -7791,16 +7780,27 @@ impl<T: CliOverride> Cli<T> {
             request = request.interface_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<String>("description") {
-            request = request.body_map(|body| body.description(value.clone()))
-        }
-
         if let Some(value) = matches.get_one::<types::Name>("name") {
             request = request.body_map(|body| body.name(value.clone()))
         }
 
+        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
+            request = request.organization_name(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<bool>("primary") {
             request = request.body_map(|body| body.primary(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("project-name") {
+            request = request.project_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value =
+                serde_json::from_str::<types::NetworkInterfaceUpdate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -7819,20 +7819,20 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_instance_network_interface_delete(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.instance_network_interface_delete();
-        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
-            request = request.organization_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("project-name") {
-            request = request.project_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<types::Name>("instance-name") {
             request = request.instance_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::Name>("interface-name") {
             request = request.interface_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
+            request = request.organization_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("project-name") {
+            request = request.project_name(value.clone());
         }
 
         self.over
@@ -7851,16 +7851,16 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_instance_reboot(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.instance_reboot();
+        if let Some(value) = matches.get_one::<types::Name>("instance-name") {
+            request = request.instance_name(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
             request = request.organization_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::Name>("project-name") {
             request = request.project_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("instance-name") {
-            request = request.instance_name(value.clone());
         }
 
         self.over
@@ -7879,20 +7879,12 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_instance_serial_console(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.instance_serial_console();
-        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
-            request = request.organization_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("project-name") {
-            request = request.project_name(value.clone());
+        if let Some(value) = matches.get_one::<u64>("from-start") {
+            request = request.from_start(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::Name>("instance-name") {
             request = request.instance_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<u64>("from-start") {
-            request = request.from_start(value.clone());
         }
 
         if let Some(value) = matches.get_one::<u64>("max-bytes") {
@@ -7901,6 +7893,14 @@ impl<T: CliOverride> Cli<T> {
 
         if let Some(value) = matches.get_one::<u64>("most-recent") {
             request = request.most_recent(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
+            request = request.organization_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("project-name") {
+            request = request.project_name(value.clone());
         }
 
         self.over
@@ -7919,16 +7919,16 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_instance_serial_console_stream(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.instance_serial_console_stream();
+        if let Some(value) = matches.get_one::<types::Name>("instance-name") {
+            request = request.instance_name(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
             request = request.organization_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::Name>("project-name") {
             request = request.project_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("instance-name") {
-            request = request.instance_name(value.clone());
         }
 
         self.over
@@ -7947,16 +7947,16 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_instance_start(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.instance_start();
+        if let Some(value) = matches.get_one::<types::Name>("instance-name") {
+            request = request.instance_name(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
             request = request.organization_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::Name>("project-name") {
             request = request.project_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("instance-name") {
-            request = request.instance_name(value.clone());
         }
 
         self.over
@@ -7975,16 +7975,16 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_instance_stop(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.instance_stop();
+        if let Some(value) = matches.get_one::<types::Name>("instance-name") {
+            request = request.instance_name(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
             request = request.organization_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::Name>("project-name") {
             request = request.project_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("instance-name") {
-            request = request.instance_name(value.clone());
         }
 
         self.over
@@ -8027,18 +8027,18 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_project_policy_update(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.project_policy_update();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::ProjectRolePolicy>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
             request = request.organization_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::Name>("project-name") {
             request = request.project_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::ProjectRolePolicy>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -8057,16 +8057,16 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_snapshot_list(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.snapshot_list();
+        if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
+            request = request.limit(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
             request = request.organization_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::Name>("project-name") {
             request = request.project_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
-            request = request.limit(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::NameSortMode>("sort-by") {
@@ -8095,20 +8095,6 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_snapshot_create(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.snapshot_create();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::SnapshotCreate>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
-            request = request.organization_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("project-name") {
-            request = request.project_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<String>("description") {
             request = request.body_map(|body| body.description(value.clone()))
         }
@@ -8119,6 +8105,20 @@ impl<T: CliOverride> Cli<T> {
 
         if let Some(value) = matches.get_one::<types::Name>("name") {
             request = request.body_map(|body| body.name(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
+            request = request.organization_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("project-name") {
+            request = request.project_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::SnapshotCreate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -8193,16 +8193,16 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_vpc_list(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.vpc_list();
+        if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
+            request = request.limit(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
             request = request.organization_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::Name>("project-name") {
             request = request.project_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
-            request = request.limit(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::NameSortMode>("sort-by") {
@@ -8229,20 +8229,6 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_vpc_create(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.vpc_create();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::VpcCreate>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
-            request = request.organization_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("project-name") {
-            request = request.project_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<String>("description") {
             request = request.body_map(|body| body.description(value.clone()))
         }
@@ -8257,6 +8243,20 @@ impl<T: CliOverride> Cli<T> {
 
         if let Some(value) = matches.get_one::<types::Name>("name") {
             request = request.body_map(|body| body.name(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
+            request = request.organization_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("project-name") {
+            request = request.project_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::VpcCreate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over.execute_vpc_create(matches, &mut request).unwrap();
@@ -8299,10 +8299,16 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_vpc_update(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.vpc_update();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::VpcUpdate>(&body_txt).unwrap();
-            request = request.body(body_value);
+        if let Some(value) = matches.get_one::<String>("description") {
+            request = request.body_map(|body| body.description(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("dns-name") {
+            request = request.body_map(|body| body.dns_name(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("name") {
+            request = request.body_map(|body| body.name(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
@@ -8317,16 +8323,10 @@ impl<T: CliOverride> Cli<T> {
             request = request.vpc_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<String>("description") {
-            request = request.body_map(|body| body.description(value.clone()))
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("dns-name") {
-            request = request.body_map(|body| body.dns_name(value.clone()))
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("name") {
-            request = request.body_map(|body| body.name(value.clone()))
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::VpcUpdate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over.execute_vpc_update(matches, &mut request).unwrap();
@@ -8397,13 +8397,6 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_vpc_firewall_rules_update(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.vpc_firewall_rules_update();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value =
-                serde_json::from_str::<types::VpcFirewallRuleUpdateParams>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
             request = request.organization_name(value.clone());
         }
@@ -8414,6 +8407,13 @@ impl<T: CliOverride> Cli<T> {
 
         if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
             request = request.vpc_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value =
+                serde_json::from_str::<types::VpcFirewallRuleUpdateParams>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -8432,6 +8432,10 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_vpc_router_list(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.vpc_router_list();
+        if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
+            request = request.limit(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
             request = request.organization_name(value.clone());
         }
@@ -8440,16 +8444,12 @@ impl<T: CliOverride> Cli<T> {
             request = request.project_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
-            request = request.vpc_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
-            request = request.limit(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<types::NameSortMode>("sort-by") {
             request = request.sort_by(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
+            request = request.vpc_name(value.clone());
         }
 
         self.over
@@ -8474,10 +8474,12 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_vpc_router_create(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.vpc_router_create();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::VpcRouterCreate>(&body_txt).unwrap();
-            request = request.body(body_value);
+        if let Some(value) = matches.get_one::<String>("description") {
+            request = request.body_map(|body| body.description(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("name") {
+            request = request.body_map(|body| body.name(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
@@ -8492,12 +8494,10 @@ impl<T: CliOverride> Cli<T> {
             request = request.vpc_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<String>("description") {
-            request = request.body_map(|body| body.description(value.clone()))
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("name") {
-            request = request.body_map(|body| body.name(value.clone()))
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::VpcRouterCreate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -8524,12 +8524,12 @@ impl<T: CliOverride> Cli<T> {
             request = request.project_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
-            request = request.vpc_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<types::Name>("router-name") {
             request = request.router_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
+            request = request.vpc_name(value.clone());
         }
 
         self.over
@@ -8548,10 +8548,12 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_vpc_router_update(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.vpc_router_update();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::VpcRouterUpdate>(&body_txt).unwrap();
-            request = request.body(body_value);
+        if let Some(value) = matches.get_one::<String>("description") {
+            request = request.body_map(|body| body.description(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("name") {
+            request = request.body_map(|body| body.name(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
@@ -8562,20 +8564,18 @@ impl<T: CliOverride> Cli<T> {
             request = request.project_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
-            request = request.vpc_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<types::Name>("router-name") {
             request = request.router_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<String>("description") {
-            request = request.body_map(|body| body.description(value.clone()))
+        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
+            request = request.vpc_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<types::Name>("name") {
-            request = request.body_map(|body| body.name(value.clone()))
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::VpcRouterUpdate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -8602,12 +8602,12 @@ impl<T: CliOverride> Cli<T> {
             request = request.project_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
-            request = request.vpc_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<types::Name>("router-name") {
             request = request.router_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
+            request = request.vpc_name(value.clone());
         }
 
         self.over
@@ -8626,6 +8626,10 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_vpc_router_route_list(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.vpc_router_route_list();
+        if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
+            request = request.limit(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
             request = request.organization_name(value.clone());
         }
@@ -8634,20 +8638,16 @@ impl<T: CliOverride> Cli<T> {
             request = request.project_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
-            request = request.vpc_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<types::Name>("router-name") {
             request = request.router_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
-            request = request.limit(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<types::NameSortMode>("sort-by") {
             request = request.sort_by(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
+            request = request.vpc_name(value.clone());
         }
 
         self.over
@@ -8672,11 +8672,12 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_vpc_router_route_create(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.vpc_router_route_create();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value =
-                serde_json::from_str::<types::RouterRouteCreateParams>(&body_txt).unwrap();
-            request = request.body(body_value);
+        if let Some(value) = matches.get_one::<String>("description") {
+            request = request.body_map(|body| body.description(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("name") {
+            request = request.body_map(|body| body.name(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
@@ -8687,20 +8688,19 @@ impl<T: CliOverride> Cli<T> {
             request = request.project_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
-            request = request.vpc_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<types::Name>("router-name") {
             request = request.router_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<String>("description") {
-            request = request.body_map(|body| body.description(value.clone()))
+        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
+            request = request.vpc_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<types::Name>("name") {
-            request = request.body_map(|body| body.name(value.clone()))
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value =
+                serde_json::from_str::<types::RouterRouteCreateParams>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -8727,16 +8727,16 @@ impl<T: CliOverride> Cli<T> {
             request = request.project_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
-            request = request.vpc_name(value.clone());
+        if let Some(value) = matches.get_one::<types::Name>("route-name") {
+            request = request.route_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::Name>("router-name") {
             request = request.router_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<types::Name>("route-name") {
-            request = request.route_name(value.clone());
+        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
+            request = request.vpc_name(value.clone());
         }
 
         self.over
@@ -8755,11 +8755,12 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_vpc_router_route_update(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.vpc_router_route_update();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value =
-                serde_json::from_str::<types::RouterRouteUpdateParams>(&body_txt).unwrap();
-            request = request.body(body_value);
+        if let Some(value) = matches.get_one::<String>("description") {
+            request = request.body_map(|body| body.description(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("name") {
+            request = request.body_map(|body| body.name(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
@@ -8770,24 +8771,23 @@ impl<T: CliOverride> Cli<T> {
             request = request.project_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
-            request = request.vpc_name(value.clone());
+        if let Some(value) = matches.get_one::<types::Name>("route-name") {
+            request = request.route_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::Name>("router-name") {
             request = request.router_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<types::Name>("route-name") {
-            request = request.route_name(value.clone());
+        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
+            request = request.vpc_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<String>("description") {
-            request = request.body_map(|body| body.description(value.clone()))
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("name") {
-            request = request.body_map(|body| body.name(value.clone()))
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value =
+                serde_json::from_str::<types::RouterRouteUpdateParams>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -8814,16 +8814,16 @@ impl<T: CliOverride> Cli<T> {
             request = request.project_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
-            request = request.vpc_name(value.clone());
+        if let Some(value) = matches.get_one::<types::Name>("route-name") {
+            request = request.route_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::Name>("router-name") {
             request = request.router_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<types::Name>("route-name") {
-            request = request.route_name(value.clone());
+        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
+            request = request.vpc_name(value.clone());
         }
 
         self.over
@@ -8842,6 +8842,10 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_vpc_subnet_list(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.vpc_subnet_list();
+        if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
+            request = request.limit(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
             request = request.organization_name(value.clone());
         }
@@ -8850,16 +8854,12 @@ impl<T: CliOverride> Cli<T> {
             request = request.project_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
-            request = request.vpc_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
-            request = request.limit(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<types::NameSortMode>("sort-by") {
             request = request.sort_by(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
+            request = request.vpc_name(value.clone());
         }
 
         self.over
@@ -8884,24 +8884,6 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_vpc_subnet_create(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.vpc_subnet_create();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::VpcSubnetCreate>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
-            request = request.organization_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("project-name") {
-            request = request.project_name(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
-            request = request.vpc_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<String>("description") {
             request = request.body_map(|body| body.description(value.clone()))
         }
@@ -8916,6 +8898,24 @@ impl<T: CliOverride> Cli<T> {
 
         if let Some(value) = matches.get_one::<types::Name>("name") {
             request = request.body_map(|body| body.name(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("organization-name") {
+            request = request.organization_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("project-name") {
+            request = request.project_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
+            request = request.vpc_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::VpcSubnetCreate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -8942,12 +8942,12 @@ impl<T: CliOverride> Cli<T> {
             request = request.project_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
-            request = request.vpc_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<types::Name>("subnet-name") {
             request = request.subnet_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
+            request = request.vpc_name(value.clone());
         }
 
         self.over
@@ -8966,10 +8966,12 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_vpc_subnet_update(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.vpc_subnet_update();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::VpcSubnetUpdate>(&body_txt).unwrap();
-            request = request.body(body_value);
+        if let Some(value) = matches.get_one::<String>("description") {
+            request = request.body_map(|body| body.description(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("name") {
+            request = request.body_map(|body| body.name(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
@@ -8980,20 +8982,18 @@ impl<T: CliOverride> Cli<T> {
             request = request.project_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
-            request = request.vpc_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<types::Name>("subnet-name") {
             request = request.subnet_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<String>("description") {
-            request = request.body_map(|body| body.description(value.clone()))
+        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
+            request = request.vpc_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<types::Name>("name") {
-            request = request.body_map(|body| body.name(value.clone()))
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::VpcSubnetUpdate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -9020,12 +9020,12 @@ impl<T: CliOverride> Cli<T> {
             request = request.project_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
-            request = request.vpc_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<types::Name>("subnet-name") {
             request = request.subnet_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
+            request = request.vpc_name(value.clone());
         }
 
         self.over
@@ -9044,6 +9044,10 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_vpc_subnet_list_network_interfaces(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.vpc_subnet_list_network_interfaces();
+        if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
+            request = request.limit(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<types::Name>("organization-name") {
             request = request.organization_name(value.clone());
         }
@@ -9052,20 +9056,16 @@ impl<T: CliOverride> Cli<T> {
             request = request.project_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
-            request = request.vpc_name(value.clone());
+        if let Some(value) = matches.get_one::<types::NameSortMode>("sort-by") {
+            request = request.sort_by(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::Name>("subnet-name") {
             request = request.subnet_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
-            request = request.limit(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::NameSortMode>("sort-by") {
-            request = request.sort_by(value.clone());
+        if let Some(value) = matches.get_one::<types::Name>("vpc-name") {
+            request = request.vpc_name(value.clone());
         }
 
         self.over
@@ -9244,12 +9244,6 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_session_sshkey_create(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.session_sshkey_create();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::SshKeyCreate>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
         if let Some(value) = matches.get_one::<String>("description") {
             request = request.body_map(|body| body.description(value.clone()))
         }
@@ -9260,6 +9254,12 @@ impl<T: CliOverride> Cli<T> {
 
         if let Some(value) = matches.get_one::<String>("public-key") {
             request = request.body_map(|body| body.public_key(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::SshKeyCreate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -9408,12 +9408,6 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_certificate_create(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.certificate_create();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::CertificateCreate>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
         if let Some(value) = matches.get_one::<String>("description") {
             request = request.body_map(|body| body.description(value.clone()))
         }
@@ -9424,6 +9418,12 @@ impl<T: CliOverride> Cli<T> {
 
         if let Some(value) = matches.get_one::<types::ServiceUsingCertificate>("service") {
             request = request.body_map(|body| body.service(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::CertificateCreate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -9604,12 +9604,12 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_sled_physical_disk_list(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.sled_physical_disk_list();
-        if let Some(value) = matches.get_one::<uuid::Uuid>("sled-id") {
-            request = request.sled_id(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
             request = request.limit(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<uuid::Uuid>("sled-id") {
+            request = request.sled_id(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::IdSortMode>("sort-by") {
@@ -9668,18 +9668,18 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_system_image_create(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.system_image_create();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::GlobalImageCreate>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
         if let Some(value) = matches.get_one::<String>("description") {
             request = request.body_map(|body| body.description(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::Name>("name") {
             request = request.body_map(|body| body.name(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::GlobalImageCreate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -9768,18 +9768,18 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_ip_pool_create(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.ip_pool_create();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::IpPoolCreate>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
         if let Some(value) = matches.get_one::<String>("description") {
             request = request.body_map(|body| body.description(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::Name>("name") {
             request = request.body_map(|body| body.name(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::IpPoolCreate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -9818,22 +9818,22 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_ip_pool_update(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.ip_pool_update();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::IpPoolUpdate>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("pool-name") {
-            request = request.pool_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<String>("description") {
             request = request.body_map(|body| body.description(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::Name>("name") {
             request = request.body_map(|body| body.name(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("pool-name") {
+            request = request.pool_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::IpPoolUpdate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -9872,12 +9872,12 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_ip_pool_range_list(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.ip_pool_range_list();
-        if let Some(value) = matches.get_one::<types::Name>("pool-name") {
-            request = request.pool_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
             request = request.limit(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("pool-name") {
+            request = request.pool_name(value.clone());
         }
 
         self.over
@@ -9902,14 +9902,14 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_ip_pool_range_add(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.ip_pool_range_add();
+        if let Some(value) = matches.get_one::<types::Name>("pool-name") {
+            request = request.pool_name(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
             let body_txt = std::fs::read_to_string(value).unwrap();
             let body_value = serde_json::from_str::<types::IpRange>(&body_txt).unwrap();
             request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("pool-name") {
-            request = request.pool_name(value.clone());
         }
 
         self.over
@@ -9928,14 +9928,14 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_ip_pool_range_remove(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.ip_pool_range_remove();
+        if let Some(value) = matches.get_one::<types::Name>("pool-name") {
+            request = request.pool_name(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
             let body_txt = std::fs::read_to_string(value).unwrap();
             let body_value = serde_json::from_str::<types::IpRange>(&body_txt).unwrap();
             request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("pool-name") {
-            request = request.pool_name(value.clone());
         }
 
         self.over
@@ -10040,10 +10040,6 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_system_metric(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.system_metric();
-        if let Some(value) = matches.get_one::<types::SystemMetricName>("metric-name") {
-            request = request.metric_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<chrono::DateTime<chrono::offset::Utc>>("end-time") {
             request = request.end_time(value.clone());
         }
@@ -10054,6 +10050,10 @@ impl<T: CliOverride> Cli<T> {
 
         if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
             request = request.limit(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::SystemMetricName>("metric-name") {
+            request = request.metric_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<String>("page-token") {
@@ -10193,12 +10193,6 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_silo_create(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.silo_create();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::SiloCreate>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
         if let Some(value) = matches.get_one::<String>("admin-group-name") {
             request = request.body_map(|body| body.admin_group_name(value.clone()))
         }
@@ -10217,6 +10211,12 @@ impl<T: CliOverride> Cli<T> {
 
         if let Some(value) = matches.get_one::<types::Name>("name") {
             request = request.body_map(|body| body.name(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::SiloCreate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -10273,12 +10273,12 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_silo_identity_provider_list(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.silo_identity_provider_list();
-        if let Some(value) = matches.get_one::<types::Name>("silo-name") {
-            request = request.silo_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
             request = request.limit(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("silo-name") {
+            request = request.silo_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::NameSortMode>("sort-by") {
@@ -10307,18 +10307,18 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_local_idp_user_create(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.local_idp_user_create();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::UserCreate>(&body_txt).unwrap();
-            request = request.body(body_value);
+        if let Some(value) = matches.get_one::<types::UserId>("external-id") {
+            request = request.body_map(|body| body.external_id(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::Name>("silo-name") {
             request = request.silo_name(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<types::UserId>("external-id") {
-            request = request.body_map(|body| body.external_id(value.clone()))
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::UserCreate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -10361,18 +10361,18 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_local_idp_user_set_password(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.local_idp_user_set_password();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::UserPassword>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
         if let Some(value) = matches.get_one::<types::Name>("silo-name") {
             request = request.silo_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<uuid::Uuid>("user-id") {
             request = request.user_id(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::UserPassword>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -10391,17 +10391,6 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_saml_identity_provider_create(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.saml_identity_provider_create();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value =
-                serde_json::from_str::<types::SamlIdentityProviderCreate>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("silo-name") {
-            request = request.silo_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<String>("acs-url") {
             request = request.body_map(|body| body.acs_url(value.clone()))
         }
@@ -10422,6 +10411,10 @@ impl<T: CliOverride> Cli<T> {
             request = request.body_map(|body| body.name(value.clone()))
         }
 
+        if let Some(value) = matches.get_one::<types::Name>("silo-name") {
+            request = request.silo_name(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<String>("slo-url") {
             request = request.body_map(|body| body.slo_url(value.clone()))
         }
@@ -10432,6 +10425,13 @@ impl<T: CliOverride> Cli<T> {
 
         if let Some(value) = matches.get_one::<String>("technical-contact-email") {
             request = request.body_map(|body| body.technical_contact_email(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value =
+                serde_json::from_str::<types::SamlIdentityProviderCreate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -10450,12 +10450,12 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_saml_identity_provider_view(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.saml_identity_provider_view();
-        if let Some(value) = matches.get_one::<types::Name>("silo-name") {
-            request = request.silo_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<types::Name>("provider-name") {
             request = request.provider_name(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("silo-name") {
+            request = request.silo_name(value.clone());
         }
 
         self.over
@@ -10494,14 +10494,14 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_silo_policy_update(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.silo_policy_update();
+        if let Some(value) = matches.get_one::<types::Name>("silo-name") {
+            request = request.silo_name(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
             let body_txt = std::fs::read_to_string(value).unwrap();
             let body_value = serde_json::from_str::<types::SiloRolePolicy>(&body_txt).unwrap();
             request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("silo-name") {
-            request = request.silo_name(value.clone());
         }
 
         self.over
@@ -10520,12 +10520,12 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_silo_users_list(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.silo_users_list();
-        if let Some(value) = matches.get_one::<types::Name>("silo-name") {
-            request = request.silo_name(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<std::num::NonZeroU32>("limit") {
             request = request.limit(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("silo-name") {
+            request = request.silo_name(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::IdSortMode>("sort-by") {
@@ -10720,10 +10720,12 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_disk_create_v1(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.disk_create_v1();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::DiskCreate>(&body_txt).unwrap();
-            request = request.body(body_value);
+        if let Some(value) = matches.get_one::<String>("description") {
+            request = request.body_map(|body| body.description(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<types::Name>("name") {
+            request = request.body_map(|body| body.name(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::NameOrId>("organization") {
@@ -10734,16 +10736,14 @@ impl<T: CliOverride> Cli<T> {
             request = request.project(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<String>("description") {
-            request = request.body_map(|body| body.description(value.clone()))
-        }
-
-        if let Some(value) = matches.get_one::<types::Name>("name") {
-            request = request.body_map(|body| body.name(value.clone()))
-        }
-
         if let Some(value) = matches.get_one::<types::ByteCount>("size") {
             request = request.body_map(|body| body.size(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::DiskCreate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -10856,20 +10856,6 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_instance_create_v1(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.instance_create_v1();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::InstanceCreate>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<types::NameOrId>("organization") {
-            request = request.organization(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::NameOrId>("project") {
-            request = request.project(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<String>("description") {
             request = request.body_map(|body| body.description(value.clone()))
         }
@@ -10890,12 +10876,26 @@ impl<T: CliOverride> Cli<T> {
             request = request.body_map(|body| body.ncpus(value.clone()))
         }
 
+        if let Some(value) = matches.get_one::<types::NameOrId>("organization") {
+            request = request.organization(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::NameOrId>("project") {
+            request = request.project(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<bool>("start") {
             request = request.body_map(|body| body.start(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<String>("user-data") {
             request = request.body_map(|body| body.user_data(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::InstanceCreate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -11012,10 +11012,8 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_instance_disk_attach_v1(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.instance_disk_attach_v1();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::DiskPath>(&body_txt).unwrap();
-            request = request.body(body_value);
+        if let Some(value) = matches.get_one::<types::NameOrId>("disk") {
+            request = request.body_map(|body| body.disk(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::NameOrId>("instance") {
@@ -11030,8 +11028,10 @@ impl<T: CliOverride> Cli<T> {
             request = request.project(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<types::NameOrId>("disk") {
-            request = request.body_map(|body| body.disk(value.clone()))
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::DiskPath>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -11050,10 +11050,8 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_instance_disk_detach_v1(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.instance_disk_detach_v1();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::DiskPath>(&body_txt).unwrap();
-            request = request.body(body_value);
+        if let Some(value) = matches.get_one::<types::NameOrId>("disk") {
+            request = request.body_map(|body| body.disk(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::NameOrId>("instance") {
@@ -11068,8 +11066,10 @@ impl<T: CliOverride> Cli<T> {
             request = request.project(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<types::NameOrId>("disk") {
-            request = request.body_map(|body| body.disk(value.clone()))
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::DiskPath>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -11088,10 +11088,8 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_instance_migrate_v1(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.instance_migrate_v1();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::InstanceMigrate>(&body_txt).unwrap();
-            request = request.body(body_value);
+        if let Some(value) = matches.get_one::<uuid::Uuid>("dst-sled-id") {
+            request = request.body_map(|body| body.dst_sled_id(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::NameOrId>("instance") {
@@ -11106,8 +11104,10 @@ impl<T: CliOverride> Cli<T> {
             request = request.project(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<uuid::Uuid>("dst-sled-id") {
-            request = request.body_map(|body| body.dst_sled_id(value.clone()))
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::InstanceMigrate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -11154,12 +11154,12 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_instance_serial_console_v1(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.instance_serial_console_v1();
-        if let Some(value) = matches.get_one::<types::NameOrId>("instance") {
-            request = request.instance(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<u64>("from-start") {
             request = request.from_start(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::NameOrId>("instance") {
+            request = request.instance(value.clone());
         }
 
         if let Some(value) = matches.get_one::<u64>("max-bytes") {
@@ -11308,18 +11308,18 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_organization_create_v1(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.organization_create_v1();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::OrganizationCreate>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
         if let Some(value) = matches.get_one::<String>("description") {
             request = request.body_map(|body| body.description(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::Name>("name") {
             request = request.body_map(|body| body.name(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::OrganizationCreate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -11358,22 +11358,22 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_organization_update_v1(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.organization_update_v1();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::OrganizationUpdate>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<types::NameOrId>("organization") {
-            request = request.organization(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<String>("description") {
             request = request.body_map(|body| body.description(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::Name>("name") {
             request = request.body_map(|body| body.name(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<types::NameOrId>("organization") {
+            request = request.organization(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::OrganizationUpdate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -11432,15 +11432,15 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_organization_policy_update_v1(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.organization_policy_update_v1();
+        if let Some(value) = matches.get_one::<types::NameOrId>("organization") {
+            request = request.organization(value.clone());
+        }
+
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
             let body_txt = std::fs::read_to_string(value).unwrap();
             let body_value =
                 serde_json::from_str::<types::OrganizationRolePolicy>(&body_txt).unwrap();
             request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<types::NameOrId>("organization") {
-            request = request.organization(value.clone());
         }
 
         self.over
@@ -11493,22 +11493,22 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_project_create_v1(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.project_create_v1();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::ProjectCreate>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<types::NameOrId>("organization") {
-            request = request.organization(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<String>("description") {
             request = request.body_map(|body| body.description(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::Name>("name") {
             request = request.body_map(|body| body.name(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<types::NameOrId>("organization") {
+            request = request.organization(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::ProjectCreate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -11527,12 +11527,12 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_project_view_v1(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.project_view_v1();
-        if let Some(value) = matches.get_one::<types::NameOrId>("project") {
-            request = request.project(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<types::NameOrId>("organization") {
             request = request.organization(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::NameOrId>("project") {
+            request = request.project(value.clone());
         }
 
         self.over
@@ -11551,26 +11551,26 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_project_update_v1(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.project_update_v1();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::ProjectUpdate>(&body_txt).unwrap();
-            request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<types::NameOrId>("project") {
-            request = request.project(value.clone());
-        }
-
-        if let Some(value) = matches.get_one::<types::NameOrId>("organization") {
-            request = request.organization(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<String>("description") {
             request = request.body_map(|body| body.description(value.clone()))
         }
 
         if let Some(value) = matches.get_one::<types::Name>("name") {
             request = request.body_map(|body| body.name(value.clone()))
+        }
+
+        if let Some(value) = matches.get_one::<types::NameOrId>("organization") {
+            request = request.organization(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::NameOrId>("project") {
+            request = request.project(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::ProjectUpdate>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -11589,12 +11589,12 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_project_delete_v1(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.project_delete_v1();
-        if let Some(value) = matches.get_one::<types::NameOrId>("project") {
-            request = request.project(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<types::NameOrId>("organization") {
             request = request.organization(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::NameOrId>("project") {
+            request = request.project(value.clone());
         }
 
         self.over
@@ -11613,12 +11613,12 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_project_policy_view_v1(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.project_policy_view_v1();
-        if let Some(value) = matches.get_one::<types::NameOrId>("project") {
-            request = request.project(value.clone());
-        }
-
         if let Some(value) = matches.get_one::<types::NameOrId>("organization") {
             request = request.organization(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<types::NameOrId>("project") {
+            request = request.project(value.clone());
         }
 
         self.over
@@ -11637,18 +11637,18 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_project_policy_update_v1(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.project_policy_update_v1();
-        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
-            let body_txt = std::fs::read_to_string(value).unwrap();
-            let body_value = serde_json::from_str::<types::ProjectRolePolicy>(&body_txt).unwrap();
-            request = request.body(body_value);
+        if let Some(value) = matches.get_one::<types::NameOrId>("organization") {
+            request = request.organization(value.clone());
         }
 
         if let Some(value) = matches.get_one::<types::NameOrId>("project") {
             request = request.project(value.clone());
         }
 
-        if let Some(value) = matches.get_one::<types::NameOrId>("organization") {
-            request = request.organization(value.clone());
+        if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
+            let body_txt = std::fs::read_to_string(value).unwrap();
+            let body_value = serde_json::from_str::<types::ProjectRolePolicy>(&body_txt).unwrap();
+            request = request.body(body_value);
         }
 
         self.over
@@ -11763,14 +11763,14 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_system_update_start(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.system_update_start();
+        if let Some(value) = matches.get_one::<types::SemverVersion>("version") {
+            request = request.body_map(|body| body.version(value.clone()))
+        }
+
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
             let body_txt = std::fs::read_to_string(value).unwrap();
             let body_value = serde_json::from_str::<types::SystemUpdateStart>(&body_txt).unwrap();
             request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<types::SemverVersion>("version") {
-            request = request.body_map(|body| body.version(value.clone()))
         }
 
         self.over

--- a/progenitor-impl/tests/output/propolis-server-cli.out
+++ b/progenitor-impl/tests/output/propolis-server-cli.out
@@ -101,7 +101,7 @@ impl Cli {
                 clap::Arg::new("json-body")
                     .long("json-body")
                     .value_name("JSON-FILE")
-                    .required(false)
+                    .required(true)
                     .value_parser(clap::value_parser!(std::path::PathBuf))
                     .help("Path to a file that contains the full json body."),
             )
@@ -188,15 +188,15 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_instance_ensure(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.instance_ensure();
+        if let Some(value) = matches.get_one::<String>("cloud-init-bytes") {
+            request = request.body_map(|body| body.cloud_init_bytes(value.clone()))
+        }
+
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
             let body_txt = std::fs::read_to_string(value).unwrap();
             let body_value =
                 serde_json::from_str::<types::InstanceEnsureRequest>(&body_txt).unwrap();
             request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<String>("cloud-init-bytes") {
-            request = request.body_map(|body| body.cloud_init_bytes(value.clone()))
         }
 
         self.over
@@ -242,15 +242,15 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_instance_migrate_status(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.instance_migrate_status();
+        if let Some(value) = matches.get_one::<uuid::Uuid>("migration-id") {
+            request = request.body_map(|body| body.migration_id(value.clone()))
+        }
+
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
             let body_txt = std::fs::read_to_string(value).unwrap();
             let body_value =
                 serde_json::from_str::<types::InstanceMigrateStatusRequest>(&body_txt).unwrap();
             request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<uuid::Uuid>("migration-id") {
-            request = request.body_map(|body| body.migration_id(value.clone()))
         }
 
         self.over
@@ -308,15 +308,15 @@ impl<T: CliOverride> Cli<T> {
 
     pub async fn execute_instance_state_monitor(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.instance_state_monitor();
+        if let Some(value) = matches.get_one::<u64>("gen") {
+            request = request.body_map(|body| body.gen(value.clone()))
+        }
+
         if let Some(value) = matches.get_one::<std::path::PathBuf>("json-body") {
             let body_txt = std::fs::read_to_string(value).unwrap();
             let body_value =
                 serde_json::from_str::<types::InstanceStateMonitorRequest>(&body_txt).unwrap();
             request = request.body(body_value);
-        }
-
-        if let Some(value) = matches.get_one::<u64>("gen") {
-            request = request.body_map(|body| body.gen(value.clone()))
         }
 
         self.over


### PR DESCRIPTION
Restructure argument processing to close up some corner cases where we didn't properly identify when the json body was required and to make it more extensible to other types of parameters such as those derived from enum variants.

The output changes in this PR should just be ordering, not structural.