### PR TITLE
Add support for text/plain and text/x-markdown body content types

### DIFF
--- a/progenitor-impl/tests/output/buildomat-builder-tagged.out
+++ b/progenitor-impl/tests/output/buildomat-builder-tagged.out
@@ -1754,6 +1754,18 @@ impl Client {
         builder::Whoami::new(self)
     }
 
+    ///Sends a `PUT` request to `/v1/whoami/name`
+    ///
+    ///```ignore
+    /// let response = client.whoami_put_name()
+    ///    .body(body)
+    ///    .send()
+    ///    .await;
+    /// ```
+    pub fn whoami_put_name(&self) -> builder::WhoamiPutName {
+        builder::WhoamiPutName::new(self)
+    }
+
     ///Sends a `POST` request to `/v1/worker/bootstrap`
     ///
     ///```ignore
@@ -2350,6 +2362,57 @@ pub mod builder {
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
+            }
+        }
+    }
+
+    ///Builder for [`Client::whoami_put_name`]
+    ///
+    ///[`Client::whoami_put_name`]: super::Client::whoami_put_name
+    #[derive(Debug)]
+    pub struct WhoamiPutName<'a> {
+        client: &'a super::Client,
+        body: Result<reqwest::Body, String>,
+    }
+
+    impl<'a> WhoamiPutName<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
+        }
+
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<String>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for body failed".to_string())
+                .map(|v| v.into());
+            self
+        }
+
+        ///Sends a `PUT` request to `/v1/whoami/name`
+        pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
+            let Self { client, body } = self;
+            let body = body.map_err(Error::InvalidRequest)?;
+            let url = format!("{}/v1/whoami/name", client.baseurl,);
+            let request = client
+                .client
+                .put(url)
+                .header(
+                    reqwest::header::CONTENT_TYPE,
+                    reqwest::header::HeaderValue::from_static("text/plain"),
+                )
+                .body(body)
+                .build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => Ok(ResponseValue::empty(response)),
                 _ => Err(Error::UnexpectedResponse(response)),
             }
         }

--- a/progenitor-impl/tests/output/buildomat-builder.out
+++ b/progenitor-impl/tests/output/buildomat-builder.out
@@ -1754,6 +1754,18 @@ impl Client {
         builder::Whoami::new(self)
     }
 
+    ///Sends a `PUT` request to `/v1/whoami/name`
+    ///
+    ///```ignore
+    /// let response = client.whoami_put_name()
+    ///    .body(body)
+    ///    .send()
+    ///    .await;
+    /// ```
+    pub fn whoami_put_name(&self) -> builder::WhoamiPutName {
+        builder::WhoamiPutName::new(self)
+    }
+
     ///Sends a `POST` request to `/v1/worker/bootstrap`
     ///
     ///```ignore
@@ -2350,6 +2362,57 @@ pub mod builder {
             let response = result?;
             match response.status().as_u16() {
                 200u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
+            }
+        }
+    }
+
+    ///Builder for [`Client::whoami_put_name`]
+    ///
+    ///[`Client::whoami_put_name`]: super::Client::whoami_put_name
+    #[derive(Debug)]
+    pub struct WhoamiPutName<'a> {
+        client: &'a super::Client,
+        body: Result<reqwest::Body, String>,
+    }
+
+    impl<'a> WhoamiPutName<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self {
+                client,
+                body: Err("body was not initialized".to_string()),
+            }
+        }
+
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<String>,
+        {
+            self.body = value
+                .try_into()
+                .map_err(|_| "conversion to `String` for body failed".to_string())
+                .map(|v| v.into());
+            self
+        }
+
+        ///Sends a `PUT` request to `/v1/whoami/name`
+        pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
+            let Self { client, body } = self;
+            let body = body.map_err(Error::InvalidRequest)?;
+            let url = format!("{}/v1/whoami/name", client.baseurl,);
+            let request = client
+                .client
+                .put(url)
+                .header(
+                    reqwest::header::CONTENT_TYPE,
+                    reqwest::header::HeaderValue::from_static("text/plain"),
+                )
+                .body(body)
+                .build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => Ok(ResponseValue::empty(response)),
                 _ => Err(Error::UnexpectedResponse(response)),
             }
         }

--- a/progenitor-impl/tests/output/buildomat-cli.out
+++ b/progenitor-impl/tests/output/buildomat-cli.out
@@ -20,6 +20,7 @@ impl Cli {
             CliCommand::TaskOutputDownload => Self::cli_task_output_download(),
             CliCommand::UserCreate => Self::cli_user_create(),
             CliCommand::Whoami => Self::cli_whoami(),
+            CliCommand::WhoamiPutName => Self::cli_whoami_put_name(),
             CliCommand::WorkerBootstrap => Self::cli_worker_bootstrap(),
             CliCommand::WorkerPing => Self::cli_worker_ping(),
             CliCommand::WorkerTaskAppend => Self::cli_worker_task_append(),
@@ -148,6 +149,10 @@ impl Cli {
     }
 
     pub fn cli_whoami() -> clap::Command {
+        clap::Command::new("")
+    }
+
+    pub fn cli_whoami_put_name() -> clap::Command {
         clap::Command::new("")
     }
 
@@ -347,6 +352,9 @@ impl<T: CliOverride> Cli<T> {
             }
             CliCommand::Whoami => {
                 self.execute_whoami(matches).await;
+            }
+            CliCommand::WhoamiPutName => {
+                self.execute_whoami_put_name(matches).await;
             }
             CliCommand::WorkerBootstrap => {
                 self.execute_worker_bootstrap(matches).await;
@@ -566,6 +574,22 @@ impl<T: CliOverride> Cli<T> {
     pub async fn execute_whoami(&self, matches: &clap::ArgMatches) {
         let mut request = self.client.whoami();
         self.over.execute_whoami(matches, &mut request).unwrap();
+        let result = request.send().await;
+        match result {
+            Ok(r) => {
+                println!("success\n{:#?}", r)
+            }
+            Err(r) => {
+                println!("success\n{:#?}", r)
+            }
+        }
+    }
+
+    pub async fn execute_whoami_put_name(&self, matches: &clap::ArgMatches) {
+        let mut request = self.client.whoami_put_name();
+        self.over
+            .execute_whoami_put_name(matches, &mut request)
+            .unwrap();
         let result = request.send().await;
         match result {
             Ok(r) => {
@@ -859,6 +883,14 @@ pub trait CliOverride {
         Ok(())
     }
 
+    fn execute_whoami_put_name(
+        &self,
+        matches: &clap::ArgMatches,
+        request: &mut builder::WhoamiPutName,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+
     fn execute_worker_bootstrap(
         &self,
         matches: &clap::ArgMatches,
@@ -938,6 +970,7 @@ pub enum CliCommand {
     TaskOutputDownload,
     UserCreate,
     Whoami,
+    WhoamiPutName,
     WorkerBootstrap,
     WorkerPing,
     WorkerTaskAppend,
@@ -961,6 +994,7 @@ impl CliCommand {
             CliCommand::TaskOutputDownload,
             CliCommand::UserCreate,
             CliCommand::Whoami,
+            CliCommand::WhoamiPutName,
             CliCommand::WorkerBootstrap,
             CliCommand::WorkerPing,
             CliCommand::WorkerTaskAppend,

--- a/progenitor-impl/tests/output/buildomat-httpmock.out
+++ b/progenitor-impl/tests/output/buildomat-httpmock.out
@@ -403,6 +403,40 @@ pub mod operations {
         }
     }
 
+    pub struct WhoamiPutNameWhen(httpmock::When);
+    impl WhoamiPutNameWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::PUT)
+                    .path_matches(regex::Regex::new("^/v1/whoami/name$").unwrap()),
+            )
+        }
+
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+
+        pub fn body(self, value: String) -> Self {
+            Self(self.0.body(value))
+        }
+    }
+
+    pub struct WhoamiPutNameThen(httpmock::Then);
+    impl WhoamiPutNameThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+
+        pub fn ok(self) -> Self {
+            Self(self.0.status(200u16))
+        }
+    }
+
     pub struct WorkerBootstrapWhen(httpmock::When);
     impl WorkerBootstrapWhen {
         pub fn new(inner: httpmock::When) -> Self {
@@ -743,6 +777,9 @@ pub trait MockServerExt {
     fn whoami<F>(&self, config_fn: F) -> httpmock::Mock
     where
         F: FnOnce(operations::WhoamiWhen, operations::WhoamiThen);
+    fn whoami_put_name<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(operations::WhoamiPutNameWhen, operations::WhoamiPutNameThen);
     fn worker_bootstrap<F>(&self, config_fn: F) -> httpmock::Mock
     where
         F: FnOnce(operations::WorkerBootstrapWhen, operations::WorkerBootstrapThen);
@@ -886,6 +923,18 @@ impl MockServerExt for httpmock::MockServer {
             config_fn(
                 operations::WhoamiWhen::new(when),
                 operations::WhoamiThen::new(then),
+            )
+        })
+    }
+
+    fn whoami_put_name<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(operations::WhoamiPutNameWhen, operations::WhoamiPutNameThen),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::WhoamiPutNameWhen::new(when),
+                operations::WhoamiPutNameThen::new(then),
             )
         })
     }

--- a/progenitor-impl/tests/output/buildomat-positional.out
+++ b/progenitor-impl/tests/output/buildomat-positional.out
@@ -532,6 +532,29 @@ impl Client {
         }
     }
 
+    ///Sends a `PUT` request to `/v1/whoami/name`
+    pub async fn whoami_put_name<'a>(
+        &'a self,
+        body: String,
+    ) -> Result<ResponseValue<()>, Error<()>> {
+        let url = format!("{}/v1/whoami/name", self.baseurl,);
+        let request = self
+            .client
+            .put(url)
+            .header(
+                reqwest::header::CONTENT_TYPE,
+                reqwest::header::HeaderValue::from_static("text/plain"),
+            )
+            .body(body)
+            .build()?;
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => Ok(ResponseValue::empty(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
+        }
+    }
+
     ///Sends a `POST` request to `/v1/worker/bootstrap`
     pub async fn worker_bootstrap<'a>(
         &'a self,

--- a/sample_openapi/buildomat.json
+++ b/sample_openapi/buildomat.json
@@ -252,6 +252,25 @@
         }
       }
     },
+    "/v1/whoami/name": {
+      "put": {
+        "operationId": "whoami_put_name",
+        "requestBody": {
+          "content": {
+            "text/plain": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
     "/v1/worker/bootstrap": {
       "post": {
         "operationId": "worker_bootstrap",


### PR DESCRIPTION
This PR adds support for the `text/plain` and `text/x-markdown` types in request bodies. This should help along with #395.