### PR TITLE
Prefix internal variable names to help avoid collisions

### DIFF
--- a/progenitor-impl/src/template.rs
+++ b/progenitor-impl/src/template.rs
@@ -50,7 +50,7 @@ impl PathTemplate {
         });
 
         quote! {
-            let url = format!(#fmt, #client.baseurl, #(#components,)*);
+            format!(#fmt, #client.baseurl, #(#components,)*)
         }
     }
 

--- a/progenitor-impl/src/template.rs
+++ b/progenitor-impl/src/template.rs
@@ -306,10 +306,10 @@ mod tests {
         let t = parse("/measure/{number}").unwrap();
         let out = t.compile(rename, quote::quote! { self });
         let want = quote::quote! {
-            let url = format!("{}/measure/{}",
+            format!("{}/measure/{}",
                 self.baseurl,
                 encode_path(&number.to_string()),
-            );
+            )
         };
         assert_eq!(want.to_string(), out.to_string());
     }
@@ -326,12 +326,12 @@ mod tests {
         let t = parse("/abc/def:{one}:jkl/{two}/a:{three}").unwrap();
         let out = t.compile(rename, quote::quote! { self });
         let want = quote::quote! {
-            let url = format!("{}/abc/def:{}:jkl/{}/a:{}",
+            format!("{}/abc/def:{}:jkl/{}/a:{}",
                 self.baseurl,
                 encode_path(&one.to_string()),
                 encode_path(&two.to_string()),
                 encode_path(&three.to_string()),
-            );
+            )
         };
         assert_eq!(want.to_string(), out.to_string());
     }

--- a/progenitor-impl/tests/output/buildomat-builder-tagged.out
+++ b/progenitor-impl/tests/output/buildomat-builder-tagged.out
@@ -1874,20 +1874,20 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/control/hold`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/control/hold", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/v1/control/hold", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -1908,13 +1908,13 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/control/resume`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/control/resume", client.baseurl,);
-            let request = client.client.post(url).build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(response)),
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_url = format!("{}/v1/control/resume", client.baseurl,);
+            let __progenitor_request = client.client.post(__progenitor_url).build()?;
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => Ok(ResponseValue::empty(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -1950,24 +1950,24 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Task>, Error<()>> {
             let Self { client, task } = self;
             let task = task.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/task/{}",
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -1988,20 +1988,20 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/tasks`
         pub async fn send(self) -> Result<ResponseValue<Vec<types::Task>>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/tasks", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/v1/tasks", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2048,21 +2048,21 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::TaskSubmit>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/tasks", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/v1/tasks", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2116,29 +2116,29 @@ pub mod builder {
             } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let minseq = minseq.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/tasks/{}/events",
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let mut query = Vec::with_capacity(1usize);
+            let mut __progenitor_query = Vec::with_capacity(1usize);
             if let Some(v) = &minseq {
-                query.push(("minseq", v.to_string()));
+                __progenitor_query.push(("minseq", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2174,24 +2174,24 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<Vec<types::TaskOutput>>, Error<()>> {
             let Self { client, task } = self;
             let task = task.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/tasks/{}/outputs",
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2244,18 +2244,18 @@ pub mod builder {
             } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let output = output.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/tasks/{}/outputs/{}",
                 client.baseurl,
                 encode_path(&task.to_string()),
                 encode_path(&output.to_string()),
             );
-            let request = client.client.get(url).build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(response)),
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_request = client.client.get(__progenitor_url).build()?;
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2302,21 +2302,21 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::UserCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/users", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/v1/users", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2337,20 +2337,20 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/whoami`
         pub async fn send(self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/whoami", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/v1/whoami", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2397,21 +2397,21 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerBootstrap>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/worker/bootstrap", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/v1/worker/bootstrap", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2432,20 +2432,20 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/worker/ping`
         pub async fn send(self) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/worker/ping", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/v1/worker/ping", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2507,17 +2507,17 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerAppendTask>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/worker/task/{}/append",
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let request = client.client.post(url).json(&body).build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => Ok(ResponseValue::empty(response)),
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_request = client.client.post(__progenitor_url).json(&body).build()?;
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => Ok(ResponseValue::empty(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2566,14 +2566,14 @@ pub mod builder {
             let Self { client, task, body } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/worker/task/{}/chunk",
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
@@ -2584,11 +2584,11 @@ pub mod builder {
                 )
                 .body(body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2650,17 +2650,17 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerCompleteTask>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/worker/task/{}/complete",
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let request = client.client.post(url).json(&body).build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(response)),
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_request = client.client.post(__progenitor_url).json(&body).build()?;
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => Ok(ResponseValue::empty(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2720,17 +2720,17 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerAddOutput>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/worker/task/{}/output",
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let request = client.client.post(url).json(&body).build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => Ok(ResponseValue::empty(response)),
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_request = client.client.post(__progenitor_url).json(&body).build()?;
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => Ok(ResponseValue::empty(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2751,20 +2751,20 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/workers`
         pub async fn send(self) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/workers", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/v1/workers", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2785,13 +2785,13 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/workers/recycle`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/workers/recycle", client.baseurl,);
-            let request = client.client.post(url).build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(response)),
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_url = format!("{}/v1/workers/recycle", client.baseurl,);
+            let __progenitor_request = client.client.post(__progenitor_url).build()?;
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => Ok(ResponseValue::empty(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/buildomat-builder.out
+++ b/progenitor-impl/tests/output/buildomat-builder.out
@@ -1874,20 +1874,20 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/control/hold`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/control/hold", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/v1/control/hold", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -1908,13 +1908,13 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/control/resume`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/control/resume", client.baseurl,);
-            let request = client.client.post(url).build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(response)),
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_url = format!("{}/v1/control/resume", client.baseurl,);
+            let __progenitor_request = client.client.post(__progenitor_url).build()?;
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => Ok(ResponseValue::empty(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -1950,24 +1950,24 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Task>, Error<()>> {
             let Self { client, task } = self;
             let task = task.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/task/{}",
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -1988,20 +1988,20 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/tasks`
         pub async fn send(self) -> Result<ResponseValue<Vec<types::Task>>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/tasks", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/v1/tasks", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2048,21 +2048,21 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::TaskSubmit>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/tasks", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/v1/tasks", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2116,29 +2116,29 @@ pub mod builder {
             } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let minseq = minseq.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/tasks/{}/events",
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let mut query = Vec::with_capacity(1usize);
+            let mut __progenitor_query = Vec::with_capacity(1usize);
             if let Some(v) = &minseq {
-                query.push(("minseq", v.to_string()));
+                __progenitor_query.push(("minseq", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2174,24 +2174,24 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<Vec<types::TaskOutput>>, Error<()>> {
             let Self { client, task } = self;
             let task = task.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/tasks/{}/outputs",
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2244,18 +2244,18 @@ pub mod builder {
             } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let output = output.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/tasks/{}/outputs/{}",
                 client.baseurl,
                 encode_path(&task.to_string()),
                 encode_path(&output.to_string()),
             );
-            let request = client.client.get(url).build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(response)),
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_request = client.client.get(__progenitor_url).build()?;
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2302,21 +2302,21 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::UserCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/users", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/v1/users", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2337,20 +2337,20 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/whoami`
         pub async fn send(self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/whoami", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/v1/whoami", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2397,21 +2397,21 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerBootstrap>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/worker/bootstrap", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/v1/worker/bootstrap", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2432,20 +2432,20 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/worker/ping`
         pub async fn send(self) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/worker/ping", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/v1/worker/ping", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2507,17 +2507,17 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerAppendTask>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/worker/task/{}/append",
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let request = client.client.post(url).json(&body).build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => Ok(ResponseValue::empty(response)),
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_request = client.client.post(__progenitor_url).json(&body).build()?;
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => Ok(ResponseValue::empty(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2566,14 +2566,14 @@ pub mod builder {
             let Self { client, task, body } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/worker/task/{}/chunk",
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
@@ -2584,11 +2584,11 @@ pub mod builder {
                 )
                 .body(body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2650,17 +2650,17 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerCompleteTask>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/worker/task/{}/complete",
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let request = client.client.post(url).json(&body).build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(response)),
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_request = client.client.post(__progenitor_url).json(&body).build()?;
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => Ok(ResponseValue::empty(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2720,17 +2720,17 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerAddOutput>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/worker/task/{}/output",
                 client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let request = client.client.post(url).json(&body).build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => Ok(ResponseValue::empty(response)),
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_request = client.client.post(__progenitor_url).json(&body).build()?;
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => Ok(ResponseValue::empty(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2751,20 +2751,20 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/workers`
         pub async fn send(self) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/workers", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/v1/workers", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2785,13 +2785,13 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/workers/recycle`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self { client } = self;
-            let url = format!("{}/v1/workers/recycle", client.baseurl,);
-            let request = client.client.post(url).build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(response)),
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_url = format!("{}/v1/workers/recycle", client.baseurl,);
+            let __progenitor_request = client.client.post(__progenitor_url).build()?;
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => Ok(ResponseValue::empty(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/buildomat-positional.out
+++ b/progenitor-impl/tests/output/buildomat-positional.out
@@ -313,32 +313,32 @@ impl Client {
 impl Client {
     ///Sends a `POST` request to `/v1/control/hold`
     pub async fn control_hold<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
-        let url = format!("{}/v1/control/hold", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/v1/control/hold", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
-            _ => Err(Error::UnexpectedResponse(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
     ///Sends a `POST` request to `/v1/control/resume`
     pub async fn control_resume<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
-        let url = format!("{}/v1/control/resume", self.baseurl,);
-        let request = self.client.post(url).build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => Ok(ResponseValue::empty(response)),
-            _ => Err(Error::UnexpectedResponse(response)),
+        let __progenitor_url = format!("{}/v1/control/resume", self.baseurl,);
+        let __progenitor_request = self.client.post(__progenitor_url).build()?;
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -347,43 +347,43 @@ impl Client {
         &'a self,
         task: &'a str,
     ) -> Result<ResponseValue<types::Task>, Error<()>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/task/{}",
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
-            _ => Err(Error::UnexpectedResponse(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
     ///Sends a `GET` request to `/v1/tasks`
     pub async fn tasks_get<'a>(&'a self) -> Result<ResponseValue<Vec<types::Task>>, Error<()>> {
-        let url = format!("{}/v1/tasks", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/v1/tasks", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
-            _ => Err(Error::UnexpectedResponse(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -392,21 +392,21 @@ impl Client {
         &'a self,
         body: &'a types::TaskSubmit,
     ) -> Result<ResponseValue<types::TaskSubmitResult>, Error<()>> {
-        let url = format!("{}/v1/tasks", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/v1/tasks", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
-            _ => Err(Error::UnexpectedResponse(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -416,30 +416,30 @@ impl Client {
         task: &'a str,
         minseq: Option<u32>,
     ) -> Result<ResponseValue<Vec<types::TaskEvent>>, Error<()>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/tasks/{}/events",
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let mut query = Vec::with_capacity(1usize);
+        let mut __progenitor_query = Vec::with_capacity(1usize);
         if let Some(v) = &minseq {
-            query.push(("minseq", v.to_string()));
+            __progenitor_query.push(("minseq", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
-            _ => Err(Error::UnexpectedResponse(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -448,24 +448,24 @@ impl Client {
         &'a self,
         task: &'a str,
     ) -> Result<ResponseValue<Vec<types::TaskOutput>>, Error<()>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/tasks/{}/outputs",
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
-            _ => Err(Error::UnexpectedResponse(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -475,18 +475,18 @@ impl Client {
         task: &'a str,
         output: &'a str,
     ) -> Result<ResponseValue<ByteStream>, Error<()>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/tasks/{}/outputs/{}",
             self.baseurl,
             encode_path(&task.to_string()),
             encode_path(&output.to_string()),
         );
-        let request = self.client.get(url).build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200..=299 => Ok(ResponseValue::stream(response)),
-            _ => Err(Error::UnexpectedResponse(response)),
+        let __progenitor_request = self.client.get(__progenitor_url).build()?;
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -495,40 +495,40 @@ impl Client {
         &'a self,
         body: &'a types::UserCreate,
     ) -> Result<ResponseValue<types::UserCreateResult>, Error<()>> {
-        let url = format!("{}/v1/users", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/v1/users", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
-            _ => Err(Error::UnexpectedResponse(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
     ///Sends a `GET` request to `/v1/whoami`
     pub async fn whoami<'a>(&'a self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
-        let url = format!("{}/v1/whoami", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/v1/whoami", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
-            _ => Err(Error::UnexpectedResponse(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -537,21 +537,21 @@ impl Client {
         &'a self,
         body: &'a types::WorkerBootstrap,
     ) -> Result<ResponseValue<types::WorkerBootstrapResult>, Error<()>> {
-        let url = format!("{}/v1/worker/bootstrap", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/v1/worker/bootstrap", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
-            _ => Err(Error::UnexpectedResponse(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -559,20 +559,20 @@ impl Client {
     pub async fn worker_ping<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
-        let url = format!("{}/v1/worker/ping", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/v1/worker/ping", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
-            _ => Err(Error::UnexpectedResponse(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -582,17 +582,17 @@ impl Client {
         task: &'a str,
         body: &'a types::WorkerAppendTask,
     ) -> Result<ResponseValue<()>, Error<()>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/worker/task/{}/append",
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let request = self.client.post(url).json(&body).build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => Ok(ResponseValue::empty(response)),
-            _ => Err(Error::UnexpectedResponse(response)),
+        let __progenitor_request = self.client.post(__progenitor_url).json(&body).build()?;
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -602,14 +602,14 @@ impl Client {
         task: &'a str,
         body: B,
     ) -> Result<ResponseValue<types::UploadedChunk>, Error<()>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/worker/task/{}/chunk",
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
@@ -620,11 +620,11 @@ impl Client {
             )
             .body(body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
-            _ => Err(Error::UnexpectedResponse(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -634,17 +634,17 @@ impl Client {
         task: &'a str,
         body: &'a types::WorkerCompleteTask,
     ) -> Result<ResponseValue<()>, Error<()>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/worker/task/{}/complete",
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let request = self.client.post(url).json(&body).build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => Ok(ResponseValue::empty(response)),
-            _ => Err(Error::UnexpectedResponse(response)),
+        let __progenitor_request = self.client.post(__progenitor_url).json(&body).build()?;
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -654,17 +654,17 @@ impl Client {
         task: &'a str,
         body: &'a types::WorkerAddOutput,
     ) -> Result<ResponseValue<()>, Error<()>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/worker/task/{}/output",
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let request = self.client.post(url).json(&body).build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => Ok(ResponseValue::empty(response)),
-            _ => Err(Error::UnexpectedResponse(response)),
+        let __progenitor_request = self.client.post(__progenitor_url).json(&body).build()?;
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -672,32 +672,32 @@ impl Client {
     pub async fn workers_list<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
-        let url = format!("{}/v1/workers", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/v1/workers", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
-            _ => Err(Error::UnexpectedResponse(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
     ///Sends a `POST` request to `/v1/workers/recycle`
     pub async fn workers_recycle<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
-        let url = format!("{}/v1/workers/recycle", self.baseurl,);
-        let request = self.client.post(url).build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => Ok(ResponseValue::empty(response)),
-            _ => Err(Error::UnexpectedResponse(response)),
+        let __progenitor_url = format!("{}/v1/workers/recycle", self.baseurl,);
+        let __progenitor_request = self.client.post(__progenitor_url).build()?;
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 }

--- a/progenitor-impl/tests/output/keeper-builder-tagged.out
+++ b/progenitor-impl/tests/output/keeper-builder-tagged.out
@@ -1119,20 +1119,20 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::EnrolBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/enrol", client.baseurl,);
+            let __progenitor_url = format!("{}/enrol", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => Ok(ResponseValue::empty(response)),
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => Ok(ResponseValue::empty(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -1171,23 +1171,23 @@ pub mod builder {
                 authorization,
             } = self;
             let authorization = authorization.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/global/jobs", client.baseurl,);
+            let __progenitor_url = format!("{}/global/jobs", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -1226,23 +1226,23 @@ pub mod builder {
                 authorization,
             } = self;
             let authorization = authorization.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/ping", client.baseurl,);
+            let __progenitor_url = format!("{}/ping", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -1308,12 +1308,12 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ReportFinishBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/report/finish", client.baseurl,);
+            let __progenitor_url = format!("{}/report/finish", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
@@ -1321,11 +1321,11 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -1391,12 +1391,12 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ReportOutputBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/report/output", client.baseurl,);
+            let __progenitor_url = format!("{}/report/output", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
@@ -1404,11 +1404,11 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -1472,12 +1472,12 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ReportStartBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/report/start", client.baseurl,);
+            let __progenitor_url = format!("{}/report/start", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
@@ -1485,11 +1485,11 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/keeper-builder.out
+++ b/progenitor-impl/tests/output/keeper-builder.out
@@ -1119,20 +1119,20 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::EnrolBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/enrol", client.baseurl,);
+            let __progenitor_url = format!("{}/enrol", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => Ok(ResponseValue::empty(response)),
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => Ok(ResponseValue::empty(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -1171,23 +1171,23 @@ pub mod builder {
                 authorization,
             } = self;
             let authorization = authorization.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/global/jobs", client.baseurl,);
+            let __progenitor_url = format!("{}/global/jobs", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -1226,23 +1226,23 @@ pub mod builder {
                 authorization,
             } = self;
             let authorization = authorization.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/ping", client.baseurl,);
+            let __progenitor_url = format!("{}/ping", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -1308,12 +1308,12 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ReportFinishBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/report/finish", client.baseurl,);
+            let __progenitor_url = format!("{}/report/finish", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
@@ -1321,11 +1321,11 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -1391,12 +1391,12 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ReportOutputBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/report/output", client.baseurl,);
+            let __progenitor_url = format!("{}/report/output", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
@@ -1404,11 +1404,11 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -1472,12 +1472,12 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ReportStartBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/report/start", client.baseurl,);
+            let __progenitor_url = format!("{}/report/start", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
@@ -1485,11 +1485,11 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/keeper-positional.out
+++ b/progenitor-impl/tests/output/keeper-positional.out
@@ -210,20 +210,20 @@ impl Client {
         authorization: &'a str,
         body: &'a types::EnrolBody,
     ) -> Result<ResponseValue<()>, Error<()>> {
-        let url = format!("{}/enrol", self.baseurl,);
+        let __progenitor_url = format!("{}/enrol", self.baseurl,);
         let mut header_map = HeaderMap::with_capacity(1usize);
         header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => Ok(ResponseValue::empty(response)),
-            _ => Err(Error::UnexpectedResponse(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -235,23 +235,23 @@ impl Client {
         &'a self,
         authorization: &'a str,
     ) -> Result<ResponseValue<types::GlobalJobsResult>, Error<()>> {
-        let url = format!("{}/global/jobs", self.baseurl,);
+        let __progenitor_url = format!("{}/global/jobs", self.baseurl,);
         let mut header_map = HeaderMap::with_capacity(1usize);
         header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
-            _ => Err(Error::UnexpectedResponse(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -263,23 +263,23 @@ impl Client {
         &'a self,
         authorization: &'a str,
     ) -> Result<ResponseValue<types::PingResult>, Error<()>> {
-        let url = format!("{}/ping", self.baseurl,);
+        let __progenitor_url = format!("{}/ping", self.baseurl,);
         let mut header_map = HeaderMap::with_capacity(1usize);
         header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
-            _ => Err(Error::UnexpectedResponse(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -293,12 +293,12 @@ impl Client {
         authorization: &'a str,
         body: &'a types::ReportFinishBody,
     ) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
-        let url = format!("{}/report/finish", self.baseurl,);
+        let __progenitor_url = format!("{}/report/finish", self.baseurl,);
         let mut header_map = HeaderMap::with_capacity(1usize);
         header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
@@ -306,11 +306,11 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
-            _ => Err(Error::UnexpectedResponse(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -324,12 +324,12 @@ impl Client {
         authorization: &'a str,
         body: &'a types::ReportOutputBody,
     ) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
-        let url = format!("{}/report/output", self.baseurl,);
+        let __progenitor_url = format!("{}/report/output", self.baseurl,);
         let mut header_map = HeaderMap::with_capacity(1usize);
         header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
@@ -337,11 +337,11 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
-            _ => Err(Error::UnexpectedResponse(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -355,12 +355,12 @@ impl Client {
         authorization: &'a str,
         body: &'a types::ReportStartBody,
     ) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
-        let url = format!("{}/report/start", self.baseurl,);
+        let __progenitor_url = format!("{}/report/start", self.baseurl,);
         let mut header_map = HeaderMap::with_capacity(1usize);
         header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
@@ -368,11 +368,11 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
-            _ => Err(Error::UnexpectedResponse(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 }

--- a/progenitor-impl/tests/output/nexus-builder-tagged.out
+++ b/progenitor-impl/tests/output/nexus-builder-tagged.out
@@ -21058,30 +21058,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/by-id/disks/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -21117,30 +21117,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/by-id/images/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -21176,30 +21176,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/by-id/instances/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -21238,30 +21238,30 @@ pub mod builder {
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/by-id/network-interfaces/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -21297,30 +21297,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/by-id/organizations/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -21356,30 +21356,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/by-id/projects/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -21415,30 +21415,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/by-id/snapshots/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -21474,30 +21474,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/by-id/vpc-router-routes/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -21533,30 +21533,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/by-id/vpc-routers/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -21592,30 +21592,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/by-id/vpc-subnets/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -21651,30 +21651,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/by-id/vpcs/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -21723,13 +21723,19 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DeviceAuthRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/device/auth", client.baseurl,);
-            let request = client.client.post(url).form_urlencoded(&body)?.build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(response)),
-                _ => Err(Error::ErrorResponse(ResponseValue::stream(response))),
+            let __progenitor_url = format!("{}/device/auth", client.baseurl,);
+            let __progenitor_request = client
+                .client
+                .post(__progenitor_url)
+                .form_urlencoded(&body)?
+                .build()?;
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
+                _ => Err(Error::ErrorResponse(ResponseValue::stream(
+                    __progenitor_response,
+                ))),
             }
         }
     }
@@ -21778,27 +21784,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DeviceAuthVerify>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/device/confirm", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/device/confirm", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -21846,13 +21852,19 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DeviceAccessTokenRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/device/token", client.baseurl,);
-            let request = client.client.post(url).form_urlencoded(&body)?.build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(response)),
-                _ => Err(Error::ErrorResponse(ResponseValue::stream(response))),
+            let __progenitor_url = format!("{}/device/token", client.baseurl,);
+            let __progenitor_request = client
+                .client
+                .post(__progenitor_url)
+                .form_urlencoded(&body)?
+                .build()?;
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
+                _ => Err(Error::ErrorResponse(ResponseValue::stream(
+                    __progenitor_response,
+                ))),
             }
         }
     }
@@ -21923,37 +21935,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/groups", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/groups", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -22056,27 +22068,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::SpoofLoginBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/login", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/login", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -22141,23 +22153,23 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::UsernamePasswordCredentials>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/login/{}/local",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let request = client.client.post(url).json(&body).build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(response)),
+            let __progenitor_request = client.client.post(__progenitor_url).json(&body).build()?;
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -22210,24 +22222,24 @@ pub mod builder {
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let provider_name = provider_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/login/{}/saml/{}",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let request = client.client.get(url).build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(response)),
+            let __progenitor_request = client.client.get(__progenitor_url).build()?;
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -22294,32 +22306,32 @@ pub mod builder {
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let provider_name = provider_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/login/{}/saml/{}",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::CONTENT_TYPE,
                     reqwest::header::HeaderValue::from_static("application/octet-stream"),
                 )
                 .body(body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -22340,26 +22352,26 @@ pub mod builder {
         ///Sends a `POST` request to `/logout`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/logout", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/logout", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -22430,37 +22442,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/organizations", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/organizations", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -22565,27 +22577,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/organizations", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/organizations", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -22624,30 +22636,30 @@ pub mod builder {
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -22713,31 +22725,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -22776,30 +22788,30 @@ pub mod builder {
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -22840,30 +22852,30 @@ pub mod builder {
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/policy",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -22931,31 +22943,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/policy",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -23041,41 +23053,41 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -23197,31 +23209,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -23275,31 +23287,31 @@ pub mod builder {
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -23378,32 +23390,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -23457,31 +23469,31 @@ pub mod builder {
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -23581,42 +23593,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/disks",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -23752,32 +23764,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/disks",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -23846,32 +23858,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let disk_name = disk_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/disks/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -23940,32 +23952,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let disk_name = disk_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/disks/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -24110,7 +24122,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let start_time = start_time.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/disks/{}/metrics/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -24118,39 +24130,39 @@ pub mod builder {
                 encode_path(&disk_name.to_string()),
                 encode_path(&metric_name.to_string()),
             );
-            let mut query = Vec::with_capacity(4usize);
+            let mut __progenitor_query = Vec::with_capacity(4usize);
             if let Some(v) = &end_time {
-                query.push(("end_time", v.to_string()));
+                __progenitor_query.push(("end_time", v.to_string()));
             }
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &start_time {
-                query.push(("start_time", v.to_string()));
+                __progenitor_query.push(("start_time", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -24309,42 +24321,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/images",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -24480,32 +24492,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ImageCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/images",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -24574,32 +24586,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/images/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -24668,32 +24680,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/images/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -24794,42 +24806,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -24967,32 +24979,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -25061,32 +25073,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -25155,32 +25167,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -25295,43 +25307,43 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -25483,33 +25495,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskIdentifier>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks/attach",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                202u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                202u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -25603,33 +25615,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskIdentifier>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks/detach",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                202u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                202u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -25700,32 +25712,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/external-ips",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -25819,33 +25831,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceMigrate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/migrate",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -25961,43 +25973,43 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -26153,33 +26165,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::NetworkInterfaceCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -26264,7 +26276,7 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let interface_name = interface_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -26272,25 +26284,25 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -26402,7 +26414,7 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::NetworkInterfaceUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -26410,26 +26422,26 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -26512,7 +26524,7 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let interface_name = interface_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -26520,25 +26532,25 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -26607,32 +26619,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/reboot",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                202u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                202u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -26748,43 +26760,43 @@ pub mod builder {
             let from_start = from_start.map_err(Error::InvalidRequest)?;
             let max_bytes = max_bytes.map_err(Error::InvalidRequest)?;
             let most_recent = most_recent.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/serial-console",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &from_start {
-                query.push(("from_start", v.to_string()));
+                __progenitor_query.push(("from_start", v.to_string()));
             }
             if let Some(v) = &max_bytes {
-                query.push(("max_bytes", v.to_string()));
+                __progenitor_query.push(("max_bytes", v.to_string()));
             }
             if let Some(v) = &most_recent {
-                query.push(("most_recent", v.to_string()));
+                __progenitor_query.push(("most_recent", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -26855,16 +26867,16 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/serial-console/stream",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(reqwest::header::CONNECTION, "Upgrade")
                 .header(reqwest::header::UPGRADE, "websocket")
                 .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -26876,12 +26888,12 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                101u16 => ResponseValue::upgrade(response).await,
-                200..=299 => ResponseValue::upgrade(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                101u16 => ResponseValue::upgrade(__progenitor_response).await,
+                200..=299 => ResponseValue::upgrade(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -26950,32 +26962,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/start",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                202u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                202u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -27044,32 +27056,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/stop",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                202u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                202u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -27125,31 +27137,31 @@ pub mod builder {
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/policy",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -27232,32 +27244,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/policy",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -27358,42 +27370,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/snapshots",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -27531,32 +27543,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::SnapshotCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/snapshots",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -27625,32 +27637,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let snapshot_name = snapshot_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/snapshots/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -27719,32 +27731,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let snapshot_name = snapshot_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/snapshots/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -27844,42 +27856,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -28015,32 +28027,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -28109,32 +28121,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -28228,33 +28240,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -28323,32 +28335,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -28419,32 +28431,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -28541,33 +28553,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcFirewallRuleUpdateParams>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -28682,43 +28694,43 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -28870,33 +28882,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcRouterCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -28979,7 +28991,7 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -28987,25 +28999,25 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -29113,7 +29125,7 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcRouterUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -29121,26 +29133,26 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -29223,7 +29235,7 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -29231,25 +29243,25 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -29378,7 +29390,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -29386,36 +29398,36 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -29583,7 +29595,7 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::RouterRouteCreateParams>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -29591,26 +29603,26 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -29707,7 +29719,7 @@ pub mod builder {
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
             let route_name = route_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -29716,25 +29728,25 @@ pub mod builder {
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -29858,7 +29870,7 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::RouterRouteUpdateParams>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -29867,26 +29879,26 @@ pub mod builder {
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -29983,7 +29995,7 @@ pub mod builder {
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
             let route_name = route_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -29992,25 +30004,25 @@ pub mod builder {
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -30125,43 +30137,43 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -30313,33 +30325,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcSubnetCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -30422,7 +30434,7 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -30430,25 +30442,25 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -30556,7 +30568,7 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcSubnetUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -30564,26 +30576,26 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -30666,7 +30678,7 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -30674,25 +30686,25 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -30822,7 +30834,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}/network-interfaces",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -30830,36 +30842,36 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -30940,26 +30952,26 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/policy", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/policy", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -31008,27 +31020,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::SiloRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/policy", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/policy", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -31084,34 +31096,34 @@ pub mod builder {
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/roles", client.baseurl,);
-            let mut query = Vec::with_capacity(2usize);
+            let __progenitor_url = format!("{}/roles", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -31202,30 +31214,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Role>, Error<types::Error>> {
             let Self { client, role_name } = self;
             let role_name = role_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/roles/{}",
                 client.baseurl,
                 encode_path(&role_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -31246,26 +31258,26 @@ pub mod builder {
         ///Sends a `GET` request to `/session/me`
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/session/me", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/session/me", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -31336,37 +31348,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/session/me/groups", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/session/me/groups", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -31493,37 +31505,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/session/me/sshkeys", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/session/me/sshkeys", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -31626,27 +31638,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::SshKeyCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/session/me/sshkeys", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/session/me/sshkeys", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -31685,30 +31697,30 @@ pub mod builder {
                 ssh_key_name,
             } = self;
             let ssh_key_name = ssh_key_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/session/me/sshkeys/{}",
                 client.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -31747,30 +31759,30 @@ pub mod builder {
                 ssh_key_name,
             } = self;
             let ssh_key_name = ssh_key_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/session/me/sshkeys/{}",
                 client.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -31806,30 +31818,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/by-id/images/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -31865,30 +31877,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/by-id/ip-pools/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -31924,30 +31936,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/by-id/silos/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -32018,37 +32030,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/certificates", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/system/certificates", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -32153,27 +32165,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::CertificateCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/certificates", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/system/certificates", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -32212,30 +32224,30 @@ pub mod builder {
                 certificate,
             } = self;
             let certificate = certificate.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/certificates/{}",
                 client.baseurl,
                 encode_path(&certificate.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -32274,30 +32286,30 @@ pub mod builder {
                 certificate,
             } = self;
             let certificate = certificate.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/certificates/{}",
                 client.baseurl,
                 encode_path(&certificate.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -32368,37 +32380,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/hardware/disks", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/system/hardware/disks", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -32525,37 +32537,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/hardware/racks", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/system/hardware/racks", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -32647,30 +32659,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Rack>, Error<types::Error>> {
             let Self { client, rack_id } = self;
             let rack_id = rack_id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/hardware/racks/{}",
                 client.baseurl,
                 encode_path(&rack_id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -32741,37 +32753,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/hardware/sleds", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/system/hardware/sleds", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -32863,30 +32875,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Sled>, Error<types::Error>> {
             let Self { client, sled_id } = self;
             let sled_id = sled_id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/hardware/sleds/{}",
                 client.baseurl,
                 encode_path(&sled_id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -32971,41 +32983,41 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/hardware/sleds/{}/disks",
                 client.baseurl,
                 encode_path(&sled_id.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -33132,37 +33144,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/images", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/system/images", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -33267,27 +33279,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::GlobalImageCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/images", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/system/images", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -33323,30 +33335,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
             let Self { client, image_name } = self;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/images/{}",
                 client.baseurl,
                 encode_path(&image_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -33382,30 +33394,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, image_name } = self;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/images/{}",
                 client.baseurl,
                 encode_path(&image_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -33476,37 +33488,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/ip-pools", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/system/ip-pools", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -33609,27 +33621,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::IpPoolCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/ip-pools", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/system/ip-pools", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -33665,30 +33677,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client, pool_name } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/ip-pools/{}",
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -33752,31 +33764,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::IpPoolUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/ip-pools/{}",
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -33812,30 +33824,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, pool_name } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/ip-pools/{}",
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -33905,38 +33917,38 @@ pub mod builder {
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/ip-pools/{}/ranges",
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -34044,31 +34056,31 @@ pub mod builder {
             } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/ip-pools/{}/ranges/add",
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -34122,31 +34134,31 @@ pub mod builder {
             } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/ip-pools/{}/ranges/remove",
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -34167,26 +34179,26 @@ pub mod builder {
         ///Sends a `GET` request to `/system/ip-pools-service`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/system/ip-pools-service", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/system/ip-pools-service", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -34242,34 +34254,34 @@ pub mod builder {
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/ip-pools-service/ranges", client.baseurl,);
-            let mut query = Vec::with_capacity(2usize);
+            let __progenitor_url = format!("{}/system/ip-pools-service/ranges", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -34360,27 +34372,28 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/ip-pools-service/ranges/add", client.baseurl,);
-            let request = client
+            let __progenitor_url =
+                format!("{}/system/ip-pools-service/ranges/add", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -34416,27 +34429,28 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/ip-pools-service/ranges/remove", client.baseurl,);
-            let request = client
+            let __progenitor_url =
+                format!("{}/system/ip-pools-service/ranges/remove", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -34551,45 +34565,45 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let start_time = start_time.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/metrics/{}",
                 client.baseurl,
                 encode_path(&metric_name.to_string()),
             );
-            let mut query = Vec::with_capacity(5usize);
+            let mut __progenitor_query = Vec::with_capacity(5usize);
             if let Some(v) = &end_time {
-                query.push(("end_time", v.to_string()));
+                __progenitor_query.push(("end_time", v.to_string()));
             }
-            query.push(("id", id.to_string()));
+            __progenitor_query.push(("id", id.to_string()));
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &start_time {
-                query.push(("start_time", v.to_string()));
+                __progenitor_query.push(("start_time", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -34612,26 +34626,26 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/system/policy", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/system/policy", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -34680,27 +34694,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::FleetRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/policy", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/system/policy", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -34771,37 +34785,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/sagas", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/system/sagas", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -34893,30 +34907,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Saga>, Error<types::Error>> {
             let Self { client, saga_id } = self;
             let saga_id = saga_id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/sagas/{}",
                 client.baseurl,
                 encode_path(&saga_id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -34987,37 +35001,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/silos", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/system/silos", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -35120,27 +35134,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::SiloCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/silos", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/system/silos", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -35176,30 +35190,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
             let Self { client, silo_name } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/silos/{}",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -35235,30 +35249,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, silo_name } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/silos/{}",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -35345,41 +35359,41 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/silos/{}/identity-providers",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -35501,31 +35515,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::UserCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/silos/{}/identity-providers/local/users",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -35579,31 +35593,31 @@ pub mod builder {
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let user_id = user_id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/silos/{}/identity-providers/local/users/{}",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -35672,32 +35686,32 @@ pub mod builder {
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let user_id = user_id.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/silos/{}/identity-providers/local/users/{}/set-password",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -35765,31 +35779,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::SamlIdentityProviderCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/silos/{}/identity-providers/saml",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -35845,31 +35859,31 @@ pub mod builder {
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let provider_name = provider_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/silos/{}/identity-providers/saml/{}",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -35907,30 +35921,30 @@ pub mod builder {
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
             let Self { client, silo_name } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/silos/{}/policy",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -35996,31 +36010,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::SiloRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/silos/{}/policy",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -36105,41 +36119,41 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/silos/{}/users/all",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -36249,31 +36263,31 @@ pub mod builder {
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let user_id = user_id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/silos/{}/users/id/{}",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -36344,37 +36358,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/user", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/system/user", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -36466,30 +36480,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::UserBuiltin>, Error<types::Error>> {
             let Self { client, user_name } = self;
             let user_name = user_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/user/{}",
                 client.baseurl,
                 encode_path(&user_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -36546,34 +36560,34 @@ pub mod builder {
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/timeseries/schema", client.baseurl,);
-            let mut query = Vec::with_capacity(2usize);
+            let __progenitor_url = format!("{}/timeseries/schema", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -36699,37 +36713,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/users", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/users", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -36886,43 +36900,43 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/disks", client.baseurl,);
-            let mut query = Vec::with_capacity(5usize);
+            let __progenitor_url = format!("{}/v1/disks", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(5usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -37059,33 +37073,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/disks", client.baseurl,);
-            let mut query = Vec::with_capacity(2usize);
+            let __progenitor_url = format!("{}/v1/disks", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
-            query.push(("project", project.to_string()));
-            let request = client
+            __progenitor_query.push(("project", project.to_string()));
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -37154,38 +37168,38 @@ pub mod builder {
             let disk = disk.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/disks/{}",
                 client.baseurl,
                 encode_path(&disk.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -37254,38 +37268,38 @@ pub mod builder {
             let disk = disk.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/disks/{}",
                 client.baseurl,
                 encode_path(&disk.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -37386,43 +37400,43 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/instances", client.baseurl,);
-            let mut query = Vec::with_capacity(5usize);
+            let __progenitor_url = format!("{}/v1/instances", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(5usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -37559,33 +37573,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/instances", client.baseurl,);
-            let mut query = Vec::with_capacity(2usize);
+            let __progenitor_url = format!("{}/v1/instances", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
-            query.push(("project", project.to_string()));
-            let request = client
+            __progenitor_query.push(("project", project.to_string()));
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -37654,38 +37668,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/instances/{}",
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -37754,38 +37768,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/instances/{}",
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -37900,47 +37914,47 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/instances/{}/disks",
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(5usize);
+            let mut __progenitor_query = Vec::with_capacity(5usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -38092,39 +38106,39 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskPath>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/instances/{}/disks/attach",
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                202u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                202u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -38218,39 +38232,39 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskPath>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/instances/{}/disks/detach",
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                202u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                202u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -38344,39 +38358,39 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceMigrate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/instances/{}/migrate",
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -38445,38 +38459,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/instances/{}/reboot",
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                202u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                202u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -38592,47 +38606,47 @@ pub mod builder {
             let most_recent = most_recent.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/instances/{}/serial-console",
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(5usize);
+            let mut __progenitor_query = Vec::with_capacity(5usize);
             if let Some(v) = &from_start {
-                query.push(("from_start", v.to_string()));
+                __progenitor_query.push(("from_start", v.to_string()));
             }
             if let Some(v) = &max_bytes {
-                query.push(("max_bytes", v.to_string()));
+                __progenitor_query.push(("max_bytes", v.to_string()));
             }
             if let Some(v) = &most_recent {
-                query.push(("most_recent", v.to_string()));
+                __progenitor_query.push(("most_recent", v.to_string()));
             }
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -38704,22 +38718,22 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/instances/{}/serial-console/stream",
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
-                .query(&query)
+                .get(__progenitor_url)
+                .query(&__progenitor_query)
                 .header(reqwest::header::CONNECTION, "Upgrade")
                 .header(reqwest::header::UPGRADE, "websocket")
                 .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -38731,12 +38745,12 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                101u16 => ResponseValue::upgrade(response).await,
-                200..=299 => ResponseValue::upgrade(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                101u16 => ResponseValue::upgrade(__progenitor_response).await,
+                200..=299 => ResponseValue::upgrade(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -38805,38 +38819,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/instances/{}/start",
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                202u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                202u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -38905,38 +38919,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/instances/{}/stop",
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                202u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                202u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -39007,37 +39021,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/organizations", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/v1/organizations", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -39142,27 +39156,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/organizations", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/v1/organizations", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -39201,30 +39215,30 @@ pub mod builder {
                 organization,
             } = self;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/organizations/{}",
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -39290,31 +39304,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/organizations/{}",
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -39353,30 +39367,30 @@ pub mod builder {
                 organization,
             } = self;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/organizations/{}",
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -39417,30 +39431,30 @@ pub mod builder {
                 organization,
             } = self;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/organizations/{}/policy",
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -39508,31 +39522,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/organizations/{}/policy",
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -39618,40 +39632,40 @@ pub mod builder {
             let organization = organization.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/projects", client.baseurl,);
-            let mut query = Vec::with_capacity(4usize);
+            let __progenitor_url = format!("{}/v1/projects", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(4usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -39772,30 +39786,30 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/projects", client.baseurl,);
-            let mut query = Vec::with_capacity(1usize);
-            query.push(("organization", organization.to_string()));
-            let request = client
+            let __progenitor_url = format!("{}/v1/projects", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(1usize);
+            __progenitor_query.push(("organization", organization.to_string()));
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -39849,35 +39863,35 @@ pub mod builder {
             } = self;
             let project = project.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/projects/{}",
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut query = Vec::with_capacity(1usize);
+            let mut __progenitor_query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -39956,36 +39970,36 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/projects/{}",
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut query = Vec::with_capacity(1usize);
+            let mut __progenitor_query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -40039,35 +40053,35 @@ pub mod builder {
             } = self;
             let project = project.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/projects/{}",
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut query = Vec::with_capacity(1usize);
+            let mut __progenitor_query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -40123,35 +40137,35 @@ pub mod builder {
             } = self;
             let project = project.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/projects/{}/policy",
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut query = Vec::with_capacity(1usize);
+            let mut __progenitor_query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -40234,36 +40248,36 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/projects/{}/policy",
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut query = Vec::with_capacity(1usize);
+            let mut __progenitor_query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -40335,37 +40349,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/system/update/components", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/v1/system/update/components", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -40494,37 +40508,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/system/update/deployments", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/v1/system/update/deployments", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -40618,30 +40632,30 @@ pub mod builder {
         ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/system/update/deployments/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -40662,26 +40676,26 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/system/update/refresh`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/v1/system/update/refresh", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/v1/system/update/refresh", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -40732,27 +40746,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::SystemUpdateStart>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/system/update/start", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/v1/system/update/start", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                202u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                202u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -40773,26 +40787,26 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/system/update/stop`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/v1/system/update/stop", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/v1/system/update/stop", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -40863,37 +40877,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/system/update/updates", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/v1/system/update/updates", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -40985,30 +40999,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::SystemUpdate>, Error<types::Error>> {
             let Self { client, version } = self;
             let version = version.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/system/update/updates/{}",
                 client.baseurl,
                 encode_path(&version.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -41047,30 +41061,30 @@ pub mod builder {
         ) -> Result<ResponseValue<types::ComponentUpdateResultsPage>, Error<types::Error>> {
             let Self { client, version } = self;
             let version = version.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/system/update/updates/{}/components",
                 client.baseurl,
                 encode_path(&version.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -41093,26 +41107,26 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SystemVersion>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/v1/system/update/version", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/v1/system/update/version", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/nexus-builder.out
+++ b/progenitor-impl/tests/output/nexus-builder.out
@@ -20853,30 +20853,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/by-id/disks/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -20912,30 +20912,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/by-id/images/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -20971,30 +20971,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/by-id/instances/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -21032,30 +21032,30 @@ pub mod builder {
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/by-id/network-interfaces/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -21091,30 +21091,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/by-id/organizations/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -21150,30 +21150,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/by-id/projects/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -21209,30 +21209,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/by-id/snapshots/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -21268,30 +21268,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/by-id/vpc-router-routes/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -21327,30 +21327,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/by-id/vpc-routers/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -21386,30 +21386,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/by-id/vpc-subnets/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -21445,30 +21445,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/by-id/vpcs/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -21517,13 +21517,19 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DeviceAuthRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/device/auth", client.baseurl,);
-            let request = client.client.post(url).form_urlencoded(&body)?.build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(response)),
-                _ => Err(Error::ErrorResponse(ResponseValue::stream(response))),
+            let __progenitor_url = format!("{}/device/auth", client.baseurl,);
+            let __progenitor_request = client
+                .client
+                .post(__progenitor_url)
+                .form_urlencoded(&body)?
+                .build()?;
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
+                _ => Err(Error::ErrorResponse(ResponseValue::stream(
+                    __progenitor_response,
+                ))),
             }
         }
     }
@@ -21572,27 +21578,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DeviceAuthVerify>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/device/confirm", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/device/confirm", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -21640,13 +21646,19 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DeviceAccessTokenRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/device/token", client.baseurl,);
-            let request = client.client.post(url).form_urlencoded(&body)?.build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(response)),
-                _ => Err(Error::ErrorResponse(ResponseValue::stream(response))),
+            let __progenitor_url = format!("{}/device/token", client.baseurl,);
+            let __progenitor_request = client
+                .client
+                .post(__progenitor_url)
+                .form_urlencoded(&body)?
+                .build()?;
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
+                _ => Err(Error::ErrorResponse(ResponseValue::stream(
+                    __progenitor_response,
+                ))),
             }
         }
     }
@@ -21717,37 +21729,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/groups", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/groups", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -21850,27 +21862,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::SpoofLoginBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/login", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/login", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -21935,23 +21947,23 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::UsernamePasswordCredentials>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/login/{}/local",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let request = client.client.post(url).json(&body).build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(response)),
+            let __progenitor_request = client.client.post(__progenitor_url).json(&body).build()?;
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -22004,24 +22016,24 @@ pub mod builder {
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let provider_name = provider_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/login/{}/saml/{}",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let request = client.client.get(url).build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(response)),
+            let __progenitor_request = client.client.get(__progenitor_url).build()?;
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -22088,32 +22100,32 @@ pub mod builder {
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let provider_name = provider_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/login/{}/saml/{}",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::CONTENT_TYPE,
                     reqwest::header::HeaderValue::from_static("application/octet-stream"),
                 )
                 .body(body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -22134,26 +22146,26 @@ pub mod builder {
         ///Sends a `POST` request to `/logout`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/logout", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/logout", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -22224,37 +22236,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/organizations", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/organizations", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -22359,27 +22371,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/organizations", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/organizations", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -22418,30 +22430,30 @@ pub mod builder {
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -22507,31 +22519,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -22570,30 +22582,30 @@ pub mod builder {
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -22634,30 +22646,30 @@ pub mod builder {
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/policy",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -22725,31 +22737,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/policy",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -22835,41 +22847,41 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -22991,31 +23003,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -23069,31 +23081,31 @@ pub mod builder {
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -23172,32 +23184,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -23251,31 +23263,31 @@ pub mod builder {
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -23375,42 +23387,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/disks",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -23546,32 +23558,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/disks",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -23640,32 +23652,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let disk_name = disk_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/disks/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -23734,32 +23746,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let disk_name = disk_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/disks/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -23904,7 +23916,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let start_time = start_time.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/disks/{}/metrics/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -23912,39 +23924,39 @@ pub mod builder {
                 encode_path(&disk_name.to_string()),
                 encode_path(&metric_name.to_string()),
             );
-            let mut query = Vec::with_capacity(4usize);
+            let mut __progenitor_query = Vec::with_capacity(4usize);
             if let Some(v) = &end_time {
-                query.push(("end_time", v.to_string()));
+                __progenitor_query.push(("end_time", v.to_string()));
             }
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &start_time {
-                query.push(("start_time", v.to_string()));
+                __progenitor_query.push(("start_time", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -24103,42 +24115,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/images",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -24274,32 +24286,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ImageCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/images",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -24368,32 +24380,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/images/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -24462,32 +24474,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/images/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -24588,42 +24600,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -24761,32 +24773,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -24855,32 +24867,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -24949,32 +24961,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -25089,43 +25101,43 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -25277,33 +25289,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskIdentifier>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks/attach",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                202u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                202u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -25397,33 +25409,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskIdentifier>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks/detach",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                202u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                202u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -25494,32 +25506,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/external-ips",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -25613,33 +25625,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceMigrate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/migrate",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -25755,43 +25767,43 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -25947,33 +25959,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::NetworkInterfaceCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -26058,7 +26070,7 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let interface_name = interface_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -26066,25 +26078,25 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -26196,7 +26208,7 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::NetworkInterfaceUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -26204,26 +26216,26 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -26306,7 +26318,7 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let interface_name = interface_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -26314,25 +26326,25 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -26401,32 +26413,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/reboot",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                202u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                202u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -26542,43 +26554,43 @@ pub mod builder {
             let from_start = from_start.map_err(Error::InvalidRequest)?;
             let max_bytes = max_bytes.map_err(Error::InvalidRequest)?;
             let most_recent = most_recent.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/serial-console",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &from_start {
-                query.push(("from_start", v.to_string()));
+                __progenitor_query.push(("from_start", v.to_string()));
             }
             if let Some(v) = &max_bytes {
-                query.push(("max_bytes", v.to_string()));
+                __progenitor_query.push(("max_bytes", v.to_string()));
             }
             if let Some(v) = &most_recent {
-                query.push(("most_recent", v.to_string()));
+                __progenitor_query.push(("most_recent", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -26649,16 +26661,16 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/serial-console/stream",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(reqwest::header::CONNECTION, "Upgrade")
                 .header(reqwest::header::UPGRADE, "websocket")
                 .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -26670,12 +26682,12 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                101u16 => ResponseValue::upgrade(response).await,
-                200..=299 => ResponseValue::upgrade(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                101u16 => ResponseValue::upgrade(__progenitor_response).await,
+                200..=299 => ResponseValue::upgrade(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -26744,32 +26756,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/start",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                202u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                202u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -26838,32 +26850,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/stop",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                202u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                202u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -26919,31 +26931,31 @@ pub mod builder {
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/policy",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -27026,32 +27038,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/policy",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -27152,42 +27164,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/snapshots",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -27325,32 +27337,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::SnapshotCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/snapshots",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -27419,32 +27431,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let snapshot_name = snapshot_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/snapshots/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -27513,32 +27525,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let snapshot_name = snapshot_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/snapshots/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -27638,42 +27650,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -27809,32 +27821,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -27903,32 +27915,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -28022,33 +28034,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -28117,32 +28129,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -28213,32 +28225,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -28335,33 +28347,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcFirewallRuleUpdateParams>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -28476,43 +28488,43 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -28664,33 +28676,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcRouterCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -28773,7 +28785,7 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -28781,25 +28793,25 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -28907,7 +28919,7 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcRouterUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -28915,26 +28927,26 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -29017,7 +29029,7 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -29025,25 +29037,25 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -29172,7 +29184,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -29180,36 +29192,36 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -29377,7 +29389,7 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::RouterRouteCreateParams>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -29385,26 +29397,26 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -29501,7 +29513,7 @@ pub mod builder {
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
             let route_name = route_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -29510,25 +29522,25 @@ pub mod builder {
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -29652,7 +29664,7 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::RouterRouteUpdateParams>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -29661,26 +29673,26 @@ pub mod builder {
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -29777,7 +29789,7 @@ pub mod builder {
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
             let route_name = route_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -29786,25 +29798,25 @@ pub mod builder {
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -29919,43 +29931,43 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -30107,33 +30119,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcSubnetCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -30216,7 +30228,7 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -30224,25 +30236,25 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -30350,7 +30362,7 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcSubnetUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -30358,26 +30370,26 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -30460,7 +30472,7 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -30468,25 +30480,25 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -30616,7 +30628,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}/network-interfaces",
                 client.baseurl,
                 encode_path(&organization_name.to_string()),
@@ -30624,36 +30636,36 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -30734,26 +30746,26 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/policy", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/policy", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -30802,27 +30814,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::SiloRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/policy", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/policy", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -30878,34 +30890,34 @@ pub mod builder {
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/roles", client.baseurl,);
-            let mut query = Vec::with_capacity(2usize);
+            let __progenitor_url = format!("{}/roles", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -30996,30 +31008,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Role>, Error<types::Error>> {
             let Self { client, role_name } = self;
             let role_name = role_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/roles/{}",
                 client.baseurl,
                 encode_path(&role_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -31040,26 +31052,26 @@ pub mod builder {
         ///Sends a `GET` request to `/session/me`
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/session/me", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/session/me", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -31130,37 +31142,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/session/me/groups", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/session/me/groups", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -31287,37 +31299,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/session/me/sshkeys", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/session/me/sshkeys", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -31420,27 +31432,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::SshKeyCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/session/me/sshkeys", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/session/me/sshkeys", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -31479,30 +31491,30 @@ pub mod builder {
                 ssh_key_name,
             } = self;
             let ssh_key_name = ssh_key_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/session/me/sshkeys/{}",
                 client.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -31541,30 +31553,30 @@ pub mod builder {
                 ssh_key_name,
             } = self;
             let ssh_key_name = ssh_key_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/session/me/sshkeys/{}",
                 client.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -31600,30 +31612,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/by-id/images/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -31659,30 +31671,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/by-id/ip-pools/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -31718,30 +31730,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/by-id/silos/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -31812,37 +31824,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/certificates", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/system/certificates", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -31947,27 +31959,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::CertificateCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/certificates", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/system/certificates", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -32006,30 +32018,30 @@ pub mod builder {
                 certificate,
             } = self;
             let certificate = certificate.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/certificates/{}",
                 client.baseurl,
                 encode_path(&certificate.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -32068,30 +32080,30 @@ pub mod builder {
                 certificate,
             } = self;
             let certificate = certificate.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/certificates/{}",
                 client.baseurl,
                 encode_path(&certificate.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -32162,37 +32174,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/hardware/disks", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/system/hardware/disks", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -32319,37 +32331,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/hardware/racks", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/system/hardware/racks", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -32441,30 +32453,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Rack>, Error<types::Error>> {
             let Self { client, rack_id } = self;
             let rack_id = rack_id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/hardware/racks/{}",
                 client.baseurl,
                 encode_path(&rack_id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -32535,37 +32547,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/hardware/sleds", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/system/hardware/sleds", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -32657,30 +32669,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Sled>, Error<types::Error>> {
             let Self { client, sled_id } = self;
             let sled_id = sled_id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/hardware/sleds/{}",
                 client.baseurl,
                 encode_path(&sled_id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -32765,41 +32777,41 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/hardware/sleds/{}/disks",
                 client.baseurl,
                 encode_path(&sled_id.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -32926,37 +32938,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/images", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/system/images", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -33061,27 +33073,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::GlobalImageCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/images", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/system/images", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -33117,30 +33129,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
             let Self { client, image_name } = self;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/images/{}",
                 client.baseurl,
                 encode_path(&image_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -33176,30 +33188,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, image_name } = self;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/images/{}",
                 client.baseurl,
                 encode_path(&image_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -33270,37 +33282,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/ip-pools", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/system/ip-pools", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -33403,27 +33415,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::IpPoolCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/ip-pools", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/system/ip-pools", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -33459,30 +33471,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client, pool_name } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/ip-pools/{}",
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -33546,31 +33558,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::IpPoolUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/ip-pools/{}",
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -33606,30 +33618,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, pool_name } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/ip-pools/{}",
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -33699,38 +33711,38 @@ pub mod builder {
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/ip-pools/{}/ranges",
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -33838,31 +33850,31 @@ pub mod builder {
             } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/ip-pools/{}/ranges/add",
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -33916,31 +33928,31 @@ pub mod builder {
             } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/ip-pools/{}/ranges/remove",
                 client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -33961,26 +33973,26 @@ pub mod builder {
         ///Sends a `GET` request to `/system/ip-pools-service`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/system/ip-pools-service", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/system/ip-pools-service", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -34036,34 +34048,34 @@ pub mod builder {
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/ip-pools-service/ranges", client.baseurl,);
-            let mut query = Vec::with_capacity(2usize);
+            let __progenitor_url = format!("{}/system/ip-pools-service/ranges", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -34154,27 +34166,28 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/ip-pools-service/ranges/add", client.baseurl,);
-            let request = client
+            let __progenitor_url =
+                format!("{}/system/ip-pools-service/ranges/add", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -34210,27 +34223,28 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/ip-pools-service/ranges/remove", client.baseurl,);
-            let request = client
+            let __progenitor_url =
+                format!("{}/system/ip-pools-service/ranges/remove", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -34345,45 +34359,45 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let start_time = start_time.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/metrics/{}",
                 client.baseurl,
                 encode_path(&metric_name.to_string()),
             );
-            let mut query = Vec::with_capacity(5usize);
+            let mut __progenitor_query = Vec::with_capacity(5usize);
             if let Some(v) = &end_time {
-                query.push(("end_time", v.to_string()));
+                __progenitor_query.push(("end_time", v.to_string()));
             }
-            query.push(("id", id.to_string()));
+            __progenitor_query.push(("id", id.to_string()));
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &start_time {
-                query.push(("start_time", v.to_string()));
+                __progenitor_query.push(("start_time", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -34406,26 +34420,26 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/system/policy", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/system/policy", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -34474,27 +34488,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::FleetRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/policy", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/system/policy", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -34565,37 +34579,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/sagas", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/system/sagas", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -34687,30 +34701,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Saga>, Error<types::Error>> {
             let Self { client, saga_id } = self;
             let saga_id = saga_id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/sagas/{}",
                 client.baseurl,
                 encode_path(&saga_id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -34781,37 +34795,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/silos", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/system/silos", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -34914,27 +34928,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::SiloCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/silos", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/system/silos", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -34970,30 +34984,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
             let Self { client, silo_name } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/silos/{}",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -35029,30 +35043,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, silo_name } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/silos/{}",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -35139,41 +35153,41 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/silos/{}/identity-providers",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -35295,31 +35309,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::UserCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/silos/{}/identity-providers/local/users",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -35373,31 +35387,31 @@ pub mod builder {
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let user_id = user_id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/silos/{}/identity-providers/local/users/{}",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -35466,32 +35480,32 @@ pub mod builder {
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let user_id = user_id.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/silos/{}/identity-providers/local/users/{}/set-password",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -35559,31 +35573,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::SamlIdentityProviderCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/silos/{}/identity-providers/saml",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -35639,31 +35653,31 @@ pub mod builder {
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let provider_name = provider_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/silos/{}/identity-providers/saml/{}",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -35701,30 +35715,30 @@ pub mod builder {
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
             let Self { client, silo_name } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/silos/{}/policy",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -35790,31 +35804,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::SiloRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/silos/{}/policy",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -35899,41 +35913,41 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/silos/{}/users/all",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut query = Vec::with_capacity(3usize);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -36043,31 +36057,31 @@ pub mod builder {
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let user_id = user_id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/silos/{}/users/id/{}",
                 client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -36138,37 +36152,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/system/user", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/system/user", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -36260,30 +36274,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::UserBuiltin>, Error<types::Error>> {
             let Self { client, user_name } = self;
             let user_name = user_name.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/system/user/{}",
                 client.baseurl,
                 encode_path(&user_name.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -36340,34 +36354,34 @@ pub mod builder {
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/timeseries/schema", client.baseurl,);
-            let mut query = Vec::with_capacity(2usize);
+            let __progenitor_url = format!("{}/timeseries/schema", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -36493,37 +36507,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/users", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/users", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -36680,43 +36694,43 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/disks", client.baseurl,);
-            let mut query = Vec::with_capacity(5usize);
+            let __progenitor_url = format!("{}/v1/disks", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(5usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -36853,33 +36867,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/disks", client.baseurl,);
-            let mut query = Vec::with_capacity(2usize);
+            let __progenitor_url = format!("{}/v1/disks", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
-            query.push(("project", project.to_string()));
-            let request = client
+            __progenitor_query.push(("project", project.to_string()));
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -36948,38 +36962,38 @@ pub mod builder {
             let disk = disk.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/disks/{}",
                 client.baseurl,
                 encode_path(&disk.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -37048,38 +37062,38 @@ pub mod builder {
             let disk = disk.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/disks/{}",
                 client.baseurl,
                 encode_path(&disk.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -37180,43 +37194,43 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/instances", client.baseurl,);
-            let mut query = Vec::with_capacity(5usize);
+            let __progenitor_url = format!("{}/v1/instances", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(5usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -37353,33 +37367,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/instances", client.baseurl,);
-            let mut query = Vec::with_capacity(2usize);
+            let __progenitor_url = format!("{}/v1/instances", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
-            query.push(("project", project.to_string()));
-            let request = client
+            __progenitor_query.push(("project", project.to_string()));
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -37448,38 +37462,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/instances/{}",
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -37548,38 +37562,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/instances/{}",
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -37694,47 +37708,47 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/instances/{}/disks",
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(5usize);
+            let mut __progenitor_query = Vec::with_capacity(5usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -37886,39 +37900,39 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskPath>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/instances/{}/disks/attach",
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                202u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                202u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -38012,39 +38026,39 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskPath>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/instances/{}/disks/detach",
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                202u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                202u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -38138,39 +38152,39 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceMigrate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/instances/{}/migrate",
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -38239,38 +38253,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/instances/{}/reboot",
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                202u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                202u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -38386,47 +38400,47 @@ pub mod builder {
             let most_recent = most_recent.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/instances/{}/serial-console",
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(5usize);
+            let mut __progenitor_query = Vec::with_capacity(5usize);
             if let Some(v) = &from_start {
-                query.push(("from_start", v.to_string()));
+                __progenitor_query.push(("from_start", v.to_string()));
             }
             if let Some(v) = &max_bytes {
-                query.push(("max_bytes", v.to_string()));
+                __progenitor_query.push(("max_bytes", v.to_string()));
             }
             if let Some(v) = &most_recent {
-                query.push(("most_recent", v.to_string()));
+                __progenitor_query.push(("most_recent", v.to_string()));
             }
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -38498,22 +38512,22 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/instances/{}/serial-console/stream",
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
-                .query(&query)
+                .get(__progenitor_url)
+                .query(&__progenitor_query)
                 .header(reqwest::header::CONNECTION, "Upgrade")
                 .header(reqwest::header::UPGRADE, "websocket")
                 .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -38525,12 +38539,12 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                101u16 => ResponseValue::upgrade(response).await,
-                200..=299 => ResponseValue::upgrade(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                101u16 => ResponseValue::upgrade(__progenitor_response).await,
+                200..=299 => ResponseValue::upgrade(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -38599,38 +38613,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/instances/{}/start",
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                202u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                202u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -38699,38 +38713,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/instances/{}/stop",
                 client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut query = Vec::with_capacity(2usize);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+                __progenitor_query.push(("project", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                202u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                202u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -38801,37 +38815,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/organizations", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/v1/organizations", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -38936,27 +38950,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/organizations", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/v1/organizations", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -38995,30 +39009,30 @@ pub mod builder {
                 organization,
             } = self;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/organizations/{}",
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -39084,31 +39098,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/organizations/{}",
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -39147,30 +39161,30 @@ pub mod builder {
                 organization,
             } = self;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/organizations/{}",
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -39211,30 +39225,30 @@ pub mod builder {
                 organization,
             } = self;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/organizations/{}/policy",
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -39302,31 +39316,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/organizations/{}/policy",
                 client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -39412,40 +39426,40 @@ pub mod builder {
             let organization = organization.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/projects", client.baseurl,);
-            let mut query = Vec::with_capacity(4usize);
+            let __progenitor_url = format!("{}/v1/projects", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(4usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -39566,30 +39580,30 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/projects", client.baseurl,);
-            let mut query = Vec::with_capacity(1usize);
-            query.push(("organization", organization.to_string()));
-            let request = client
+            let __progenitor_url = format!("{}/v1/projects", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(1usize);
+            __progenitor_query.push(("organization", organization.to_string()));
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -39643,35 +39657,35 @@ pub mod builder {
             } = self;
             let project = project.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/projects/{}",
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut query = Vec::with_capacity(1usize);
+            let mut __progenitor_query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -39750,36 +39764,36 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/projects/{}",
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut query = Vec::with_capacity(1usize);
+            let mut __progenitor_query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -39833,35 +39847,35 @@ pub mod builder {
             } = self;
             let project = project.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/projects/{}",
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut query = Vec::with_capacity(1usize);
+            let mut __progenitor_query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .delete(url)
+                .delete(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -39917,35 +39931,35 @@ pub mod builder {
             } = self;
             let project = project.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/projects/{}/policy",
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut query = Vec::with_capacity(1usize);
+            let mut __progenitor_query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -40028,36 +40042,36 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/projects/{}/policy",
                 client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut query = Vec::with_capacity(1usize);
+            let mut __progenitor_query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+                __progenitor_query.push(("organization", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -40129,37 +40143,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/system/update/components", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/v1/system/update/components", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -40288,37 +40302,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/system/update/deployments", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/v1/system/update/deployments", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -40412,30 +40426,30 @@ pub mod builder {
         ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
             let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/system/update/deployments/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -40456,26 +40470,26 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/system/update/refresh`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/v1/system/update/refresh", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/v1/system/update/refresh", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -40526,27 +40540,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::SystemUpdateStart>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/system/update/start", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/v1/system/update/start", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                202u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                202u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -40567,26 +40581,26 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/system/update/stop`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/v1/system/update/stop", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/v1/system/update/stop", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -40657,37 +40671,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/v1/system/update/updates", client.baseurl,);
-            let mut query = Vec::with_capacity(3usize);
+            let __progenitor_url = format!("{}/v1/system/update/updates", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+                __progenitor_query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+                __progenitor_query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+                __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&query)
+                .query(&__progenitor_query)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
 
@@ -40779,30 +40793,30 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<types::SystemUpdate>, Error<types::Error>> {
             let Self { client, version } = self;
             let version = version.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/system/update/updates/{}",
                 client.baseurl,
                 encode_path(&version.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -40841,30 +40855,30 @@ pub mod builder {
         ) -> Result<ResponseValue<types::ComponentUpdateResultsPage>, Error<types::Error>> {
             let Self { client, version } = self;
             let version = version.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/v1/system/update/updates/{}/components",
                 client.baseurl,
                 encode_path(&version.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -40887,26 +40901,26 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SystemVersion>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/v1/system/update/version", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/v1/system/update/version", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/nexus-positional.out
+++ b/progenitor-impl/tests/output/nexus-positional.out
@@ -5957,30 +5957,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/by-id/disks/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -5991,30 +5991,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/by-id/images/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -6025,30 +6025,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/by-id/instances/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -6059,30 +6059,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/by-id/network-interfaces/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -6095,30 +6095,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/by-id/organizations/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -6131,30 +6131,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/by-id/projects/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -6165,30 +6165,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/by-id/snapshots/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -6199,30 +6199,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/by-id/vpc-router-routes/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -6233,30 +6233,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/by-id/vpc-routers/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -6267,30 +6267,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/by-id/vpc-subnets/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -6301,30 +6301,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/by-id/vpcs/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -6339,13 +6339,19 @@ impl Client {
         &'a self,
         body: &'a types::DeviceAuthRequest,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-        let url = format!("{}/device/auth", self.baseurl,);
-        let request = self.client.post(url).form_urlencoded(&body)?.build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200..=299 => Ok(ResponseValue::stream(response)),
-            _ => Err(Error::ErrorResponse(ResponseValue::stream(response))),
+        let __progenitor_url = format!("{}/device/auth", self.baseurl,);
+        let __progenitor_request = self
+            .client
+            .post(__progenitor_url)
+            .form_urlencoded(&body)?
+            .build()?;
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
+            _ => Err(Error::ErrorResponse(ResponseValue::stream(
+                __progenitor_response,
+            ))),
         }
     }
 
@@ -6361,27 +6367,27 @@ impl Client {
         &'a self,
         body: &'a types::DeviceAuthVerify,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!("{}/device/confirm", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/device/confirm", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -6395,13 +6401,19 @@ impl Client {
         &'a self,
         body: &'a types::DeviceAccessTokenRequest,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-        let url = format!("{}/device/token", self.baseurl,);
-        let request = self.client.post(url).form_urlencoded(&body)?.build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200..=299 => Ok(ResponseValue::stream(response)),
-            _ => Err(Error::ErrorResponse(ResponseValue::stream(response))),
+        let __progenitor_url = format!("{}/device/token", self.baseurl,);
+        let __progenitor_request = self
+            .client
+            .post(__progenitor_url)
+            .form_urlencoded(&body)?
+            .build()?;
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
+            _ => Err(Error::ErrorResponse(ResponseValue::stream(
+                __progenitor_response,
+            ))),
         }
     }
 
@@ -6420,40 +6432,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
-        let url = format!("{}/groups", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
+        let __progenitor_url = format!("{}/groups", self.baseurl,);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -6507,27 +6519,27 @@ impl Client {
         &'a self,
         body: &'a types::SpoofLoginBody,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!("{}/login", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/login", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -6539,23 +6551,23 @@ impl Client {
         silo_name: &'a types::Name,
         body: &'a types::UsernamePasswordCredentials,
     ) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/login/{}/local",
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let request = self.client.post(url).json(&body).build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200..=299 => Ok(ResponseValue::stream(response)),
+        let __progenitor_request = self.client.post(__progenitor_url).json(&body).build()?;
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -6570,24 +6582,24 @@ impl Client {
         silo_name: &'a types::Name,
         provider_name: &'a types::Name,
     ) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/login/{}/saml/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
             encode_path(&provider_name.to_string()),
         );
-        let request = self.client.get(url).build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200..=299 => Ok(ResponseValue::stream(response)),
+        let __progenitor_request = self.client.get(__progenitor_url).build()?;
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -6600,57 +6612,57 @@ impl Client {
         provider_name: &'a types::Name,
         body: B,
     ) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/login/{}/saml/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
             encode_path(&provider_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::CONTENT_TYPE,
                 reqwest::header::HeaderValue::from_static("application/octet-stream"),
             )
             .body(body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200..=299 => Ok(ResponseValue::stream(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
     ///Sends a `POST` request to `/logout`
     pub async fn logout<'a>(&'a self) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!("{}/logout", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/logout", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -6671,40 +6683,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
-        let url = format!("{}/organizations", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
+        let __progenitor_url = format!("{}/organizations", self.baseurl,);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -6765,27 +6777,27 @@ impl Client {
         &'a self,
         body: &'a types::OrganizationCreate,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let url = format!("{}/organizations", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/organizations", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -6801,30 +6813,30 @@ impl Client {
         &'a self,
         organization_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -6842,31 +6854,31 @@ impl Client {
         organization_name: &'a types::Name,
         body: &'a types::OrganizationUpdate,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .put(url)
+            .put(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -6882,30 +6894,30 @@ impl Client {
         &'a self,
         organization_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .delete(url)
+            .delete(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -6921,30 +6933,30 @@ impl Client {
         &'a self,
         organization_name: &'a types::Name,
     ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/policy",
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -6962,31 +6974,31 @@ impl Client {
         organization_name: &'a types::Name,
         body: &'a types::OrganizationRolePolicy,
     ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/policy",
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .put(url)
+            .put(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -7009,44 +7021,44 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects",
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -7114,31 +7126,31 @@ impl Client {
         organization_name: &'a types::Name,
         body: &'a types::ProjectCreate,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects",
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -7157,31 +7169,31 @@ impl Client {
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -7202,32 +7214,32 @@ impl Client {
         project_name: &'a types::Name,
         body: &'a types::ProjectUpdate,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .put(url)
+            .put(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -7246,31 +7258,31 @@ impl Client {
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .delete(url)
+            .delete(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -7296,45 +7308,45 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/disks",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -7411,32 +7423,32 @@ impl Client {
         project_name: &'a types::Name,
         body: &'a types::DiskCreate,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/disks",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -7453,32 +7465,32 @@ impl Client {
         project_name: &'a types::Name,
         disk_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/disks/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&disk_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -7493,32 +7505,32 @@ impl Client {
         project_name: &'a types::Name,
         disk_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/disks/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&disk_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .delete(url)
+            .delete(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -7549,7 +7561,7 @@ impl Client {
         page_token: Option<&'a str>,
         start_time: Option<&'a chrono::DateTime<chrono::offset::Utc>>,
     ) -> Result<ResponseValue<types::MeasurementResultsPage>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/disks/{}/metrics/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -7557,43 +7569,43 @@ impl Client {
             encode_path(&disk_name.to_string()),
             encode_path(&metric_name.to_string()),
         );
-        let mut query = Vec::with_capacity(4usize);
+        let mut __progenitor_query = Vec::with_capacity(4usize);
         if let Some(v) = &end_time {
-            query.push(("end_time", v.to_string()));
+            __progenitor_query.push(("end_time", v.to_string()));
         }
 
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &start_time {
-            query.push(("start_time", v.to_string()));
+            __progenitor_query.push(("start_time", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -7695,45 +7707,45 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::ImageResultsPage>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/images",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -7813,32 +7825,32 @@ impl Client {
         project_name: &'a types::Name,
         body: &'a types::ImageCreate,
     ) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/images",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -7855,32 +7867,32 @@ impl Client {
         project_name: &'a types::Name,
         image_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/images/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&image_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -7899,32 +7911,32 @@ impl Client {
         project_name: &'a types::Name,
         image_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/images/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&image_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .delete(url)
+            .delete(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -7948,45 +7960,45 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/instances",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -8064,32 +8076,32 @@ impl Client {
         project_name: &'a types::Name,
         body: &'a types::InstanceCreate,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/instances",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -8106,32 +8118,32 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/instances/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -8146,32 +8158,32 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/instances/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .delete(url)
+            .delete(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -8200,46 +8212,46 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/disks",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -8325,33 +8337,33 @@ impl Client {
         instance_name: &'a types::Name,
         body: &'a types::DiskIdentifier,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/disks/attach",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            202u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            202u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -8369,33 +8381,33 @@ impl Client {
         instance_name: &'a types::Name,
         body: &'a types::DiskIdentifier,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/disks/detach",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            202u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            202u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -8410,32 +8422,32 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
     ) -> Result<ResponseValue<types::ExternalIpResultsPage>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/external-ips",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -8453,33 +8465,33 @@ impl Client {
         instance_name: &'a types::Name,
         body: &'a types::InstanceMigrate,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/migrate",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -8506,46 +8518,46 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::NetworkInterfaceResultsPage>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -8628,33 +8640,33 @@ impl Client {
         instance_name: &'a types::Name,
         body: &'a types::NetworkInterfaceCreate,
     ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -8670,7 +8682,7 @@ impl Client {
         instance_name: &'a types::Name,
         interface_name: &'a types::Name,
     ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -8678,25 +8690,25 @@ impl Client {
             encode_path(&instance_name.to_string()),
             encode_path(&interface_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -8713,7 +8725,7 @@ impl Client {
         interface_name: &'a types::Name,
         body: &'a types::NetworkInterfaceUpdate,
     ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -8721,26 +8733,26 @@ impl Client {
             encode_path(&instance_name.to_string()),
             encode_path(&interface_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .put(url)
+            .put(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -8761,7 +8773,7 @@ impl Client {
         instance_name: &'a types::Name,
         interface_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -8769,25 +8781,25 @@ impl Client {
             encode_path(&instance_name.to_string()),
             encode_path(&interface_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .delete(url)
+            .delete(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -8804,32 +8816,32 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/reboot",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            202u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            202u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -8865,46 +8877,46 @@ impl Client {
         max_bytes: Option<u64>,
         most_recent: Option<u64>,
     ) -> Result<ResponseValue<types::InstanceSerialConsoleData>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/serial-console",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &from_start {
-            query.push(("from_start", v.to_string()));
+            __progenitor_query.push(("from_start", v.to_string()));
         }
 
         if let Some(v) = &max_bytes {
-            query.push(("max_bytes", v.to_string()));
+            __progenitor_query.push(("max_bytes", v.to_string()));
         }
 
         if let Some(v) = &most_recent {
-            query.push(("most_recent", v.to_string()));
+            __progenitor_query.push(("most_recent", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -8921,16 +8933,16 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
     ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/serial-console/stream",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(reqwest::header::CONNECTION, "Upgrade")
             .header(reqwest::header::UPGRADE, "websocket")
             .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -8942,12 +8954,12 @@ impl Client {
                 ),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            101u16 => ResponseValue::upgrade(response).await,
-            200..=299 => ResponseValue::upgrade(response).await,
-            _ => Err(Error::UnexpectedResponse(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            101u16 => ResponseValue::upgrade(__progenitor_response).await,
+            200..=299 => ResponseValue::upgrade(__progenitor_response).await,
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -8964,32 +8976,32 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/start",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            202u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            202u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -9006,32 +9018,32 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/stop",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            202u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            202u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -9050,31 +9062,31 @@ impl Client {
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
     ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/policy",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -9093,32 +9105,32 @@ impl Client {
         project_name: &'a types::Name,
         body: &'a types::ProjectRolePolicy,
     ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/policy",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .put(url)
+            .put(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -9142,45 +9154,45 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::SnapshotResultsPage>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/snapshots",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -9258,32 +9270,32 @@ impl Client {
         project_name: &'a types::Name,
         body: &'a types::SnapshotCreate,
     ) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/snapshots",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -9298,32 +9310,32 @@ impl Client {
         project_name: &'a types::Name,
         snapshot_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/snapshots/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&snapshot_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -9338,32 +9350,32 @@ impl Client {
         project_name: &'a types::Name,
         snapshot_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/snapshots/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&snapshot_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .delete(url)
+            .delete(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -9387,45 +9399,45 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::VpcResultsPage>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/vpcs",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -9500,32 +9512,32 @@ impl Client {
         project_name: &'a types::Name,
         body: &'a types::VpcCreate,
     ) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/vpcs",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -9540,32 +9552,32 @@ impl Client {
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -9581,33 +9593,33 @@ impl Client {
         vpc_name: &'a types::Name,
         body: &'a types::VpcUpdate,
     ) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .put(url)
+            .put(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -9622,32 +9634,32 @@ impl Client {
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .delete(url)
+            .delete(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -9662,32 +9674,32 @@ impl Client {
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
     ) -> Result<ResponseValue<types::VpcFirewallRules>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -9703,33 +9715,33 @@ impl Client {
         vpc_name: &'a types::Name,
         body: &'a types::VpcFirewallRuleUpdateParams,
     ) -> Result<ResponseValue<types::VpcFirewallRules>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .put(url)
+            .put(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -9756,46 +9768,46 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::VpcRouterResultsPage>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -9878,33 +9890,33 @@ impl Client {
         vpc_name: &'a types::Name,
         body: &'a types::VpcRouterCreate,
     ) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -9920,7 +9932,7 @@ impl Client {
         vpc_name: &'a types::Name,
         router_name: &'a types::Name,
     ) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -9928,25 +9940,25 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -9963,7 +9975,7 @@ impl Client {
         router_name: &'a types::Name,
         body: &'a types::VpcRouterUpdate,
     ) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -9971,26 +9983,26 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .put(url)
+            .put(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -10006,7 +10018,7 @@ impl Client {
         vpc_name: &'a types::Name,
         router_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10014,25 +10026,25 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .delete(url)
+            .delete(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -10063,7 +10075,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::RouterRouteResultsPage>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10071,39 +10083,39 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -10194,7 +10206,7 @@ impl Client {
         router_name: &'a types::Name,
         body: &'a types::RouterRouteCreateParams,
     ) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10202,26 +10214,26 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -10238,7 +10250,7 @@ impl Client {
         router_name: &'a types::Name,
         route_name: &'a types::Name,
     ) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10247,25 +10259,25 @@ impl Client {
             encode_path(&router_name.to_string()),
             encode_path(&route_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -10283,7 +10295,7 @@ impl Client {
         route_name: &'a types::Name,
         body: &'a types::RouterRouteUpdateParams,
     ) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10292,26 +10304,26 @@ impl Client {
             encode_path(&router_name.to_string()),
             encode_path(&route_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .put(url)
+            .put(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -10328,7 +10340,7 @@ impl Client {
         router_name: &'a types::Name,
         route_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10337,25 +10349,25 @@ impl Client {
             encode_path(&router_name.to_string()),
             encode_path(&route_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .delete(url)
+            .delete(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -10382,46 +10394,46 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::VpcSubnetResultsPage>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -10504,33 +10516,33 @@ impl Client {
         vpc_name: &'a types::Name,
         body: &'a types::VpcSubnetCreate,
     ) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -10546,7 +10558,7 @@ impl Client {
         vpc_name: &'a types::Name,
         subnet_name: &'a types::Name,
     ) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10554,25 +10566,25 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&subnet_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -10589,7 +10601,7 @@ impl Client {
         subnet_name: &'a types::Name,
         body: &'a types::VpcSubnetUpdate,
     ) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10597,26 +10609,26 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&subnet_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .put(url)
+            .put(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -10632,7 +10644,7 @@ impl Client {
         vpc_name: &'a types::Name,
         subnet_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10640,25 +10652,25 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&subnet_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .delete(url)
+            .delete(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -10687,7 +10699,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::NetworkInterfaceResultsPage>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}/network-interfaces",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10695,39 +10707,39 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&subnet_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -10809,26 +10821,26 @@ impl Client {
     pub async fn policy_view<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-        let url = format!("{}/policy", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/policy", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -10839,27 +10851,27 @@ impl Client {
         &'a self,
         body: &'a types::SiloRolePolicy,
     ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-        let url = format!("{}/policy", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/policy", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .put(url)
+            .put(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -10876,36 +10888,36 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::RoleResultsPage>, Error<types::Error>> {
-        let url = format!("{}/roles", self.baseurl,);
-        let mut query = Vec::with_capacity(2usize);
+        let __progenitor_url = format!("{}/roles", self.baseurl,);
+        let mut __progenitor_query = Vec::with_capacity(2usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -10962,30 +10974,30 @@ impl Client {
         &'a self,
         role_name: &'a str,
     ) -> Result<ResponseValue<types::Role>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/roles/{}",
             self.baseurl,
             encode_path(&role_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -10995,26 +11007,26 @@ impl Client {
     pub async fn session_me<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::User>, Error<types::Error>> {
-        let url = format!("{}/session/me", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/session/me", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -11033,40 +11045,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
-        let url = format!("{}/session/me/groups", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
+        let __progenitor_url = format!("{}/session/me/groups", self.baseurl,);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -11132,40 +11144,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::SshKeyResultsPage>, Error<types::Error>> {
-        let url = format!("{}/session/me/sshkeys", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
+        let __progenitor_url = format!("{}/session/me/sshkeys", self.baseurl,);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -11225,27 +11237,27 @@ impl Client {
         &'a self,
         body: &'a types::SshKeyCreate,
     ) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
-        let url = format!("{}/session/me/sshkeys", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/session/me/sshkeys", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -11259,30 +11271,30 @@ impl Client {
         &'a self,
         ssh_key_name: &'a types::Name,
     ) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/session/me/sshkeys/{}",
             self.baseurl,
             encode_path(&ssh_key_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -11296,30 +11308,30 @@ impl Client {
         &'a self,
         ssh_key_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/session/me/sshkeys/{}",
             self.baseurl,
             encode_path(&ssh_key_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .delete(url)
+            .delete(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -11330,30 +11342,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/by-id/images/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -11364,30 +11376,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/by-id/ip-pools/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -11398,30 +11410,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/by-id/silos/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -11444,40 +11456,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::CertificateResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/certificates", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
+        let __progenitor_url = format!("{}/system/certificates", self.baseurl,);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -11541,27 +11553,27 @@ impl Client {
         &'a self,
         body: &'a types::CertificateCreate,
     ) -> Result<ResponseValue<types::Certificate>, Error<types::Error>> {
-        let url = format!("{}/system/certificates", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/system/certificates", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -11574,30 +11586,30 @@ impl Client {
         &'a self,
         certificate: &'a types::NameOrId,
     ) -> Result<ResponseValue<types::Certificate>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/certificates/{}",
             self.baseurl,
             encode_path(&certificate.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -11610,30 +11622,30 @@ impl Client {
         &'a self,
         certificate: &'a types::NameOrId,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/certificates/{}",
             self.baseurl,
             encode_path(&certificate.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .delete(url)
+            .delete(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -11652,40 +11664,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::PhysicalDiskResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/hardware/disks", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
+        let __progenitor_url = format!("{}/system/hardware/disks", self.baseurl,);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -11750,40 +11762,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::RackResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/hardware/racks", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
+        let __progenitor_url = format!("{}/system/hardware/racks", self.baseurl,);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -11842,30 +11854,30 @@ impl Client {
         &'a self,
         rack_id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Rack>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/hardware/racks/{}",
             self.baseurl,
             encode_path(&rack_id.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -11884,40 +11896,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SledResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/hardware/sleds", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
+        let __progenitor_url = format!("{}/system/hardware/sleds", self.baseurl,);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -11976,30 +11988,30 @@ impl Client {
         &'a self,
         sled_id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Sled>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/hardware/sleds/{}",
             self.baseurl,
             encode_path(&sled_id.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -12020,44 +12032,44 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::PhysicalDiskResultsPage>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/hardware/sleds/{}/disks",
             self.baseurl,
             encode_path(&sled_id.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -12129,40 +12141,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::GlobalImageResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/images", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
+        let __progenitor_url = format!("{}/system/images", self.baseurl,);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -12226,27 +12238,27 @@ impl Client {
         &'a self,
         body: &'a types::GlobalImageCreate,
     ) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-        let url = format!("{}/system/images", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/system/images", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -12259,30 +12271,30 @@ impl Client {
         &'a self,
         image_name: &'a types::Name,
     ) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/images/{}",
             self.baseurl,
             encode_path(&image_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -12297,30 +12309,30 @@ impl Client {
         &'a self,
         image_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/images/{}",
             self.baseurl,
             encode_path(&image_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .delete(url)
+            .delete(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -12339,40 +12351,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::IpPoolResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/ip-pools", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
+        let __progenitor_url = format!("{}/system/ip-pools", self.baseurl,);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -12428,27 +12440,27 @@ impl Client {
         &'a self,
         body: &'a types::IpPoolCreate,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-        let url = format!("{}/system/ip-pools", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/system/ip-pools", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -12459,30 +12471,30 @@ impl Client {
         &'a self,
         pool_name: &'a types::Name,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/ip-pools/{}",
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -12494,31 +12506,31 @@ impl Client {
         pool_name: &'a types::Name,
         body: &'a types::IpPoolUpdate,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/ip-pools/{}",
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .put(url)
+            .put(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -12529,30 +12541,30 @@ impl Client {
         &'a self,
         pool_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/ip-pools/{}",
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .delete(url)
+            .delete(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -12573,40 +12585,40 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/ip-pools/{}/ranges",
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let mut query = Vec::with_capacity(2usize);
+        let mut __progenitor_query = Vec::with_capacity(2usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -12666,31 +12678,31 @@ impl Client {
         pool_name: &'a types::Name,
         body: &'a types::IpRange,
     ) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/ip-pools/{}/ranges/add",
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -12702,31 +12714,31 @@ impl Client {
         pool_name: &'a types::Name,
         body: &'a types::IpRange,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/ip-pools/{}/ranges/remove",
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -12736,26 +12748,26 @@ impl Client {
     pub async fn ip_pool_service_view<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-        let url = format!("{}/system/ip-pools-service", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/system/ip-pools-service", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -12774,36 +12786,36 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/ip-pools-service/ranges", self.baseurl,);
-        let mut query = Vec::with_capacity(2usize);
+        let __progenitor_url = format!("{}/system/ip-pools-service/ranges", self.baseurl,);
+        let mut __progenitor_query = Vec::with_capacity(2usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -12860,27 +12872,27 @@ impl Client {
         &'a self,
         body: &'a types::IpRange,
     ) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
-        let url = format!("{}/system/ip-pools-service/ranges/add", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/system/ip-pools-service/ranges/add", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -12891,27 +12903,27 @@ impl Client {
         &'a self,
         body: &'a types::IpRange,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!("{}/system/ip-pools-service/ranges/remove", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/system/ip-pools-service/ranges/remove", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -12936,49 +12948,49 @@ impl Client {
         page_token: Option<&'a str>,
         start_time: Option<&'a chrono::DateTime<chrono::offset::Utc>>,
     ) -> Result<ResponseValue<types::MeasurementResultsPage>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/metrics/{}",
             self.baseurl,
             encode_path(&metric_name.to_string()),
         );
-        let mut query = Vec::with_capacity(5usize);
+        let mut __progenitor_query = Vec::with_capacity(5usize);
         if let Some(v) = &end_time {
-            query.push(("end_time", v.to_string()));
+            __progenitor_query.push(("end_time", v.to_string()));
         }
 
-        query.push(("id", id.to_string()));
+        __progenitor_query.push(("id", id.to_string()));
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &start_time {
-            query.push(("start_time", v.to_string()));
+            __progenitor_query.push(("start_time", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -12988,26 +13000,26 @@ impl Client {
     pub async fn system_policy_view<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
-        let url = format!("{}/system/policy", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/system/policy", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -13018,27 +13030,27 @@ impl Client {
         &'a self,
         body: &'a types::FleetRolePolicy,
     ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
-        let url = format!("{}/system/policy", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/system/policy", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .put(url)
+            .put(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -13057,40 +13069,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SagaResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/sagas", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
+        let __progenitor_url = format!("{}/system/sagas", self.baseurl,);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -13146,30 +13158,30 @@ impl Client {
         &'a self,
         saga_id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Saga>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/sagas/{}",
             self.baseurl,
             encode_path(&saga_id.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -13190,40 +13202,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::SiloResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/silos", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
+        let __progenitor_url = format!("{}/system/silos", self.baseurl,);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -13281,27 +13293,27 @@ impl Client {
         &'a self,
         body: &'a types::SiloCreate,
     ) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-        let url = format!("{}/system/silos", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/system/silos", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -13317,30 +13329,30 @@ impl Client {
         &'a self,
         silo_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/silos/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -13356,30 +13368,30 @@ impl Client {
         &'a self,
         silo_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/silos/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .delete(url)
+            .delete(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -13400,44 +13412,44 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::IdentityProviderResultsPage>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/silos/{}/identity-providers",
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -13507,31 +13519,31 @@ impl Client {
         silo_name: &'a types::Name,
         body: &'a types::UserCreate,
     ) -> Result<ResponseValue<types::User>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/silos/{}/identity-providers/local/users",
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -13548,31 +13560,31 @@ impl Client {
         silo_name: &'a types::Name,
         user_id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/silos/{}/identity-providers/local/users/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
             encode_path(&user_id.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .delete(url)
+            .delete(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -13595,32 +13607,32 @@ impl Client {
         user_id: &'a uuid::Uuid,
         body: &'a types::UserPassword,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/silos/{}/identity-providers/local/users/{}/set-password",
             self.baseurl,
             encode_path(&silo_name.to_string()),
             encode_path(&user_id.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -13637,31 +13649,31 @@ impl Client {
         silo_name: &'a types::Name,
         body: &'a types::SamlIdentityProviderCreate,
     ) -> Result<ResponseValue<types::SamlIdentityProvider>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/silos/{}/identity-providers/saml",
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -13678,31 +13690,31 @@ impl Client {
         silo_name: &'a types::Name,
         provider_name: &'a types::Name,
     ) -> Result<ResponseValue<types::SamlIdentityProvider>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/silos/{}/identity-providers/saml/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
             encode_path(&provider_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -13716,30 +13728,30 @@ impl Client {
         &'a self,
         silo_name: &'a types::Name,
     ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/silos/{}/policy",
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -13755,31 +13767,31 @@ impl Client {
         silo_name: &'a types::Name,
         body: &'a types::SiloRolePolicy,
     ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/silos/{}/policy",
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .put(url)
+            .put(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -13800,44 +13812,44 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/silos/{}/users/all",
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -13900,31 +13912,31 @@ impl Client {
         silo_name: &'a types::Name,
         user_id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::User>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/silos/{}/users/id/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
             encode_path(&user_id.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -13943,40 +13955,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::UserBuiltinResultsPage>, Error<types::Error>> {
-        let url = format!("{}/system/user", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
+        let __progenitor_url = format!("{}/system/user", self.baseurl,);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -14036,30 +14048,30 @@ impl Client {
         &'a self,
         user_name: &'a types::Name,
     ) -> Result<ResponseValue<types::UserBuiltin>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/system/user/{}",
             self.baseurl,
             encode_path(&user_name.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -14076,36 +14088,36 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::TimeseriesSchemaResultsPage>, Error<types::Error>> {
-        let url = format!("{}/timeseries/schema", self.baseurl,);
-        let mut query = Vec::with_capacity(2usize);
+        let __progenitor_url = format!("{}/timeseries/schema", self.baseurl,);
+        let mut __progenitor_query = Vec::with_capacity(2usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -14168,40 +14180,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
-        let url = format!("{}/users", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
+        let __progenitor_url = format!("{}/users", self.baseurl,);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -14269,48 +14281,48 @@ impl Client {
         project: Option<&'a types::NameOrId>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
-        let url = format!("{}/v1/disks", self.baseurl,);
-        let mut query = Vec::with_capacity(5usize);
+        let __progenitor_url = format!("{}/v1/disks", self.baseurl,);
+        let mut __progenitor_query = Vec::with_capacity(5usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+            __progenitor_query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+            __progenitor_query.push(("project", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -14372,34 +14384,34 @@ impl Client {
         project: &'a types::NameOrId,
         body: &'a types::DiskCreate,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let url = format!("{}/v1/disks", self.baseurl,);
-        let mut query = Vec::with_capacity(2usize);
+        let __progenitor_url = format!("{}/v1/disks", self.baseurl,);
+        let mut __progenitor_query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+            __progenitor_query.push(("organization", v.to_string()));
         }
 
-        query.push(("project", project.to_string()));
-        let request = self
+        __progenitor_query.push(("project", project.to_string()));
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -14412,40 +14424,40 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         project: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/disks/{}",
             self.baseurl,
             encode_path(&disk.to_string()),
         );
-        let mut query = Vec::with_capacity(2usize);
+        let mut __progenitor_query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+            __progenitor_query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+            __progenitor_query.push(("project", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -14458,40 +14470,40 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         project: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/disks/{}",
             self.baseurl,
             encode_path(&disk.to_string()),
         );
-        let mut query = Vec::with_capacity(2usize);
+        let mut __progenitor_query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+            __progenitor_query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+            __progenitor_query.push(("project", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .delete(url)
+            .delete(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -14514,48 +14526,48 @@ impl Client {
         project: Option<&'a types::NameOrId>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
-        let url = format!("{}/v1/instances", self.baseurl,);
-        let mut query = Vec::with_capacity(5usize);
+        let __progenitor_url = format!("{}/v1/instances", self.baseurl,);
+        let mut __progenitor_query = Vec::with_capacity(5usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+            __progenitor_query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+            __progenitor_query.push(("project", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -14618,34 +14630,34 @@ impl Client {
         project: &'a types::NameOrId,
         body: &'a types::InstanceCreate,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let url = format!("{}/v1/instances", self.baseurl,);
-        let mut query = Vec::with_capacity(2usize);
+        let __progenitor_url = format!("{}/v1/instances", self.baseurl,);
+        let mut __progenitor_query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+            __progenitor_query.push(("organization", v.to_string()));
         }
 
-        query.push(("project", project.to_string()));
-        let request = self
+        __progenitor_query.push(("project", project.to_string()));
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -14658,40 +14670,40 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         project: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/instances/{}",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut query = Vec::with_capacity(2usize);
+        let mut __progenitor_query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+            __progenitor_query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+            __progenitor_query.push(("project", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -14704,40 +14716,40 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         project: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/instances/{}",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut query = Vec::with_capacity(2usize);
+        let mut __progenitor_query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+            __progenitor_query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+            __progenitor_query.push(("project", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .delete(url)
+            .delete(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -14762,52 +14774,52 @@ impl Client {
         project: Option<&'a types::NameOrId>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/instances/{}/disks",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut query = Vec::with_capacity(5usize);
+        let mut __progenitor_query = Vec::with_capacity(5usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+            __progenitor_query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+            __progenitor_query.push(("project", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -14879,41 +14891,41 @@ impl Client {
         project: Option<&'a types::NameOrId>,
         body: &'a types::DiskPath,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/instances/{}/disks/attach",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut query = Vec::with_capacity(2usize);
+        let mut __progenitor_query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+            __progenitor_query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+            __progenitor_query.push(("project", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            202u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            202u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -14927,41 +14939,41 @@ impl Client {
         project: Option<&'a types::NameOrId>,
         body: &'a types::DiskPath,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/instances/{}/disks/detach",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut query = Vec::with_capacity(2usize);
+        let mut __progenitor_query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+            __progenitor_query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+            __progenitor_query.push(("project", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            202u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            202u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -14975,41 +14987,41 @@ impl Client {
         project: Option<&'a types::NameOrId>,
         body: &'a types::InstanceMigrate,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/instances/{}/migrate",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut query = Vec::with_capacity(2usize);
+        let mut __progenitor_query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+            __progenitor_query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+            __progenitor_query.push(("project", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -15022,40 +15034,40 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         project: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/instances/{}/reboot",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut query = Vec::with_capacity(2usize);
+        let mut __progenitor_query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+            __progenitor_query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+            __progenitor_query.push(("project", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            202u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            202u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -15087,52 +15099,52 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         project: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<types::InstanceSerialConsoleData>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/instances/{}/serial-console",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut query = Vec::with_capacity(5usize);
+        let mut __progenitor_query = Vec::with_capacity(5usize);
         if let Some(v) = &from_start {
-            query.push(("from_start", v.to_string()));
+            __progenitor_query.push(("from_start", v.to_string()));
         }
 
         if let Some(v) = &max_bytes {
-            query.push(("max_bytes", v.to_string()));
+            __progenitor_query.push(("max_bytes", v.to_string()));
         }
 
         if let Some(v) = &most_recent {
-            query.push(("most_recent", v.to_string()));
+            __progenitor_query.push(("most_recent", v.to_string()));
         }
 
         if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+            __progenitor_query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+            __progenitor_query.push(("project", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -15146,24 +15158,24 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         project: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/instances/{}/serial-console/stream",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut query = Vec::with_capacity(2usize);
+        let mut __progenitor_query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+            __progenitor_query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+            __progenitor_query.push(("project", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
-            .query(&query)
+            .get(__progenitor_url)
+            .query(&__progenitor_query)
             .header(reqwest::header::CONNECTION, "Upgrade")
             .header(reqwest::header::UPGRADE, "websocket")
             .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -15175,12 +15187,12 @@ impl Client {
                 ),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            101u16 => ResponseValue::upgrade(response).await,
-            200..=299 => ResponseValue::upgrade(response).await,
-            _ => Err(Error::UnexpectedResponse(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            101u16 => ResponseValue::upgrade(__progenitor_response).await,
+            200..=299 => ResponseValue::upgrade(__progenitor_response).await,
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -15193,40 +15205,40 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         project: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/instances/{}/start",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut query = Vec::with_capacity(2usize);
+        let mut __progenitor_query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+            __progenitor_query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+            __progenitor_query.push(("project", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            202u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            202u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -15239,40 +15251,40 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         project: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/instances/{}/stop",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut query = Vec::with_capacity(2usize);
+        let mut __progenitor_query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+            __progenitor_query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+            __progenitor_query.push(("project", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            202u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            202u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -15291,40 +15303,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
-        let url = format!("{}/v1/organizations", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
+        let __progenitor_url = format!("{}/v1/organizations", self.baseurl,);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -15381,27 +15393,27 @@ impl Client {
         &'a self,
         body: &'a types::OrganizationCreate,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let url = format!("{}/v1/organizations", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/v1/organizations", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -15412,30 +15424,30 @@ impl Client {
         &'a self,
         organization: &'a types::NameOrId,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/organizations/{}",
             self.baseurl,
             encode_path(&organization.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -15447,31 +15459,31 @@ impl Client {
         organization: &'a types::NameOrId,
         body: &'a types::OrganizationUpdate,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/organizations/{}",
             self.baseurl,
             encode_path(&organization.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .put(url)
+            .put(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -15482,30 +15494,30 @@ impl Client {
         &'a self,
         organization: &'a types::NameOrId,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/organizations/{}",
             self.baseurl,
             encode_path(&organization.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .delete(url)
+            .delete(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -15516,30 +15528,30 @@ impl Client {
         &'a self,
         organization: &'a types::NameOrId,
     ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/organizations/{}/policy",
             self.baseurl,
             encode_path(&organization.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -15551,31 +15563,31 @@ impl Client {
         organization: &'a types::NameOrId,
         body: &'a types::OrganizationRolePolicy,
     ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/organizations/{}/policy",
             self.baseurl,
             encode_path(&organization.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .put(url)
+            .put(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -15596,44 +15608,44 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
-        let url = format!("{}/v1/projects", self.baseurl,);
-        let mut query = Vec::with_capacity(4usize);
+        let __progenitor_url = format!("{}/v1/projects", self.baseurl,);
+        let mut __progenitor_query = Vec::with_capacity(4usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+            __progenitor_query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -15692,30 +15704,30 @@ impl Client {
         organization: &'a types::NameOrId,
         body: &'a types::ProjectCreate,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-        let url = format!("{}/v1/projects", self.baseurl,);
-        let mut query = Vec::with_capacity(1usize);
-        query.push(("organization", organization.to_string()));
-        let request = self
+        let __progenitor_url = format!("{}/v1/projects", self.baseurl,);
+        let mut __progenitor_query = Vec::with_capacity(1usize);
+        __progenitor_query.push(("organization", organization.to_string()));
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -15727,36 +15739,36 @@ impl Client {
         project: &'a types::NameOrId,
         organization: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/projects/{}",
             self.baseurl,
             encode_path(&project.to_string()),
         );
-        let mut query = Vec::with_capacity(1usize);
+        let mut __progenitor_query = Vec::with_capacity(1usize);
         if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+            __progenitor_query.push(("organization", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -15769,37 +15781,37 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         body: &'a types::ProjectUpdate,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/projects/{}",
             self.baseurl,
             encode_path(&project.to_string()),
         );
-        let mut query = Vec::with_capacity(1usize);
+        let mut __progenitor_query = Vec::with_capacity(1usize);
         if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+            __progenitor_query.push(("organization", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .put(url)
+            .put(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -15811,36 +15823,36 @@ impl Client {
         project: &'a types::NameOrId,
         organization: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/projects/{}",
             self.baseurl,
             encode_path(&project.to_string()),
         );
-        let mut query = Vec::with_capacity(1usize);
+        let mut __progenitor_query = Vec::with_capacity(1usize);
         if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+            __progenitor_query.push(("organization", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .delete(url)
+            .delete(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -15852,36 +15864,36 @@ impl Client {
         project: &'a types::NameOrId,
         organization: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/projects/{}/policy",
             self.baseurl,
             encode_path(&project.to_string()),
         );
-        let mut query = Vec::with_capacity(1usize);
+        let mut __progenitor_query = Vec::with_capacity(1usize);
         if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+            __progenitor_query.push(("organization", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -15894,37 +15906,37 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         body: &'a types::ProjectRolePolicy,
     ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/projects/{}/policy",
             self.baseurl,
             encode_path(&project.to_string()),
         );
-        let mut query = Vec::with_capacity(1usize);
+        let mut __progenitor_query = Vec::with_capacity(1usize);
         if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+            __progenitor_query.push(("organization", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .put(url)
+            .put(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -15943,40 +15955,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UpdateableComponentResultsPage>, Error<types::Error>> {
-        let url = format!("{}/v1/system/update/components", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
+        let __progenitor_url = format!("{}/v1/system/update/components", self.baseurl,);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -16041,40 +16053,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UpdateDeploymentResultsPage>, Error<types::Error>> {
-        let url = format!("{}/v1/system/update/deployments", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
+        let __progenitor_url = format!("{}/v1/system/update/deployments", self.baseurl,);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -16131,30 +16143,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/system/update/deployments/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -16164,26 +16176,26 @@ impl Client {
     pub async fn system_update_refresh<'a>(
         &'a self,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!("{}/v1/system/update/refresh", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/v1/system/update/refresh", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -16194,27 +16206,27 @@ impl Client {
         &'a self,
         body: &'a types::SystemUpdateStart,
     ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
-        let url = format!("{}/v1/system/update/start", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/v1/system/update/start", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            202u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            202u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -16226,26 +16238,26 @@ impl Client {
     pub async fn system_update_stop<'a>(
         &'a self,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!("{}/v1/system/update/stop", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/v1/system/update/stop", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -16264,40 +16276,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SystemUpdateResultsPage>, Error<types::Error>> {
-        let url = format!("{}/v1/system/update/updates", self.baseurl,);
-        let mut query = Vec::with_capacity(3usize);
+        let __progenitor_url = format!("{}/v1/system/update/updates", self.baseurl,);
+        let mut __progenitor_query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+            __progenitor_query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+            __progenitor_query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+            __progenitor_query.push(("sort_by", v.to_string()));
         }
 
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -16354,30 +16366,30 @@ impl Client {
         &'a self,
         version: &'a types::SemverVersion,
     ) -> Result<ResponseValue<types::SystemUpdate>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/system/update/updates/{}",
             self.baseurl,
             encode_path(&version.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -16389,30 +16401,30 @@ impl Client {
         &'a self,
         version: &'a types::SemverVersion,
     ) -> Result<ResponseValue<types::ComponentUpdateResultsPage>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/v1/system/update/updates/{}/components",
             self.baseurl,
             encode_path(&version.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -16422,26 +16434,26 @@ impl Client {
     pub async fn system_version<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::SystemVersion>, Error<types::Error>> {
-        let url = format!("{}/v1/system/update/version", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/v1/system/update/version", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 }

--- a/progenitor-impl/tests/output/param-overrides-builder-tagged.out
+++ b/progenitor-impl/tests/output/param-overrides-builder-tagged.out
@@ -149,20 +149,24 @@ pub mod builder {
             } = self;
             let key = key.map_err(Error::InvalidRequest)?;
             let unique_key = unique_key.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/key", client.baseurl,);
-            let mut query = Vec::with_capacity(2usize);
+            let __progenitor_url = format!("{}/key", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &key {
-                query.push(("key", v.to_string()));
+                __progenitor_query.push(("key", v.to_string()));
             }
             if let Some(v) = &unique_key {
-                query.push(("uniqueKey", v.to_string()));
+                __progenitor_query.push(("uniqueKey", v.to_string()));
             }
-            let request = client.client.get(url).query(&query).build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(response)),
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_request = client
+                .client
+                .get(__progenitor_url)
+                .query(&__progenitor_query)
+                .build()?;
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => Ok(ResponseValue::empty(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/param-overrides-builder.out
+++ b/progenitor-impl/tests/output/param-overrides-builder.out
@@ -149,20 +149,24 @@ pub mod builder {
             } = self;
             let key = key.map_err(Error::InvalidRequest)?;
             let unique_key = unique_key.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/key", client.baseurl,);
-            let mut query = Vec::with_capacity(2usize);
+            let __progenitor_url = format!("{}/key", client.baseurl,);
+            let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &key {
-                query.push(("key", v.to_string()));
+                __progenitor_query.push(("key", v.to_string()));
             }
             if let Some(v) = &unique_key {
-                query.push(("uniqueKey", v.to_string()));
+                __progenitor_query.push(("uniqueKey", v.to_string()));
             }
-            let request = client.client.get(url).query(&query).build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(response)),
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_request = client
+                .client
+                .get(__progenitor_url)
+                .query(&__progenitor_query)
+                .build()?;
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => Ok(ResponseValue::empty(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/param-overrides-positional.out
+++ b/progenitor-impl/tests/output/param-overrides-positional.out
@@ -86,22 +86,26 @@ impl Client {
         key: Option<bool>,
         unique_key: Option<&'a str>,
     ) -> Result<ResponseValue<()>, Error<()>> {
-        let url = format!("{}/key", self.baseurl,);
-        let mut query = Vec::with_capacity(2usize);
+        let __progenitor_url = format!("{}/key", self.baseurl,);
+        let mut __progenitor_query = Vec::with_capacity(2usize);
         if let Some(v) = &key {
-            query.push(("key", v.to_string()));
+            __progenitor_query.push(("key", v.to_string()));
         }
 
         if let Some(v) = &unique_key {
-            query.push(("uniqueKey", v.to_string()));
+            __progenitor_query.push(("uniqueKey", v.to_string()));
         }
 
-        let request = self.client.get(url).query(&query).build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => Ok(ResponseValue::empty(response)),
-            _ => Err(Error::UnexpectedResponse(response)),
+        let __progenitor_request = self
+            .client
+            .get(__progenitor_url)
+            .query(&__progenitor_query)
+            .build()?;
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 }

--- a/progenitor-impl/tests/output/propolis-server-builder-tagged.out
+++ b/progenitor-impl/tests/output/propolis-server-builder-tagged.out
@@ -2126,26 +2126,26 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/instance", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/instance", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2196,27 +2196,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceEnsureRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/instance", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/instance", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2270,31 +2270,31 @@ pub mod builder {
             } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let snapshot_id = snapshot_id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/instance/disk/{}/snapshot/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
                 encode_path(&snapshot_id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2345,27 +2345,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceMigrateStatusRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/instance/migrate/status", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/instance/migrate/status", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2388,10 +2388,10 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
             let Self { client } = self;
-            let url = format!("{}/instance/serial", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/instance/serial", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(reqwest::header::CONNECTION, "Upgrade")
                 .header(reqwest::header::UPGRADE, "websocket")
                 .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -2403,12 +2403,12 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                101u16 => ResponseValue::upgrade(response).await,
-                200..=299 => ResponseValue::upgrade(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                101u16 => ResponseValue::upgrade(__progenitor_response).await,
+                200..=299 => ResponseValue::upgrade(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2444,27 +2444,27 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/instance/state", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/instance/state", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2515,27 +2515,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceStateMonitorRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/instance/state-monitor", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/instance/state-monitor", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/propolis-server-builder.out
+++ b/progenitor-impl/tests/output/propolis-server-builder.out
@@ -2132,26 +2132,26 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
             let Self { client } = self;
-            let url = format!("{}/instance", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/instance", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2202,27 +2202,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceEnsureRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/instance", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/instance", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                201u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                201u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2276,31 +2276,31 @@ pub mod builder {
             } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let snapshot_id = snapshot_id.map_err(Error::InvalidRequest)?;
-            let url = format!(
+            let __progenitor_url = format!(
                 "{}/instance/disk/{}/snapshot/{}",
                 client.baseurl,
                 encode_path(&id.to_string()),
                 encode_path(&snapshot_id.to_string()),
             );
-            let request = client
+            let __progenitor_request = client
                 .client
-                .post(url)
+                .post(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2351,27 +2351,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceMigrateStatusRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/instance/migrate/status", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/instance/migrate/status", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2394,10 +2394,10 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
             let Self { client } = self;
-            let url = format!("{}/instance/serial", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/instance/serial", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(reqwest::header::CONNECTION, "Upgrade")
                 .header(reqwest::header::UPGRADE, "websocket")
                 .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -2409,12 +2409,12 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                101u16 => ResponseValue::upgrade(response).await,
-                200..=299 => ResponseValue::upgrade(response).await,
-                _ => Err(Error::UnexpectedResponse(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                101u16 => ResponseValue::upgrade(__progenitor_response).await,
+                200..=299 => ResponseValue::upgrade(__progenitor_response).await,
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2450,27 +2450,27 @@ pub mod builder {
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let url = format!("{}/instance/state", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/instance/state", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .put(url)
+                .put(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(response)),
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }
@@ -2521,27 +2521,27 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceStateMonitorRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/instance/state-monitor", client.baseurl,);
-            let request = client
+            let __progenitor_url = format!("{}/instance/state-monitor", client.baseurl,);
+            let __progenitor_request = client
                 .client
-                .get(url)
+                .get(__progenitor_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200u16 => ResponseValue::from_response(response).await,
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200u16 => ResponseValue::from_response(__progenitor_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(response).await?,
+                    ResponseValue::from_response(__progenitor_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(response)),
+                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/propolis-server-positional.out
+++ b/progenitor-impl/tests/output/propolis-server-positional.out
@@ -671,26 +671,26 @@ impl Client {
     pub async fn instance_get<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
-        let url = format!("{}/instance", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/instance", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -699,27 +699,27 @@ impl Client {
         &'a self,
         body: &'a types::InstanceEnsureRequest,
     ) -> Result<ResponseValue<types::InstanceEnsureResponse>, Error<types::Error>> {
-        let url = format!("{}/instance", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/instance", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .put(url)
+            .put(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            201u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            201u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -731,31 +731,31 @@ impl Client {
         id: &'a uuid::Uuid,
         snapshot_id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/instance/disk/{}/snapshot/{}",
             self.baseurl,
             encode_path(&id.to_string()),
             encode_path(&snapshot_id.to_string()),
         );
-        let request = self
+        let __progenitor_request = self
             .client
-            .post(url)
+            .post(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -764,27 +764,27 @@ impl Client {
         &'a self,
         body: &'a types::InstanceMigrateStatusRequest,
     ) -> Result<ResponseValue<types::InstanceMigrateStatusResponse>, Error<types::Error>> {
-        let url = format!("{}/instance/migrate/status", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/instance/migrate/status", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -792,10 +792,10 @@ impl Client {
     pub async fn instance_serial<'a>(
         &'a self,
     ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
-        let url = format!("{}/instance/serial", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/instance/serial", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(reqwest::header::CONNECTION, "Upgrade")
             .header(reqwest::header::UPGRADE, "websocket")
             .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -807,12 +807,12 @@ impl Client {
                 ),
             )
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            101u16 => ResponseValue::upgrade(response).await,
-            200..=299 => ResponseValue::upgrade(response).await,
-            _ => Err(Error::UnexpectedResponse(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            101u16 => ResponseValue::upgrade(__progenitor_response).await,
+            200..=299 => ResponseValue::upgrade(__progenitor_response).await,
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -821,27 +821,27 @@ impl Client {
         &'a self,
         body: types::InstanceStateRequested,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!("{}/instance/state", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/instance/state", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .put(url)
+            .put(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 
@@ -850,27 +850,27 @@ impl Client {
         &'a self,
         body: &'a types::InstanceStateMonitorRequest,
     ) -> Result<ResponseValue<types::InstanceStateMonitorResponse>, Error<types::Error>> {
-        let url = format!("{}/instance/state-monitor", self.baseurl,);
-        let request = self
+        let __progenitor_url = format!("{}/instance/state-monitor", self.baseurl,);
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200u16 => ResponseValue::from_response(__progenitor_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 }

--- a/progenitor-impl/tests/output/test_default_params_builder.out
+++ b/progenitor-impl/tests/output/test_default_params_builder.out
@@ -348,13 +348,15 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::BodyWithDefaults>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let url = format!("{}/", client.baseurl,);
-            let request = client.client.post(url).json(&body).build()?;
-            let result = client.client.execute(request).await;
-            let response = result?;
-            match response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(response)),
-                _ => Err(Error::ErrorResponse(ResponseValue::stream(response))),
+            let __progenitor_url = format!("{}/", client.baseurl,);
+            let __progenitor_request = client.client.post(__progenitor_url).json(&body).build()?;
+            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_response = __progenitor_result?;
+            match __progenitor_response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
+                _ => Err(Error::ErrorResponse(ResponseValue::stream(
+                    __progenitor_response,
+                ))),
             }
         }
     }

--- a/progenitor-impl/tests/output/test_default_params_positional.out
+++ b/progenitor-impl/tests/output/test_default_params_positional.out
@@ -120,13 +120,15 @@ impl Client {
         &'a self,
         body: &'a types::BodyWithDefaults,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-        let url = format!("{}/", self.baseurl,);
-        let request = self.client.post(url).json(&body).build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200..=299 => Ok(ResponseValue::stream(response)),
-            _ => Err(Error::ErrorResponse(ResponseValue::stream(response))),
+        let __progenitor_url = format!("{}/", self.baseurl,);
+        let __progenitor_request = self.client.post(__progenitor_url).json(&body).build()?;
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
+            _ => Err(Error::ErrorResponse(ResponseValue::stream(
+                __progenitor_response,
+            ))),
         }
     }
 }

--- a/progenitor-impl/tests/output/test_freeform_response.out
+++ b/progenitor-impl/tests/output/test_freeform_response.out
@@ -88,13 +88,15 @@ impl Client {
     pub async fn freeform_response<'a>(
         &'a self,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-        let url = format!("{}/", self.baseurl,);
-        let request = self.client.get(url).build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            200..=299 => Ok(ResponseValue::stream(response)),
-            _ => Err(Error::ErrorResponse(ResponseValue::stream(response))),
+        let __progenitor_url = format!("{}/", self.baseurl,);
+        let __progenitor_request = self.client.get(__progenitor_url).build()?;
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
+            _ => Err(Error::ErrorResponse(ResponseValue::stream(
+                __progenitor_response,
+            ))),
         }
     }
 }

--- a/progenitor-impl/tests/output/test_renamed_parameters.out
+++ b/progenitor-impl/tests/output/test_renamed_parameters.out
@@ -94,37 +94,37 @@ impl Client {
         in_: &'a str,
         use_: &'a str,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let url = format!(
+        let __progenitor_url = format!(
             "{}/{}/{}/{}",
             self.baseurl,
             encode_path(&ref_.to_string()),
             encode_path(&type_.to_string()),
             encode_path(&trait_.to_string()),
         );
-        let mut query = Vec::with_capacity(3usize);
-        query.push(("if", if_.to_string()));
-        query.push(("in", in_.to_string()));
-        query.push(("use", use_.to_string()));
-        let request = self
+        let mut __progenitor_query = Vec::with_capacity(3usize);
+        __progenitor_query.push(("if", if_.to_string()));
+        __progenitor_query.push(("in", in_.to_string()));
+        __progenitor_query.push(("use", use_.to_string()));
+        let __progenitor_request = self
             .client
-            .get(url)
+            .get(__progenitor_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&query)
+            .query(&__progenitor_query)
             .build()?;
-        let result = self.client.execute(request).await;
-        let response = result?;
-        match response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(response)),
+        let __progenitor_result = self.client.execute(__progenitor_request).await;
+        let __progenitor_response = __progenitor_result?;
+        match __progenitor_response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(response).await?,
+                ResponseValue::from_response(__progenitor_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(response)),
+            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
         }
     }
 }


### PR DESCRIPTION
This PR is essentially a reboot of https://github.com/oxidecomputer/progenitor/pull/261, using a name prefix for internal variables as discussed in that PR.

I saw the discussion of possible fixes in I ran into https://github.com/oxidecomputer/progenitor/issues/288. I decided to go with the internal name prefix approach because it seems to be the simplest. While not exactly 100% perfect and checking for collisions ahead of time probably would be, I think this PR is gets close enough to make it worthwhile.

There is a slight change to the `compile` function in `template.rs` which was done to bring the reference to the url variable back into the calling function so we wouldn't have to export the formatted identity variable, or define it in both locations (yuck).

Before:
```rust
        let url = format!(
            "{}/admin/directory/v1/customer/{}/devices/chromeos", self.baseurl,
            encode_path(& customer_id.to_string()),
        );
        let mut query = Vec::with_capacity(19usize);
        ...
        if let Some(v) = &query {
            query.push(("query", v.to_string()));
        }
        ...
        let request = self
            .client
            .get(url)
            .header(
                reqwest::header::ACCEPT,
                reqwest::header::HeaderValue::from_static("application/json"),
            )
            .query(&query)
            .build()?;
        let result = self.client.execute(request).await;
        let response = result?;
        match response.status().as_u16() {
            200u16 => ResponseValue::from_response(response).await,
            _ => Err(Error::UnexpectedResponse(response)),
        }
```

After:
```rust
        let __progenitor_url = format!(
            "{}/admin/directory/v1/customer/{}/devices/chromeos",
            self.baseurl,
            encode_path(&customer_id.to_string()),
        );
        ...
        if let Some(v) = &query {
            __progenitor_query.push(("query", v.to_string()));
        }
        ...
        let __progenitor_request = self
            .client
            .get(__progenitor_url)
            .header(
                reqwest::header::ACCEPT,
                reqwest::header::HeaderValue::from_static("application/json"),
            )
            .query(&__progenitor_query)
            .build()?;
        let __progenitor_result = self.client.execute(__progenitor_request).await;
        let __progenitor_response = __progenitor_result?;
        match __progenitor_response.status().as_u16() {
            200u16 => ResponseValue::from_response(__progenitor_response).await,
            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
        }
```