### PR TITLE
Rename internal `client` variable to help avoid collisions with input specs.

### DIFF
--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -1429,6 +1429,7 @@ impl Generator {
     ) -> Result<TokenStream> {
         let struct_name = sanitize(&method.operation_id, Case::Pascal);
         let struct_ident = format_ident!("{}", struct_name);
+        let client_ident = format_ident!("__progenitor_client");
 
         // Generate an ident for each parameter.
         let param_names = method
@@ -1646,7 +1647,7 @@ impl Generator {
             success,
             error,
             body,
-        } = self.method_sig_body(method, quote! { client})?;
+        } = self.method_sig_body(method, quote! { #client_ident })?;
 
         let send_doc = format!(
             "Sends a `{}` request to `{}`",
@@ -1661,7 +1662,7 @@ impl Generator {
             > {
                 // Destructure the builder for convenience.
                 let Self {
-                    client,
+                    #client_ident,
                     #( #param_names, )*
                 } = self;
 
@@ -1863,14 +1864,14 @@ impl Generator {
             #[doc = #struct_doc]
             #derive
             pub struct #struct_ident<'a> {
-                client: &'a super::Client,
+                #client_ident: &'a super::Client,
                 #( #param_names: #param_types, )*
             }
 
             impl<'a> #struct_ident<'a> {
                 pub fn new(client: &'a super::Client) -> Self {
                     Self {
-                        client,
+                        #client_ident: client,
                         #( #param_names: #param_values, )*
                     }
                 }

--- a/progenitor-impl/tests/output/buildomat-builder-tagged.out
+++ b/progenitor-impl/tests/output/buildomat-builder-tagged.out
@@ -1863,19 +1863,23 @@ pub mod builder {
     ///[`Client::control_hold`]: super::Client::control_hold
     #[derive(Debug, Clone)]
     pub struct ControlHold<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> ControlHold<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `POST` request to `/v1/control/hold`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/v1/control/hold", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url = format!("{}/v1/control/hold", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -1883,7 +1887,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -1897,20 +1904,27 @@ pub mod builder {
     ///[`Client::control_resume`]: super::Client::control_resume
     #[derive(Debug, Clone)]
     pub struct ControlResume<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> ControlResume<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `POST` request to `/v1/control/resume`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/v1/control/resume", client.baseurl,);
-            let __progenitor_request = client.client.post(__progenitor_url).build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url = format!("{}/v1/control/resume", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client.client.post(__progenitor_url).build()?;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -1924,14 +1938,14 @@ pub mod builder {
     ///[`Client::task_get`]: super::Client::task_get
     #[derive(Debug, Clone)]
     pub struct TaskGet<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         task: Result<String, String>,
     }
 
     impl<'a> TaskGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 task: Err("task was not initialized".to_string()),
             }
         }
@@ -1948,14 +1962,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/v1/task/{task}`
         pub async fn send(self) -> Result<ResponseValue<types::Task>, Error<()>> {
-            let Self { client, task } = self;
+            let Self {
+                __progenitor_client,
+                task,
+            } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/task/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -1963,7 +1980,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -1977,19 +1997,23 @@ pub mod builder {
     ///[`Client::tasks_get`]: super::Client::tasks_get
     #[derive(Debug, Clone)]
     pub struct TasksGet<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> TasksGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `GET` request to `/v1/tasks`
         pub async fn send(self) -> Result<ResponseValue<Vec<types::Task>>, Error<()>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/v1/tasks", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url = format!("{}/v1/tasks", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -1997,7 +2021,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -2011,14 +2038,14 @@ pub mod builder {
     ///[`Client::task_submit`]: super::Client::task_submit
     #[derive(Debug, Clone)]
     pub struct TaskSubmit<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::TaskSubmit, String>,
     }
 
     impl<'a> TaskSubmit<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::TaskSubmit::default()),
             }
         }
@@ -2044,12 +2071,15 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/tasks`
         pub async fn send(self) -> Result<ResponseValue<types::TaskSubmitResult>, Error<()>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::TaskSubmit>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/tasks", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/v1/tasks", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -2058,7 +2088,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -2072,7 +2105,7 @@ pub mod builder {
     ///[`Client::task_events_get`]: super::Client::task_events_get
     #[derive(Debug, Clone)]
     pub struct TaskEventsGet<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         task: Result<String, String>,
         minseq: Result<Option<u32>, String>,
     }
@@ -2080,7 +2113,7 @@ pub mod builder {
     impl<'a> TaskEventsGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 task: Err("task was not initialized".to_string()),
                 minseq: Ok(None),
             }
@@ -2110,7 +2143,7 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/tasks/{task}/events`
         pub async fn send(self) -> Result<ResponseValue<Vec<types::TaskEvent>>, Error<()>> {
             let Self {
-                client,
+                __progenitor_client,
                 task,
                 minseq,
             } = self;
@@ -2118,14 +2151,14 @@ pub mod builder {
             let minseq = minseq.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/tasks/{}/events",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&task.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(1usize);
             if let Some(v) = &minseq {
                 __progenitor_query.push(("minseq", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -2134,7 +2167,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -2148,14 +2184,14 @@ pub mod builder {
     ///[`Client::task_outputs_get`]: super::Client::task_outputs_get
     #[derive(Debug, Clone)]
     pub struct TaskOutputsGet<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         task: Result<String, String>,
     }
 
     impl<'a> TaskOutputsGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 task: Err("task was not initialized".to_string()),
             }
         }
@@ -2172,14 +2208,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/v1/tasks/{task}/outputs`
         pub async fn send(self) -> Result<ResponseValue<Vec<types::TaskOutput>>, Error<()>> {
-            let Self { client, task } = self;
+            let Self {
+                __progenitor_client,
+                task,
+            } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/tasks/{}/outputs",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -2187,7 +2226,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -2201,7 +2243,7 @@ pub mod builder {
     ///[`Client::task_output_download`]: super::Client::task_output_download
     #[derive(Debug, Clone)]
     pub struct TaskOutputDownload<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         task: Result<String, String>,
         output: Result<String, String>,
     }
@@ -2209,7 +2251,7 @@ pub mod builder {
     impl<'a> TaskOutputDownload<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 task: Err("task was not initialized".to_string()),
                 output: Err("output was not initialized".to_string()),
             }
@@ -2238,7 +2280,7 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/tasks/{task}/outputs/{output}`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<()>> {
             let Self {
-                client,
+                __progenitor_client,
                 task,
                 output,
             } = self;
@@ -2246,12 +2288,15 @@ pub mod builder {
             let output = output.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/tasks/{}/outputs/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&task.to_string()),
                 encode_path(&output.to_string()),
             );
-            let __progenitor_request = client.client.get(__progenitor_url).build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_request = __progenitor_client.client.get(__progenitor_url).build()?;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
@@ -2265,14 +2310,14 @@ pub mod builder {
     ///[`Client::user_create`]: super::Client::user_create
     #[derive(Debug, Clone)]
     pub struct UserCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::UserCreate, String>,
     }
 
     impl<'a> UserCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::UserCreate::default()),
             }
         }
@@ -2298,12 +2343,15 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/users`
         pub async fn send(self) -> Result<ResponseValue<types::UserCreateResult>, Error<()>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::UserCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/users", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/v1/users", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -2312,7 +2360,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -2326,19 +2377,23 @@ pub mod builder {
     ///[`Client::whoami`]: super::Client::whoami
     #[derive(Debug, Clone)]
     pub struct Whoami<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> Whoami<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `GET` request to `/v1/whoami`
         pub async fn send(self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/v1/whoami", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url = format!("{}/v1/whoami", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -2346,7 +2401,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -2360,14 +2418,14 @@ pub mod builder {
     ///[`Client::worker_bootstrap`]: super::Client::worker_bootstrap
     #[derive(Debug, Clone)]
     pub struct WorkerBootstrap<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::WorkerBootstrap, String>,
     }
 
     impl<'a> WorkerBootstrap<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::WorkerBootstrap::default()),
             }
         }
@@ -2393,12 +2451,15 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/worker/bootstrap`
         pub async fn send(self) -> Result<ResponseValue<types::WorkerBootstrapResult>, Error<()>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerBootstrap>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/worker/bootstrap", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/v1/worker/bootstrap", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -2407,7 +2468,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -2421,19 +2485,23 @@ pub mod builder {
     ///[`Client::worker_ping`]: super::Client::worker_ping
     #[derive(Debug, Clone)]
     pub struct WorkerPing<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> WorkerPing<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `GET` request to `/v1/worker/ping`
         pub async fn send(self) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/v1/worker/ping", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url = format!("{}/v1/worker/ping", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -2441,7 +2509,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -2455,7 +2526,7 @@ pub mod builder {
     ///[`Client::worker_task_append`]: super::Client::worker_task_append
     #[derive(Debug, Clone)]
     pub struct WorkerTaskAppend<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         task: Result<String, String>,
         body: Result<types::builder::WorkerAppendTask, String>,
     }
@@ -2463,7 +2534,7 @@ pub mod builder {
     impl<'a> WorkerTaskAppend<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 task: Err("task was not initialized".to_string()),
                 body: Ok(types::builder::WorkerAppendTask::default()),
             }
@@ -2502,18 +2573,29 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/append`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self { client, task, body } = self;
+            let Self {
+                __progenitor_client,
+                task,
+                body,
+            } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerAppendTask>::try_into)
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/worker/task/{}/append",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let __progenitor_request = client.client.post(__progenitor_url).json(&body).build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_request = __progenitor_client
+                .client
+                .post(__progenitor_url)
+                .json(&body)
+                .build()?;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -2527,7 +2609,7 @@ pub mod builder {
     ///[`Client::worker_task_upload_chunk`]: super::Client::worker_task_upload_chunk
     #[derive(Debug)]
     pub struct WorkerTaskUploadChunk<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         task: Result<String, String>,
         body: Result<reqwest::Body, String>,
     }
@@ -2535,7 +2617,7 @@ pub mod builder {
     impl<'a> WorkerTaskUploadChunk<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 task: Err("task was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
@@ -2563,15 +2645,19 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/chunk`
         pub async fn send(self) -> Result<ResponseValue<types::UploadedChunk>, Error<()>> {
-            let Self { client, task, body } = self;
+            let Self {
+                __progenitor_client,
+                task,
+                body,
+            } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/worker/task/{}/chunk",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -2584,7 +2670,10 @@ pub mod builder {
                 )
                 .body(body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -2598,7 +2687,7 @@ pub mod builder {
     ///[`Client::worker_task_complete`]: super::Client::worker_task_complete
     #[derive(Debug, Clone)]
     pub struct WorkerTaskComplete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         task: Result<String, String>,
         body: Result<types::builder::WorkerCompleteTask, String>,
     }
@@ -2606,7 +2695,7 @@ pub mod builder {
     impl<'a> WorkerTaskComplete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 task: Err("task was not initialized".to_string()),
                 body: Ok(types::builder::WorkerCompleteTask::default()),
             }
@@ -2645,18 +2734,29 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/complete`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self { client, task, body } = self;
+            let Self {
+                __progenitor_client,
+                task,
+                body,
+            } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerCompleteTask>::try_into)
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/worker/task/{}/complete",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let __progenitor_request = client.client.post(__progenitor_url).json(&body).build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_request = __progenitor_client
+                .client
+                .post(__progenitor_url)
+                .json(&body)
+                .build()?;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -2670,7 +2770,7 @@ pub mod builder {
     ///[`Client::worker_task_add_output`]: super::Client::worker_task_add_output
     #[derive(Debug, Clone)]
     pub struct WorkerTaskAddOutput<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         task: Result<String, String>,
         body: Result<types::builder::WorkerAddOutput, String>,
     }
@@ -2678,7 +2778,7 @@ pub mod builder {
     impl<'a> WorkerTaskAddOutput<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 task: Err("task was not initialized".to_string()),
                 body: Ok(types::builder::WorkerAddOutput::default()),
             }
@@ -2715,18 +2815,29 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/output`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self { client, task, body } = self;
+            let Self {
+                __progenitor_client,
+                task,
+                body,
+            } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerAddOutput>::try_into)
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/worker/task/{}/output",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let __progenitor_request = client.client.post(__progenitor_url).json(&body).build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_request = __progenitor_client
+                .client
+                .post(__progenitor_url)
+                .json(&body)
+                .build()?;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -2740,19 +2851,23 @@ pub mod builder {
     ///[`Client::workers_list`]: super::Client::workers_list
     #[derive(Debug, Clone)]
     pub struct WorkersList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> WorkersList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `GET` request to `/v1/workers`
         pub async fn send(self) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/v1/workers", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url = format!("{}/v1/workers", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -2760,7 +2875,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -2774,20 +2892,27 @@ pub mod builder {
     ///[`Client::workers_recycle`]: super::Client::workers_recycle
     #[derive(Debug, Clone)]
     pub struct WorkersRecycle<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> WorkersRecycle<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `POST` request to `/v1/workers/recycle`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/v1/workers/recycle", client.baseurl,);
-            let __progenitor_request = client.client.post(__progenitor_url).build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url = format!("{}/v1/workers/recycle", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client.client.post(__progenitor_url).build()?;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(__progenitor_response)),

--- a/progenitor-impl/tests/output/buildomat-builder.out
+++ b/progenitor-impl/tests/output/buildomat-builder.out
@@ -1863,19 +1863,23 @@ pub mod builder {
     ///[`Client::control_hold`]: super::Client::control_hold
     #[derive(Debug, Clone)]
     pub struct ControlHold<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> ControlHold<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `POST` request to `/v1/control/hold`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/v1/control/hold", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url = format!("{}/v1/control/hold", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -1883,7 +1887,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -1897,20 +1904,27 @@ pub mod builder {
     ///[`Client::control_resume`]: super::Client::control_resume
     #[derive(Debug, Clone)]
     pub struct ControlResume<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> ControlResume<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `POST` request to `/v1/control/resume`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/v1/control/resume", client.baseurl,);
-            let __progenitor_request = client.client.post(__progenitor_url).build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url = format!("{}/v1/control/resume", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client.client.post(__progenitor_url).build()?;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -1924,14 +1938,14 @@ pub mod builder {
     ///[`Client::task_get`]: super::Client::task_get
     #[derive(Debug, Clone)]
     pub struct TaskGet<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         task: Result<String, String>,
     }
 
     impl<'a> TaskGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 task: Err("task was not initialized".to_string()),
             }
         }
@@ -1948,14 +1962,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/v1/task/{task}`
         pub async fn send(self) -> Result<ResponseValue<types::Task>, Error<()>> {
-            let Self { client, task } = self;
+            let Self {
+                __progenitor_client,
+                task,
+            } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/task/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -1963,7 +1980,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -1977,19 +1997,23 @@ pub mod builder {
     ///[`Client::tasks_get`]: super::Client::tasks_get
     #[derive(Debug, Clone)]
     pub struct TasksGet<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> TasksGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `GET` request to `/v1/tasks`
         pub async fn send(self) -> Result<ResponseValue<Vec<types::Task>>, Error<()>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/v1/tasks", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url = format!("{}/v1/tasks", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -1997,7 +2021,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -2011,14 +2038,14 @@ pub mod builder {
     ///[`Client::task_submit`]: super::Client::task_submit
     #[derive(Debug, Clone)]
     pub struct TaskSubmit<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::TaskSubmit, String>,
     }
 
     impl<'a> TaskSubmit<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::TaskSubmit::default()),
             }
         }
@@ -2044,12 +2071,15 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/tasks`
         pub async fn send(self) -> Result<ResponseValue<types::TaskSubmitResult>, Error<()>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::TaskSubmit>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/tasks", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/v1/tasks", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -2058,7 +2088,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -2072,7 +2105,7 @@ pub mod builder {
     ///[`Client::task_events_get`]: super::Client::task_events_get
     #[derive(Debug, Clone)]
     pub struct TaskEventsGet<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         task: Result<String, String>,
         minseq: Result<Option<u32>, String>,
     }
@@ -2080,7 +2113,7 @@ pub mod builder {
     impl<'a> TaskEventsGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 task: Err("task was not initialized".to_string()),
                 minseq: Ok(None),
             }
@@ -2110,7 +2143,7 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/tasks/{task}/events`
         pub async fn send(self) -> Result<ResponseValue<Vec<types::TaskEvent>>, Error<()>> {
             let Self {
-                client,
+                __progenitor_client,
                 task,
                 minseq,
             } = self;
@@ -2118,14 +2151,14 @@ pub mod builder {
             let minseq = minseq.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/tasks/{}/events",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&task.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(1usize);
             if let Some(v) = &minseq {
                 __progenitor_query.push(("minseq", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -2134,7 +2167,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -2148,14 +2184,14 @@ pub mod builder {
     ///[`Client::task_outputs_get`]: super::Client::task_outputs_get
     #[derive(Debug, Clone)]
     pub struct TaskOutputsGet<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         task: Result<String, String>,
     }
 
     impl<'a> TaskOutputsGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 task: Err("task was not initialized".to_string()),
             }
         }
@@ -2172,14 +2208,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/v1/tasks/{task}/outputs`
         pub async fn send(self) -> Result<ResponseValue<Vec<types::TaskOutput>>, Error<()>> {
-            let Self { client, task } = self;
+            let Self {
+                __progenitor_client,
+                task,
+            } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/tasks/{}/outputs",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -2187,7 +2226,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -2201,7 +2243,7 @@ pub mod builder {
     ///[`Client::task_output_download`]: super::Client::task_output_download
     #[derive(Debug, Clone)]
     pub struct TaskOutputDownload<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         task: Result<String, String>,
         output: Result<String, String>,
     }
@@ -2209,7 +2251,7 @@ pub mod builder {
     impl<'a> TaskOutputDownload<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 task: Err("task was not initialized".to_string()),
                 output: Err("output was not initialized".to_string()),
             }
@@ -2238,7 +2280,7 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/tasks/{task}/outputs/{output}`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<()>> {
             let Self {
-                client,
+                __progenitor_client,
                 task,
                 output,
             } = self;
@@ -2246,12 +2288,15 @@ pub mod builder {
             let output = output.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/tasks/{}/outputs/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&task.to_string()),
                 encode_path(&output.to_string()),
             );
-            let __progenitor_request = client.client.get(__progenitor_url).build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_request = __progenitor_client.client.get(__progenitor_url).build()?;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
@@ -2265,14 +2310,14 @@ pub mod builder {
     ///[`Client::user_create`]: super::Client::user_create
     #[derive(Debug, Clone)]
     pub struct UserCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::UserCreate, String>,
     }
 
     impl<'a> UserCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::UserCreate::default()),
             }
         }
@@ -2298,12 +2343,15 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/users`
         pub async fn send(self) -> Result<ResponseValue<types::UserCreateResult>, Error<()>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::UserCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/users", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/v1/users", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -2312,7 +2360,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -2326,19 +2377,23 @@ pub mod builder {
     ///[`Client::whoami`]: super::Client::whoami
     #[derive(Debug, Clone)]
     pub struct Whoami<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> Whoami<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `GET` request to `/v1/whoami`
         pub async fn send(self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/v1/whoami", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url = format!("{}/v1/whoami", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -2346,7 +2401,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -2360,14 +2418,14 @@ pub mod builder {
     ///[`Client::worker_bootstrap`]: super::Client::worker_bootstrap
     #[derive(Debug, Clone)]
     pub struct WorkerBootstrap<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::WorkerBootstrap, String>,
     }
 
     impl<'a> WorkerBootstrap<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::WorkerBootstrap::default()),
             }
         }
@@ -2393,12 +2451,15 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/worker/bootstrap`
         pub async fn send(self) -> Result<ResponseValue<types::WorkerBootstrapResult>, Error<()>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerBootstrap>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/worker/bootstrap", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/v1/worker/bootstrap", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -2407,7 +2468,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -2421,19 +2485,23 @@ pub mod builder {
     ///[`Client::worker_ping`]: super::Client::worker_ping
     #[derive(Debug, Clone)]
     pub struct WorkerPing<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> WorkerPing<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `GET` request to `/v1/worker/ping`
         pub async fn send(self) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/v1/worker/ping", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url = format!("{}/v1/worker/ping", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -2441,7 +2509,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -2455,7 +2526,7 @@ pub mod builder {
     ///[`Client::worker_task_append`]: super::Client::worker_task_append
     #[derive(Debug, Clone)]
     pub struct WorkerTaskAppend<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         task: Result<String, String>,
         body: Result<types::builder::WorkerAppendTask, String>,
     }
@@ -2463,7 +2534,7 @@ pub mod builder {
     impl<'a> WorkerTaskAppend<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 task: Err("task was not initialized".to_string()),
                 body: Ok(types::builder::WorkerAppendTask::default()),
             }
@@ -2502,18 +2573,29 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/append`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self { client, task, body } = self;
+            let Self {
+                __progenitor_client,
+                task,
+                body,
+            } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerAppendTask>::try_into)
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/worker/task/{}/append",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let __progenitor_request = client.client.post(__progenitor_url).json(&body).build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_request = __progenitor_client
+                .client
+                .post(__progenitor_url)
+                .json(&body)
+                .build()?;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -2527,7 +2609,7 @@ pub mod builder {
     ///[`Client::worker_task_upload_chunk`]: super::Client::worker_task_upload_chunk
     #[derive(Debug)]
     pub struct WorkerTaskUploadChunk<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         task: Result<String, String>,
         body: Result<reqwest::Body, String>,
     }
@@ -2535,7 +2617,7 @@ pub mod builder {
     impl<'a> WorkerTaskUploadChunk<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 task: Err("task was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
@@ -2563,15 +2645,19 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/chunk`
         pub async fn send(self) -> Result<ResponseValue<types::UploadedChunk>, Error<()>> {
-            let Self { client, task, body } = self;
+            let Self {
+                __progenitor_client,
+                task,
+                body,
+            } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/worker/task/{}/chunk",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -2584,7 +2670,10 @@ pub mod builder {
                 )
                 .body(body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -2598,7 +2687,7 @@ pub mod builder {
     ///[`Client::worker_task_complete`]: super::Client::worker_task_complete
     #[derive(Debug, Clone)]
     pub struct WorkerTaskComplete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         task: Result<String, String>,
         body: Result<types::builder::WorkerCompleteTask, String>,
     }
@@ -2606,7 +2695,7 @@ pub mod builder {
     impl<'a> WorkerTaskComplete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 task: Err("task was not initialized".to_string()),
                 body: Ok(types::builder::WorkerCompleteTask::default()),
             }
@@ -2645,18 +2734,29 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/complete`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self { client, task, body } = self;
+            let Self {
+                __progenitor_client,
+                task,
+                body,
+            } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerCompleteTask>::try_into)
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/worker/task/{}/complete",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let __progenitor_request = client.client.post(__progenitor_url).json(&body).build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_request = __progenitor_client
+                .client
+                .post(__progenitor_url)
+                .json(&body)
+                .build()?;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -2670,7 +2770,7 @@ pub mod builder {
     ///[`Client::worker_task_add_output`]: super::Client::worker_task_add_output
     #[derive(Debug, Clone)]
     pub struct WorkerTaskAddOutput<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         task: Result<String, String>,
         body: Result<types::builder::WorkerAddOutput, String>,
     }
@@ -2678,7 +2778,7 @@ pub mod builder {
     impl<'a> WorkerTaskAddOutput<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 task: Err("task was not initialized".to_string()),
                 body: Ok(types::builder::WorkerAddOutput::default()),
             }
@@ -2715,18 +2815,29 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/output`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self { client, task, body } = self;
+            let Self {
+                __progenitor_client,
+                task,
+                body,
+            } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerAddOutput>::try_into)
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/worker/task/{}/output",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let __progenitor_request = client.client.post(__progenitor_url).json(&body).build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_request = __progenitor_client
+                .client
+                .post(__progenitor_url)
+                .json(&body)
+                .build()?;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -2740,19 +2851,23 @@ pub mod builder {
     ///[`Client::workers_list`]: super::Client::workers_list
     #[derive(Debug, Clone)]
     pub struct WorkersList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> WorkersList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `GET` request to `/v1/workers`
         pub async fn send(self) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/v1/workers", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url = format!("{}/v1/workers", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -2760,7 +2875,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -2774,20 +2892,27 @@ pub mod builder {
     ///[`Client::workers_recycle`]: super::Client::workers_recycle
     #[derive(Debug, Clone)]
     pub struct WorkersRecycle<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> WorkersRecycle<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `POST` request to `/v1/workers/recycle`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/v1/workers/recycle", client.baseurl,);
-            let __progenitor_request = client.client.post(__progenitor_url).build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url = format!("{}/v1/workers/recycle", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client.client.post(__progenitor_url).build()?;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(__progenitor_response)),

--- a/progenitor-impl/tests/output/keeper-builder-tagged.out
+++ b/progenitor-impl/tests/output/keeper-builder-tagged.out
@@ -1065,7 +1065,7 @@ pub mod builder {
     ///[`Client::enrol`]: super::Client::enrol
     #[derive(Debug, Clone)]
     pub struct Enrol<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         authorization: Result<String, String>,
         body: Result<types::builder::EnrolBody, String>,
     }
@@ -1073,7 +1073,7 @@ pub mod builder {
     impl<'a> Enrol<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(types::builder::EnrolBody::default()),
             }
@@ -1111,7 +1111,7 @@ pub mod builder {
         ///Sends a `POST` request to `/enrol`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self {
-                client,
+                __progenitor_client,
                 authorization,
                 body,
             } = self;
@@ -1119,16 +1119,19 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::EnrolBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/enrol", client.baseurl,);
+            let __progenitor_url = format!("{}/enrol", __progenitor_client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -1142,14 +1145,14 @@ pub mod builder {
     ///[`Client::global_jobs`]: super::Client::global_jobs
     #[derive(Debug, Clone)]
     pub struct GlobalJobs<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         authorization: Result<String, String>,
     }
 
     impl<'a> GlobalJobs<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 authorization: Err("authorization was not initialized".to_string()),
             }
         }
@@ -1167,14 +1170,14 @@ pub mod builder {
         ///Sends a `GET` request to `/global/jobs`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalJobsResult>, Error<()>> {
             let Self {
-                client,
+                __progenitor_client,
                 authorization,
             } = self;
             let authorization = authorization.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/global/jobs", client.baseurl,);
+            let __progenitor_url = format!("{}/global/jobs", __progenitor_client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -1183,7 +1186,10 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -1197,14 +1203,14 @@ pub mod builder {
     ///[`Client::ping`]: super::Client::ping
     #[derive(Debug, Clone)]
     pub struct Ping<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         authorization: Result<String, String>,
     }
 
     impl<'a> Ping<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 authorization: Err("authorization was not initialized".to_string()),
             }
         }
@@ -1222,14 +1228,14 @@ pub mod builder {
         ///Sends a `GET` request to `/ping`
         pub async fn send(self) -> Result<ResponseValue<types::PingResult>, Error<()>> {
             let Self {
-                client,
+                __progenitor_client,
                 authorization,
             } = self;
             let authorization = authorization.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/ping", client.baseurl,);
+            let __progenitor_url = format!("{}/ping", __progenitor_client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -1238,7 +1244,10 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -1252,7 +1261,7 @@ pub mod builder {
     ///[`Client::report_finish`]: super::Client::report_finish
     #[derive(Debug, Clone)]
     pub struct ReportFinish<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         authorization: Result<String, String>,
         body: Result<types::builder::ReportFinishBody, String>,
     }
@@ -1260,7 +1269,7 @@ pub mod builder {
     impl<'a> ReportFinish<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(types::builder::ReportFinishBody::default()),
             }
@@ -1300,7 +1309,7 @@ pub mod builder {
         ///Sends a `POST` request to `/report/finish`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self {
-                client,
+                __progenitor_client,
                 authorization,
                 body,
             } = self;
@@ -1308,10 +1317,10 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ReportFinishBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/report/finish", client.baseurl,);
+            let __progenitor_url = format!("{}/report/finish", __progenitor_client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -1321,7 +1330,10 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -1335,7 +1347,7 @@ pub mod builder {
     ///[`Client::report_output`]: super::Client::report_output
     #[derive(Debug, Clone)]
     pub struct ReportOutput<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         authorization: Result<String, String>,
         body: Result<types::builder::ReportOutputBody, String>,
     }
@@ -1343,7 +1355,7 @@ pub mod builder {
     impl<'a> ReportOutput<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(types::builder::ReportOutputBody::default()),
             }
@@ -1383,7 +1395,7 @@ pub mod builder {
         ///Sends a `POST` request to `/report/output`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self {
-                client,
+                __progenitor_client,
                 authorization,
                 body,
             } = self;
@@ -1391,10 +1403,10 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ReportOutputBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/report/output", client.baseurl,);
+            let __progenitor_url = format!("{}/report/output", __progenitor_client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -1404,7 +1416,10 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -1418,7 +1433,7 @@ pub mod builder {
     ///[`Client::report_start`]: super::Client::report_start
     #[derive(Debug, Clone)]
     pub struct ReportStart<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         authorization: Result<String, String>,
         body: Result<types::builder::ReportStartBody, String>,
     }
@@ -1426,7 +1441,7 @@ pub mod builder {
     impl<'a> ReportStart<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(types::builder::ReportStartBody::default()),
             }
@@ -1464,7 +1479,7 @@ pub mod builder {
         ///Sends a `POST` request to `/report/start`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self {
-                client,
+                __progenitor_client,
                 authorization,
                 body,
             } = self;
@@ -1472,10 +1487,10 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ReportStartBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/report/start", client.baseurl,);
+            let __progenitor_url = format!("{}/report/start", __progenitor_client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -1485,7 +1500,10 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,

--- a/progenitor-impl/tests/output/keeper-builder.out
+++ b/progenitor-impl/tests/output/keeper-builder.out
@@ -1065,7 +1065,7 @@ pub mod builder {
     ///[`Client::enrol`]: super::Client::enrol
     #[derive(Debug, Clone)]
     pub struct Enrol<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         authorization: Result<String, String>,
         body: Result<types::builder::EnrolBody, String>,
     }
@@ -1073,7 +1073,7 @@ pub mod builder {
     impl<'a> Enrol<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(types::builder::EnrolBody::default()),
             }
@@ -1111,7 +1111,7 @@ pub mod builder {
         ///Sends a `POST` request to `/enrol`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self {
-                client,
+                __progenitor_client,
                 authorization,
                 body,
             } = self;
@@ -1119,16 +1119,19 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::EnrolBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/enrol", client.baseurl,);
+            let __progenitor_url = format!("{}/enrol", __progenitor_client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -1142,14 +1145,14 @@ pub mod builder {
     ///[`Client::global_jobs`]: super::Client::global_jobs
     #[derive(Debug, Clone)]
     pub struct GlobalJobs<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         authorization: Result<String, String>,
     }
 
     impl<'a> GlobalJobs<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 authorization: Err("authorization was not initialized".to_string()),
             }
         }
@@ -1167,14 +1170,14 @@ pub mod builder {
         ///Sends a `GET` request to `/global/jobs`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalJobsResult>, Error<()>> {
             let Self {
-                client,
+                __progenitor_client,
                 authorization,
             } = self;
             let authorization = authorization.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/global/jobs", client.baseurl,);
+            let __progenitor_url = format!("{}/global/jobs", __progenitor_client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -1183,7 +1186,10 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -1197,14 +1203,14 @@ pub mod builder {
     ///[`Client::ping`]: super::Client::ping
     #[derive(Debug, Clone)]
     pub struct Ping<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         authorization: Result<String, String>,
     }
 
     impl<'a> Ping<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 authorization: Err("authorization was not initialized".to_string()),
             }
         }
@@ -1222,14 +1228,14 @@ pub mod builder {
         ///Sends a `GET` request to `/ping`
         pub async fn send(self) -> Result<ResponseValue<types::PingResult>, Error<()>> {
             let Self {
-                client,
+                __progenitor_client,
                 authorization,
             } = self;
             let authorization = authorization.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/ping", client.baseurl,);
+            let __progenitor_url = format!("{}/ping", __progenitor_client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -1238,7 +1244,10 @@ pub mod builder {
                 )
                 .headers(header_map)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -1252,7 +1261,7 @@ pub mod builder {
     ///[`Client::report_finish`]: super::Client::report_finish
     #[derive(Debug, Clone)]
     pub struct ReportFinish<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         authorization: Result<String, String>,
         body: Result<types::builder::ReportFinishBody, String>,
     }
@@ -1260,7 +1269,7 @@ pub mod builder {
     impl<'a> ReportFinish<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(types::builder::ReportFinishBody::default()),
             }
@@ -1300,7 +1309,7 @@ pub mod builder {
         ///Sends a `POST` request to `/report/finish`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self {
-                client,
+                __progenitor_client,
                 authorization,
                 body,
             } = self;
@@ -1308,10 +1317,10 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ReportFinishBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/report/finish", client.baseurl,);
+            let __progenitor_url = format!("{}/report/finish", __progenitor_client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -1321,7 +1330,10 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -1335,7 +1347,7 @@ pub mod builder {
     ///[`Client::report_output`]: super::Client::report_output
     #[derive(Debug, Clone)]
     pub struct ReportOutput<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         authorization: Result<String, String>,
         body: Result<types::builder::ReportOutputBody, String>,
     }
@@ -1343,7 +1355,7 @@ pub mod builder {
     impl<'a> ReportOutput<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(types::builder::ReportOutputBody::default()),
             }
@@ -1383,7 +1395,7 @@ pub mod builder {
         ///Sends a `POST` request to `/report/output`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self {
-                client,
+                __progenitor_client,
                 authorization,
                 body,
             } = self;
@@ -1391,10 +1403,10 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ReportOutputBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/report/output", client.baseurl,);
+            let __progenitor_url = format!("{}/report/output", __progenitor_client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -1404,7 +1416,10 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -1418,7 +1433,7 @@ pub mod builder {
     ///[`Client::report_start`]: super::Client::report_start
     #[derive(Debug, Clone)]
     pub struct ReportStart<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         authorization: Result<String, String>,
         body: Result<types::builder::ReportStartBody, String>,
     }
@@ -1426,7 +1441,7 @@ pub mod builder {
     impl<'a> ReportStart<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(types::builder::ReportStartBody::default()),
             }
@@ -1464,7 +1479,7 @@ pub mod builder {
         ///Sends a `POST` request to `/report/start`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self {
-                client,
+                __progenitor_client,
                 authorization,
                 body,
             } = self;
@@ -1472,10 +1487,10 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ReportStartBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/report/start", client.baseurl,);
+            let __progenitor_url = format!("{}/report/start", __progenitor_client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -1485,7 +1500,10 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,

--- a/progenitor-impl/tests/output/nexus-builder-tagged.out
+++ b/progenitor-impl/tests/output/nexus-builder-tagged.out
@@ -21032,14 +21032,14 @@ pub mod builder {
     ///[`ClientDisksExt::disk_view_by_id`]: super::ClientDisksExt::disk_view_by_id
     #[derive(Debug, Clone)]
     pub struct DiskViewById<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> DiskViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21056,14 +21056,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/disks/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/by-id/disks/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -21071,7 +21074,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -21091,14 +21097,14 @@ pub mod builder {
     ///[`ClientImagesExt::image_view_by_id`]: super::ClientImagesExt::image_view_by_id
     #[derive(Debug, Clone)]
     pub struct ImageViewById<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> ImageViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21115,14 +21121,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/images/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/by-id/images/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -21130,7 +21139,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -21150,14 +21162,14 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_view_by_id`]: super::ClientInstancesExt::instance_view_by_id
     #[derive(Debug, Clone)]
     pub struct InstanceViewById<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> InstanceViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21174,14 +21186,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/instances/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/by-id/instances/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -21189,7 +21204,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -21210,14 +21228,14 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_network_interface_view_by_id`]: super::ClientInstancesExt::instance_network_interface_view_by_id
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceViewById<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> InstanceNetworkInterfaceViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21236,14 +21254,17 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/by-id/network-interfaces/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -21251,7 +21272,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -21271,14 +21295,14 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_view_by_id`]: super::ClientOrganizationsExt::organization_view_by_id
     #[derive(Debug, Clone)]
     pub struct OrganizationViewById<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> OrganizationViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21295,14 +21319,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/organizations/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/by-id/organizations/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -21310,7 +21337,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -21330,14 +21360,14 @@ pub mod builder {
     ///[`ClientProjectsExt::project_view_by_id`]: super::ClientProjectsExt::project_view_by_id
     #[derive(Debug, Clone)]
     pub struct ProjectViewById<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> ProjectViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21354,14 +21384,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/projects/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/by-id/projects/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -21369,7 +21402,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -21389,14 +21425,14 @@ pub mod builder {
     ///[`ClientSnapshotsExt::snapshot_view_by_id`]: super::ClientSnapshotsExt::snapshot_view_by_id
     #[derive(Debug, Clone)]
     pub struct SnapshotViewById<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SnapshotViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21413,14 +21449,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/snapshots/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/by-id/snapshots/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -21428,7 +21467,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -21448,14 +21490,14 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_route_view_by_id`]: super::ClientVpcsExt::vpc_router_route_view_by_id
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteViewById<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcRouterRouteViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21472,14 +21514,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/vpc-router-routes/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/by-id/vpc-router-routes/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -21487,7 +21532,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -21507,14 +21555,14 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_view_by_id`]: super::ClientVpcsExt::vpc_router_view_by_id
     #[derive(Debug, Clone)]
     pub struct VpcRouterViewById<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcRouterViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21531,14 +21579,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/vpc-routers/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/by-id/vpc-routers/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -21546,7 +21597,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -21566,14 +21620,14 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_subnet_view_by_id`]: super::ClientVpcsExt::vpc_subnet_view_by_id
     #[derive(Debug, Clone)]
     pub struct VpcSubnetViewById<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcSubnetViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21590,14 +21644,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/vpc-subnets/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/by-id/vpc-subnets/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -21605,7 +21662,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -21625,14 +21685,14 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_view_by_id`]: super::ClientVpcsExt::vpc_view_by_id
     #[derive(Debug, Clone)]
     pub struct VpcViewById<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21649,14 +21709,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/vpcs/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/by-id/vpcs/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -21664,7 +21727,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -21684,14 +21750,14 @@ pub mod builder {
     ///[`ClientHiddenExt::device_auth_request`]: super::ClientHiddenExt::device_auth_request
     #[derive(Debug, Clone)]
     pub struct DeviceAuthRequest<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::DeviceAuthRequest, String>,
     }
 
     impl<'a> DeviceAuthRequest<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::DeviceAuthRequest::default()),
             }
         }
@@ -21719,17 +21785,23 @@ pub mod builder {
 
         ///Sends a `POST` request to `/device/auth`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::DeviceAuthRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/device/auth", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/device/auth", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .form_urlencoded(&body)?
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
@@ -21745,14 +21817,14 @@ pub mod builder {
     ///[`ClientHiddenExt::device_auth_confirm`]: super::ClientHiddenExt::device_auth_confirm
     #[derive(Debug, Clone)]
     pub struct DeviceAuthConfirm<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::DeviceAuthVerify, String>,
     }
 
     impl<'a> DeviceAuthConfirm<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::DeviceAuthVerify::default()),
             }
         }
@@ -21780,12 +21852,15 @@ pub mod builder {
 
         ///Sends a `POST` request to `/device/confirm`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::DeviceAuthVerify>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/device/confirm", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/device/confirm", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -21794,7 +21869,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -21814,14 +21892,14 @@ pub mod builder {
     ///[`ClientHiddenExt::device_access_token`]: super::ClientHiddenExt::device_access_token
     #[derive(Debug, Clone)]
     pub struct DeviceAccessToken<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::DeviceAccessTokenRequest, String>,
     }
 
     impl<'a> DeviceAccessToken<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::DeviceAccessTokenRequest::default()),
             }
         }
@@ -21848,17 +21926,23 @@ pub mod builder {
 
         ///Sends a `POST` request to `/device/token`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::DeviceAccessTokenRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/device/token", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/device/token", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .form_urlencoded(&body)?
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
@@ -21874,7 +21958,7 @@ pub mod builder {
     ///[`ClientSilosExt::group_list`]: super::ClientSilosExt::group_list
     #[derive(Debug, Clone)]
     pub struct GroupList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -21883,7 +21967,7 @@ pub mod builder {
     impl<'a> GroupList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -21927,7 +22011,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -21935,7 +22019,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/groups", client.baseurl,);
+            let __progenitor_url = format!("{}/groups", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -21946,7 +22030,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -21955,7 +22039,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -22031,14 +22118,14 @@ pub mod builder {
     ///[`ClientHiddenExt::login_spoof`]: super::ClientHiddenExt::login_spoof
     #[derive(Debug, Clone)]
     pub struct LoginSpoof<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::SpoofLoginBody, String>,
     }
 
     impl<'a> LoginSpoof<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::SpoofLoginBody::default()),
             }
         }
@@ -22064,12 +22151,15 @@ pub mod builder {
 
         ///Sends a `POST` request to `/login`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SpoofLoginBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/login", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/login", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -22078,7 +22168,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -22098,7 +22191,7 @@ pub mod builder {
     ///[`ClientLoginExt::login_local`]: super::ClientLoginExt::login_local
     #[derive(Debug, Clone)]
     pub struct LoginLocal<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         body: Result<types::builder::UsernamePasswordCredentials, String>,
     }
@@ -22106,7 +22199,7 @@ pub mod builder {
     impl<'a> LoginLocal<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(types::builder::UsernamePasswordCredentials::default()),
             }
@@ -22145,7 +22238,7 @@ pub mod builder {
         ///Sends a `POST` request to `/login/{silo_name}/local`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 silo_name,
                 body,
             } = self;
@@ -22155,11 +22248,18 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/login/{}/local",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let __progenitor_request = client.client.post(__progenitor_url).json(&body).build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_request = __progenitor_client
+                .client
+                .post(__progenitor_url)
+                .json(&body)
+                .build()?;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
@@ -22179,7 +22279,7 @@ pub mod builder {
     ///[`ClientLoginExt::login_saml_begin`]: super::ClientLoginExt::login_saml_begin
     #[derive(Debug, Clone)]
     pub struct LoginSamlBegin<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         provider_name: Result<types::Name, String>,
     }
@@ -22187,7 +22287,7 @@ pub mod builder {
     impl<'a> LoginSamlBegin<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 provider_name: Err("provider_name was not initialized".to_string()),
             }
@@ -22216,7 +22316,7 @@ pub mod builder {
         ///Sends a `GET` request to `/login/{silo_name}/saml/{provider_name}`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 silo_name,
                 provider_name,
             } = self;
@@ -22224,12 +22324,15 @@ pub mod builder {
             let provider_name = provider_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/login/{}/saml/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let __progenitor_request = client.client.get(__progenitor_url).build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_request = __progenitor_client.client.get(__progenitor_url).build()?;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
@@ -22249,7 +22352,7 @@ pub mod builder {
     ///[`ClientLoginExt::login_saml`]: super::ClientLoginExt::login_saml
     #[derive(Debug)]
     pub struct LoginSaml<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         provider_name: Result<types::Name, String>,
         body: Result<reqwest::Body, String>,
@@ -22258,7 +22361,7 @@ pub mod builder {
     impl<'a> LoginSaml<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 provider_name: Err("provider_name was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
@@ -22298,7 +22401,7 @@ pub mod builder {
         ///Sends a `POST` request to `/login/{silo_name}/saml/{provider_name}`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 silo_name,
                 provider_name,
                 body,
@@ -22308,11 +22411,11 @@ pub mod builder {
             let body = body.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/login/{}/saml/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -22321,7 +22424,10 @@ pub mod builder {
                 )
                 .body(body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
@@ -22341,19 +22447,23 @@ pub mod builder {
     ///[`ClientHiddenExt::logout`]: super::ClientHiddenExt::logout
     #[derive(Debug, Clone)]
     pub struct Logout<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> Logout<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `POST` request to `/logout`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/logout", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url = format!("{}/logout", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -22361,7 +22471,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -22381,7 +22494,7 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_list`]: super::ClientOrganizationsExt::organization_list
     #[derive(Debug, Clone)]
     pub struct OrganizationList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameOrIdSortMode>, String>,
@@ -22390,7 +22503,7 @@ pub mod builder {
     impl<'a> OrganizationList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -22434,7 +22547,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -22442,7 +22555,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/organizations", client.baseurl,);
+            let __progenitor_url = format!("{}/organizations", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -22453,7 +22566,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -22462,7 +22575,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -22538,14 +22654,14 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_create`]: super::ClientOrganizationsExt::organization_create
     #[derive(Debug, Clone)]
     pub struct OrganizationCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::OrganizationCreate, String>,
     }
 
     impl<'a> OrganizationCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::OrganizationCreate::default()),
             }
         }
@@ -22573,12 +22689,15 @@ pub mod builder {
 
         ///Sends a `POST` request to `/organizations`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/organizations", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/organizations", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -22587,7 +22706,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -22607,14 +22729,14 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_view`]: super::ClientOrganizationsExt::organization_view
     #[derive(Debug, Clone)]
     pub struct OrganizationView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
     }
 
     impl<'a> OrganizationView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
@@ -22632,16 +22754,16 @@ pub mod builder {
         ///Sends a `GET` request to `/organizations/{organization_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -22649,7 +22771,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -22669,7 +22794,7 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_update`]: super::ClientOrganizationsExt::organization_update
     #[derive(Debug, Clone)]
     pub struct OrganizationUpdate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         body: Result<types::builder::OrganizationUpdate, String>,
     }
@@ -22677,7 +22802,7 @@ pub mod builder {
     impl<'a> OrganizationUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 body: Ok(types::builder::OrganizationUpdate::default()),
             }
@@ -22717,7 +22842,7 @@ pub mod builder {
         ///Sends a `PUT` request to `/organizations/{organization_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 body,
             } = self;
@@ -22727,10 +22852,10 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -22739,7 +22864,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -22759,14 +22887,14 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_delete`]: super::ClientOrganizationsExt::organization_delete
     #[derive(Debug, Clone)]
     pub struct OrganizationDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
     }
 
     impl<'a> OrganizationDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
@@ -22784,16 +22912,16 @@ pub mod builder {
         ///Sends a `DELETE` request to `/organizations/{organization_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -22801,7 +22929,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -22821,14 +22952,14 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_policy_view`]: super::ClientOrganizationsExt::organization_policy_view
     #[derive(Debug, Clone)]
     pub struct OrganizationPolicyView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
     }
 
     impl<'a> OrganizationPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
@@ -22848,16 +22979,16 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/policy",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -22865,7 +22996,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -22885,7 +23019,7 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_policy_update`]: super::ClientOrganizationsExt::organization_policy_update
     #[derive(Debug, Clone)]
     pub struct OrganizationPolicyUpdate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         body: Result<types::builder::OrganizationRolePolicy, String>,
     }
@@ -22893,7 +23027,7 @@ pub mod builder {
     impl<'a> OrganizationPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 body: Ok(types::builder::OrganizationRolePolicy::default()),
             }
@@ -22935,7 +23069,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 body,
             } = self;
@@ -22945,10 +23079,10 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/policy",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -22957,7 +23091,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -22977,7 +23114,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_list`]: super::ClientProjectsExt::project_list
     #[derive(Debug, Clone)]
     pub struct ProjectList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -22987,7 +23124,7 @@ pub mod builder {
     impl<'a> ProjectList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -23043,7 +23180,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 limit,
                 page_token,
@@ -23055,7 +23192,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(3usize);
@@ -23068,7 +23205,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -23077,7 +23214,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -23154,7 +23294,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_create`]: super::ClientProjectsExt::project_create
     #[derive(Debug, Clone)]
     pub struct ProjectCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         body: Result<types::builder::ProjectCreate, String>,
     }
@@ -23162,7 +23302,7 @@ pub mod builder {
     impl<'a> ProjectCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 body: Ok(types::builder::ProjectCreate::default()),
             }
@@ -23201,7 +23341,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 body,
             } = self;
@@ -23211,10 +23351,10 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -23223,7 +23363,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -23243,7 +23386,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_view`]: super::ClientProjectsExt::project_view
     #[derive(Debug, Clone)]
     pub struct ProjectView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
     }
@@ -23251,7 +23394,7 @@ pub mod builder {
     impl<'a> ProjectView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
             }
@@ -23281,7 +23424,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
             } = self;
@@ -23289,11 +23432,11 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -23301,7 +23444,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -23321,7 +23467,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_update`]: super::ClientProjectsExt::project_update
     #[derive(Debug, Clone)]
     pub struct ProjectUpdate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::ProjectUpdate, String>,
@@ -23330,7 +23476,7 @@ pub mod builder {
     impl<'a> ProjectUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::ProjectUpdate::default()),
@@ -23380,7 +23526,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 body,
@@ -23392,11 +23538,11 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -23405,7 +23551,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -23425,7 +23574,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_delete`]: super::ClientProjectsExt::project_delete
     #[derive(Debug, Clone)]
     pub struct ProjectDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
     }
@@ -23433,7 +23582,7 @@ pub mod builder {
     impl<'a> ProjectDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
             }
@@ -23463,7 +23612,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
             } = self;
@@ -23471,11 +23620,11 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -23483,7 +23632,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -23503,7 +23655,7 @@ pub mod builder {
     ///[`ClientDisksExt::disk_list`]: super::ClientDisksExt::disk_list
     #[derive(Debug, Clone)]
     pub struct DiskList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -23514,7 +23666,7 @@ pub mod builder {
     impl<'a> DiskList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -23581,7 +23733,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 limit,
@@ -23595,7 +23747,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/disks",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
@@ -23609,7 +23761,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -23618,7 +23770,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -23695,7 +23850,7 @@ pub mod builder {
     ///[`ClientDisksExt::disk_create`]: super::ClientDisksExt::disk_create
     #[derive(Debug, Clone)]
     pub struct DiskCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::DiskCreate, String>,
@@ -23704,7 +23859,7 @@ pub mod builder {
     impl<'a> DiskCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::DiskCreate::default()),
@@ -23754,7 +23909,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}/disks`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 body,
@@ -23766,11 +23921,11 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/disks",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -23779,7 +23934,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -23799,7 +23957,7 @@ pub mod builder {
     ///[`ClientDisksExt::disk_view`]: super::ClientDisksExt::disk_view
     #[derive(Debug, Clone)]
     pub struct DiskView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         disk_name: Result<types::Name, String>,
@@ -23808,7 +23966,7 @@ pub mod builder {
     impl<'a> DiskView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 disk_name: Err("disk_name was not initialized".to_string()),
@@ -23850,7 +24008,7 @@ pub mod builder {
         /// {disk_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 disk_name,
@@ -23860,12 +24018,12 @@ pub mod builder {
             let disk_name = disk_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/disks/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -23873,7 +24031,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -23893,7 +24054,7 @@ pub mod builder {
     ///[`ClientDisksExt::disk_delete`]: super::ClientDisksExt::disk_delete
     #[derive(Debug, Clone)]
     pub struct DiskDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         disk_name: Result<types::Name, String>,
@@ -23902,7 +24063,7 @@ pub mod builder {
     impl<'a> DiskDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 disk_name: Err("disk_name was not initialized".to_string()),
@@ -23944,7 +24105,7 @@ pub mod builder {
         /// {disk_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 disk_name,
@@ -23954,12 +24115,12 @@ pub mod builder {
             let disk_name = disk_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/disks/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -23967,7 +24128,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -23987,7 +24151,7 @@ pub mod builder {
     ///[`ClientDisksExt::disk_metrics_list`]: super::ClientDisksExt::disk_metrics_list
     #[derive(Debug, Clone)]
     pub struct DiskMetricsList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         disk_name: Result<types::Name, String>,
@@ -24001,7 +24165,7 @@ pub mod builder {
     impl<'a> DiskMetricsList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 disk_name: Err("disk_name was not initialized".to_string()),
@@ -24104,7 +24268,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::MeasurementResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 disk_name,
@@ -24124,7 +24288,7 @@ pub mod builder {
             let start_time = start_time.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/disks/{}/metrics/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
@@ -24143,7 +24307,7 @@ pub mod builder {
             if let Some(v) = &start_time {
                 __progenitor_query.push(("start_time", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -24152,7 +24316,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -24231,7 +24398,7 @@ pub mod builder {
     ///[`ClientImagesExt::image_list`]: super::ClientImagesExt::image_list
     #[derive(Debug, Clone)]
     pub struct ImageList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -24242,7 +24409,7 @@ pub mod builder {
     impl<'a> ImageList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -24309,7 +24476,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ImageResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 limit,
@@ -24323,7 +24490,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/images",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
@@ -24337,7 +24504,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -24346,7 +24513,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -24423,7 +24593,7 @@ pub mod builder {
     ///[`ClientImagesExt::image_create`]: super::ClientImagesExt::image_create
     #[derive(Debug, Clone)]
     pub struct ImageCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::ImageCreate, String>,
@@ -24432,7 +24602,7 @@ pub mod builder {
     impl<'a> ImageCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::ImageCreate::default()),
@@ -24482,7 +24652,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}/images`
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 body,
@@ -24494,11 +24664,11 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/images",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -24507,7 +24677,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -24527,7 +24700,7 @@ pub mod builder {
     ///[`ClientImagesExt::image_view`]: super::ClientImagesExt::image_view
     #[derive(Debug, Clone)]
     pub struct ImageView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         image_name: Result<types::Name, String>,
@@ -24536,7 +24709,7 @@ pub mod builder {
     impl<'a> ImageView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 image_name: Err("image_name was not initialized".to_string()),
@@ -24578,7 +24751,7 @@ pub mod builder {
         /// {image_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 image_name,
@@ -24588,12 +24761,12 @@ pub mod builder {
             let image_name = image_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/images/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -24601,7 +24774,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -24621,7 +24797,7 @@ pub mod builder {
     ///[`ClientImagesExt::image_delete`]: super::ClientImagesExt::image_delete
     #[derive(Debug, Clone)]
     pub struct ImageDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         image_name: Result<types::Name, String>,
@@ -24630,7 +24806,7 @@ pub mod builder {
     impl<'a> ImageDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 image_name: Err("image_name was not initialized".to_string()),
@@ -24672,7 +24848,7 @@ pub mod builder {
         /// {image_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 image_name,
@@ -24682,12 +24858,12 @@ pub mod builder {
             let image_name = image_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/images/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -24695,7 +24871,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -24715,7 +24894,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_list`]: super::ClientInstancesExt::instance_list
     #[derive(Debug, Clone)]
     pub struct InstanceList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -24726,7 +24905,7 @@ pub mod builder {
     impl<'a> InstanceList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -24794,7 +24973,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 limit,
@@ -24808,7 +24987,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
@@ -24822,7 +25001,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -24831,7 +25010,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -24909,7 +25091,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_create`]: super::ClientInstancesExt::instance_create
     #[derive(Debug, Clone)]
     pub struct InstanceCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::InstanceCreate, String>,
@@ -24918,7 +25100,7 @@ pub mod builder {
     impl<'a> InstanceCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::InstanceCreate::default()),
@@ -24969,7 +25151,7 @@ pub mod builder {
         /// instances`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 body,
@@ -24981,11 +25163,11 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -24994,7 +25176,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -25014,7 +25199,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_view`]: super::ClientInstancesExt::instance_view
     #[derive(Debug, Clone)]
     pub struct InstanceView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25023,7 +25208,7 @@ pub mod builder {
     impl<'a> InstanceView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25065,7 +25250,7 @@ pub mod builder {
         /// instances/{instance_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25075,12 +25260,12 @@ pub mod builder {
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -25088,7 +25273,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -25108,7 +25296,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_delete`]: super::ClientInstancesExt::instance_delete
     #[derive(Debug, Clone)]
     pub struct InstanceDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25117,7 +25305,7 @@ pub mod builder {
     impl<'a> InstanceDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25159,7 +25347,7 @@ pub mod builder {
         /// instances/{instance_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25169,12 +25357,12 @@ pub mod builder {
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -25182,7 +25370,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -25202,7 +25393,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_disk_list`]: super::ClientInstancesExt::instance_disk_list
     #[derive(Debug, Clone)]
     pub struct InstanceDiskList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25214,7 +25405,7 @@ pub mod builder {
     impl<'a> InstanceDiskList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25293,7 +25484,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25309,7 +25500,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
@@ -25324,7 +25515,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -25333,7 +25524,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -25411,7 +25605,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_disk_attach`]: super::ClientInstancesExt::instance_disk_attach
     #[derive(Debug, Clone)]
     pub struct InstanceDiskAttach<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25421,7 +25615,7 @@ pub mod builder {
     impl<'a> InstanceDiskAttach<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25483,7 +25677,7 @@ pub mod builder {
         /// instances/{instance_name}/disks/attach`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25497,12 +25691,12 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks/attach",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -25511,7 +25705,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 202u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -25531,7 +25728,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_disk_detach`]: super::ClientInstancesExt::instance_disk_detach
     #[derive(Debug, Clone)]
     pub struct InstanceDiskDetach<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25541,7 +25738,7 @@ pub mod builder {
     impl<'a> InstanceDiskDetach<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25603,7 +25800,7 @@ pub mod builder {
         /// instances/{instance_name}/disks/detach`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25617,12 +25814,12 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks/detach",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -25631,7 +25828,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 202u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -25651,7 +25851,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_external_ip_list`]: super::ClientInstancesExt::instance_external_ip_list
     #[derive(Debug, Clone)]
     pub struct InstanceExternalIpList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25660,7 +25860,7 @@ pub mod builder {
     impl<'a> InstanceExternalIpList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25704,7 +25904,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ExternalIpResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25714,12 +25914,12 @@ pub mod builder {
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/external-ips",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -25727,7 +25927,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -25747,7 +25950,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_migrate`]: super::ClientInstancesExt::instance_migrate
     #[derive(Debug, Clone)]
     pub struct InstanceMigrate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25757,7 +25960,7 @@ pub mod builder {
     impl<'a> InstanceMigrate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25819,7 +26022,7 @@ pub mod builder {
         /// instances/{instance_name}/migrate`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25833,12 +26036,12 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/migrate",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -25847,7 +26050,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -25867,7 +26073,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_network_interface_list`]: super::ClientInstancesExt::instance_network_interface_list
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25879,7 +26085,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25959,7 +26165,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::NetworkInterfaceResultsPage>, Error<types::Error>>
         {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25975,7 +26181,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
@@ -25990,7 +26196,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -25999,7 +26205,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -26077,7 +26286,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_network_interface_create`]: super::ClientInstancesExt::instance_network_interface_create
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26087,7 +26296,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26153,7 +26362,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26167,12 +26376,12 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -26181,7 +26390,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -26201,7 +26413,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_network_interface_view`]: super::ClientInstancesExt::instance_network_interface_view
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26211,7 +26423,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26266,7 +26478,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26278,13 +26490,13 @@ pub mod builder {
             let interface_name = interface_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -26292,7 +26504,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -26312,7 +26527,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_network_interface_update`]: super::ClientInstancesExt::instance_network_interface_update
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceUpdate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26323,7 +26538,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26400,7 +26615,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26416,13 +26631,13 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -26431,7 +26646,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -26451,7 +26669,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_network_interface_delete`]: super::ClientInstancesExt::instance_network_interface_delete
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26461,7 +26679,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26514,7 +26732,7 @@ pub mod builder {
         /// instances/{instance_name}/network-interfaces/{interface_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26526,13 +26744,13 @@ pub mod builder {
             let interface_name = interface_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -26540,7 +26758,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -26560,7 +26781,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_reboot`]: super::ClientInstancesExt::instance_reboot
     #[derive(Debug, Clone)]
     pub struct InstanceReboot<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26569,7 +26790,7 @@ pub mod builder {
     impl<'a> InstanceReboot<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26611,7 +26832,7 @@ pub mod builder {
         /// instances/{instance_name}/reboot`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26621,12 +26842,12 @@ pub mod builder {
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/reboot",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -26634,7 +26855,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 202u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -26654,7 +26878,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_serial_console`]: super::ClientInstancesExt::instance_serial_console
     #[derive(Debug, Clone)]
     pub struct InstanceSerialConsole<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26666,7 +26890,7 @@ pub mod builder {
     impl<'a> InstanceSerialConsole<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26746,7 +26970,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceSerialConsoleData>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26762,7 +26986,7 @@ pub mod builder {
             let most_recent = most_recent.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/serial-console",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
@@ -26777,7 +27001,7 @@ pub mod builder {
             if let Some(v) = &most_recent {
                 __progenitor_query.push(("most_recent", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -26786,7 +27010,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -26806,7 +27033,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_serial_console_stream`]: super::ClientInstancesExt::instance_serial_console_stream
     #[derive(Debug, Clone)]
     pub struct InstanceSerialConsoleStream<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26815,7 +27042,7 @@ pub mod builder {
     impl<'a> InstanceSerialConsoleStream<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26859,7 +27086,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26869,12 +27096,12 @@ pub mod builder {
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/serial-console/stream",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(reqwest::header::CONNECTION, "Upgrade")
@@ -26888,7 +27115,10 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 101u16 => ResponseValue::upgrade(__progenitor_response).await,
@@ -26903,7 +27133,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_start`]: super::ClientInstancesExt::instance_start
     #[derive(Debug, Clone)]
     pub struct InstanceStart<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26912,7 +27142,7 @@ pub mod builder {
     impl<'a> InstanceStart<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26954,7 +27184,7 @@ pub mod builder {
         /// instances/{instance_name}/start`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26964,12 +27194,12 @@ pub mod builder {
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/start",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -26977,7 +27207,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 202u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -26997,7 +27230,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_stop`]: super::ClientInstancesExt::instance_stop
     #[derive(Debug, Clone)]
     pub struct InstanceStop<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -27006,7 +27239,7 @@ pub mod builder {
     impl<'a> InstanceStop<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -27048,7 +27281,7 @@ pub mod builder {
         /// instances/{instance_name}/stop`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -27058,12 +27291,12 @@ pub mod builder {
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/stop",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -27071,7 +27304,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 202u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -27091,7 +27327,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_policy_view`]: super::ClientProjectsExt::project_policy_view
     #[derive(Debug, Clone)]
     pub struct ProjectPolicyView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
     }
@@ -27099,7 +27335,7 @@ pub mod builder {
     impl<'a> ProjectPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
             }
@@ -27131,7 +27367,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
             } = self;
@@ -27139,11 +27375,11 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/policy",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -27151,7 +27387,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -27171,7 +27410,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_policy_update`]: super::ClientProjectsExt::project_policy_update
     #[derive(Debug, Clone)]
     pub struct ProjectPolicyUpdate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::ProjectRolePolicy, String>,
@@ -27180,7 +27419,7 @@ pub mod builder {
     impl<'a> ProjectPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::ProjectRolePolicy::default()),
@@ -27234,7 +27473,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 body,
@@ -27246,11 +27485,11 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/policy",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -27259,7 +27498,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -27279,7 +27521,7 @@ pub mod builder {
     ///[`ClientSnapshotsExt::snapshot_list`]: super::ClientSnapshotsExt::snapshot_list
     #[derive(Debug, Clone)]
     pub struct SnapshotList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -27290,7 +27532,7 @@ pub mod builder {
     impl<'a> SnapshotList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -27358,7 +27600,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SnapshotResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 limit,
@@ -27372,7 +27614,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/snapshots",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
@@ -27386,7 +27628,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -27395,7 +27637,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -27473,7 +27718,7 @@ pub mod builder {
     ///[`ClientSnapshotsExt::snapshot_create`]: super::ClientSnapshotsExt::snapshot_create
     #[derive(Debug, Clone)]
     pub struct SnapshotCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::SnapshotCreate, String>,
@@ -27482,7 +27727,7 @@ pub mod builder {
     impl<'a> SnapshotCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::SnapshotCreate::default()),
@@ -27533,7 +27778,7 @@ pub mod builder {
         /// snapshots`
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 body,
@@ -27545,11 +27790,11 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/snapshots",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -27558,7 +27803,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -27578,7 +27826,7 @@ pub mod builder {
     ///[`ClientSnapshotsExt::snapshot_view`]: super::ClientSnapshotsExt::snapshot_view
     #[derive(Debug, Clone)]
     pub struct SnapshotView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         snapshot_name: Result<types::Name, String>,
@@ -27587,7 +27835,7 @@ pub mod builder {
     impl<'a> SnapshotView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 snapshot_name: Err("snapshot_name was not initialized".to_string()),
@@ -27629,7 +27877,7 @@ pub mod builder {
         /// snapshots/{snapshot_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 snapshot_name,
@@ -27639,12 +27887,12 @@ pub mod builder {
             let snapshot_name = snapshot_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/snapshots/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -27652,7 +27900,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -27672,7 +27923,7 @@ pub mod builder {
     ///[`ClientSnapshotsExt::snapshot_delete`]: super::ClientSnapshotsExt::snapshot_delete
     #[derive(Debug, Clone)]
     pub struct SnapshotDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         snapshot_name: Result<types::Name, String>,
@@ -27681,7 +27932,7 @@ pub mod builder {
     impl<'a> SnapshotDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 snapshot_name: Err("snapshot_name was not initialized".to_string()),
@@ -27723,7 +27974,7 @@ pub mod builder {
         /// snapshots/{snapshot_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 snapshot_name,
@@ -27733,12 +27984,12 @@ pub mod builder {
             let snapshot_name = snapshot_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/snapshots/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -27746,7 +27997,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -27766,7 +28020,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_list`]: super::ClientVpcsExt::vpc_list
     #[derive(Debug, Clone)]
     pub struct VpcList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -27777,7 +28031,7 @@ pub mod builder {
     impl<'a> VpcList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -27844,7 +28098,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 limit,
@@ -27858,7 +28112,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
@@ -27872,7 +28126,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -27881,7 +28135,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -27958,7 +28215,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_create`]: super::ClientVpcsExt::vpc_create
     #[derive(Debug, Clone)]
     pub struct VpcCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::VpcCreate, String>,
@@ -27967,7 +28224,7 @@ pub mod builder {
     impl<'a> VpcCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::VpcCreate::default()),
@@ -28017,7 +28274,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs`
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 body,
@@ -28029,11 +28286,11 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -28042,7 +28299,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -28062,7 +28322,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_view`]: super::ClientVpcsExt::vpc_view
     #[derive(Debug, Clone)]
     pub struct VpcView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28071,7 +28331,7 @@ pub mod builder {
     impl<'a> VpcView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28113,7 +28373,7 @@ pub mod builder {
         /// {vpc_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28123,12 +28383,12 @@ pub mod builder {
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -28136,7 +28396,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -28156,7 +28419,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_update`]: super::ClientVpcsExt::vpc_update
     #[derive(Debug, Clone)]
     pub struct VpcUpdate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28166,7 +28429,7 @@ pub mod builder {
     impl<'a> VpcUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28228,7 +28491,7 @@ pub mod builder {
         /// {vpc_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28242,12 +28505,12 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -28256,7 +28519,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -28276,7 +28542,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_delete`]: super::ClientVpcsExt::vpc_delete
     #[derive(Debug, Clone)]
     pub struct VpcDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28285,7 +28551,7 @@ pub mod builder {
     impl<'a> VpcDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28327,7 +28593,7 @@ pub mod builder {
         /// {vpc_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28337,12 +28603,12 @@ pub mod builder {
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -28350,7 +28616,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -28370,7 +28639,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_firewall_rules_view`]: super::ClientVpcsExt::vpc_firewall_rules_view
     #[derive(Debug, Clone)]
     pub struct VpcFirewallRulesView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28379,7 +28648,7 @@ pub mod builder {
     impl<'a> VpcFirewallRulesView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28423,7 +28692,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcFirewallRules>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28433,12 +28702,12 @@ pub mod builder {
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -28446,7 +28715,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -28466,7 +28738,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_firewall_rules_update`]: super::ClientVpcsExt::vpc_firewall_rules_update
     #[derive(Debug, Clone)]
     pub struct VpcFirewallRulesUpdate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28476,7 +28748,7 @@ pub mod builder {
     impl<'a> VpcFirewallRulesUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28541,7 +28813,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcFirewallRules>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28555,12 +28827,12 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -28569,7 +28841,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -28589,7 +28864,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_list`]: super::ClientVpcsExt::vpc_router_list
     #[derive(Debug, Clone)]
     pub struct VpcRouterList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28601,7 +28876,7 @@ pub mod builder {
     impl<'a> VpcRouterList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28680,7 +28955,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcRouterResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28696,7 +28971,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
@@ -28711,7 +28986,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -28720,7 +28995,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -28798,7 +29076,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_create`]: super::ClientVpcsExt::vpc_router_create
     #[derive(Debug, Clone)]
     pub struct VpcRouterCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28808,7 +29086,7 @@ pub mod builder {
     impl<'a> VpcRouterCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28870,7 +29148,7 @@ pub mod builder {
         /// {vpc_name}/routers`
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28884,12 +29162,12 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -28898,7 +29176,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -28918,7 +29199,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_view`]: super::ClientVpcsExt::vpc_router_view
     #[derive(Debug, Clone)]
     pub struct VpcRouterView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28928,7 +29209,7 @@ pub mod builder {
     impl<'a> VpcRouterView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28981,7 +29262,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28993,13 +29274,13 @@ pub mod builder {
             let router_name = router_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -29007,7 +29288,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -29027,7 +29311,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_update`]: super::ClientVpcsExt::vpc_router_update
     #[derive(Debug, Clone)]
     pub struct VpcRouterUpdate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29038,7 +29322,7 @@ pub mod builder {
     impl<'a> VpcRouterUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29111,7 +29395,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29127,13 +29411,13 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -29142,7 +29426,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -29162,7 +29449,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_delete`]: super::ClientVpcsExt::vpc_router_delete
     #[derive(Debug, Clone)]
     pub struct VpcRouterDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29172,7 +29459,7 @@ pub mod builder {
     impl<'a> VpcRouterDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29225,7 +29512,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29237,13 +29524,13 @@ pub mod builder {
             let router_name = router_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -29251,7 +29538,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -29271,7 +29561,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_route_list`]: super::ClientVpcsExt::vpc_router_route_list
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29284,7 +29574,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29374,7 +29664,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::RouterRouteResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29392,7 +29682,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
@@ -29408,7 +29698,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -29417,7 +29707,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -29495,7 +29788,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_route_create`]: super::ClientVpcsExt::vpc_router_route_create
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29506,7 +29799,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29581,7 +29874,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}/routes`
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29597,13 +29890,13 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -29612,7 +29905,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -29632,7 +29928,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_route_view`]: super::ClientVpcsExt::vpc_router_route_view
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29643,7 +29939,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29707,7 +30003,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}/routes/{route_name}`
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29721,14 +30017,14 @@ pub mod builder {
             let route_name = route_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -29736,7 +30032,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -29756,7 +30055,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_route_update`]: super::ClientVpcsExt::vpc_router_route_update
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteUpdate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29768,7 +30067,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29854,7 +30153,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}/routes/{route_name}`
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29872,14 +30171,14 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -29888,7 +30187,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -29908,7 +30210,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_route_delete`]: super::ClientVpcsExt::vpc_router_route_delete
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29919,7 +30221,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29983,7 +30285,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}/routes/{route_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29997,14 +30299,14 @@ pub mod builder {
             let route_name = route_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -30012,7 +30314,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -30032,7 +30337,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_subnet_list`]: super::ClientVpcsExt::vpc_subnet_list
     #[derive(Debug, Clone)]
     pub struct VpcSubnetList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30044,7 +30349,7 @@ pub mod builder {
     impl<'a> VpcSubnetList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30123,7 +30428,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcSubnetResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30139,7 +30444,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
@@ -30154,7 +30459,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -30163,7 +30468,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -30241,7 +30549,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_subnet_create`]: super::ClientVpcsExt::vpc_subnet_create
     #[derive(Debug, Clone)]
     pub struct VpcSubnetCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30251,7 +30559,7 @@ pub mod builder {
     impl<'a> VpcSubnetCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30313,7 +30621,7 @@ pub mod builder {
         /// {vpc_name}/subnets`
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30327,12 +30635,12 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -30341,7 +30649,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -30361,7 +30672,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_subnet_view`]: super::ClientVpcsExt::vpc_subnet_view
     #[derive(Debug, Clone)]
     pub struct VpcSubnetView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30371,7 +30682,7 @@ pub mod builder {
     impl<'a> VpcSubnetView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30424,7 +30735,7 @@ pub mod builder {
         /// {vpc_name}/subnets/{subnet_name}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30436,13 +30747,13 @@ pub mod builder {
             let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -30450,7 +30761,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -30470,7 +30784,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_subnet_update`]: super::ClientVpcsExt::vpc_subnet_update
     #[derive(Debug, Clone)]
     pub struct VpcSubnetUpdate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30481,7 +30795,7 @@ pub mod builder {
     impl<'a> VpcSubnetUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30554,7 +30868,7 @@ pub mod builder {
         /// {vpc_name}/subnets/{subnet_name}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30570,13 +30884,13 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -30585,7 +30899,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -30605,7 +30922,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_subnet_delete`]: super::ClientVpcsExt::vpc_subnet_delete
     #[derive(Debug, Clone)]
     pub struct VpcSubnetDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30615,7 +30932,7 @@ pub mod builder {
     impl<'a> VpcSubnetDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30668,7 +30985,7 @@ pub mod builder {
         /// {vpc_name}/subnets/{subnet_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30680,13 +30997,13 @@ pub mod builder {
             let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -30694,7 +31011,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -30714,7 +31034,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_subnet_list_network_interfaces`]: super::ClientVpcsExt::vpc_subnet_list_network_interfaces
     #[derive(Debug, Clone)]
     pub struct VpcSubnetListNetworkInterfaces<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30727,7 +31047,7 @@ pub mod builder {
     impl<'a> VpcSubnetListNetworkInterfaces<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30818,7 +31138,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::NetworkInterfaceResultsPage>, Error<types::Error>>
         {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30836,7 +31156,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}/network-interfaces",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
@@ -30852,7 +31172,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -30861,7 +31181,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -30939,21 +31262,25 @@ pub mod builder {
     ///[`ClientSilosExt::policy_view`]: super::ClientSilosExt::policy_view
     #[derive(Debug, Clone)]
     pub struct PolicyView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> PolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `GET` request to `/policy`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/policy", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url = format!("{}/policy", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -30961,7 +31288,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -30981,14 +31311,14 @@ pub mod builder {
     ///[`ClientSilosExt::policy_update`]: super::ClientSilosExt::policy_update
     #[derive(Debug, Clone)]
     pub struct PolicyUpdate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::SiloRolePolicy, String>,
     }
 
     impl<'a> PolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::SiloRolePolicy::default()),
             }
         }
@@ -31016,12 +31346,15 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SiloRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/policy", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/policy", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -31030,7 +31363,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -31050,7 +31386,7 @@ pub mod builder {
     ///[`ClientRolesExt::role_list`]: super::ClientRolesExt::role_list
     #[derive(Debug, Clone)]
     pub struct RoleList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
     }
@@ -31058,7 +31394,7 @@ pub mod builder {
     impl<'a> RoleList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
             }
@@ -31090,13 +31426,13 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::RoleResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/roles", client.baseurl,);
+            let __progenitor_url = format!("{}/roles", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -31104,7 +31440,7 @@ pub mod builder {
             if let Some(v) = &page_token {
                 __progenitor_query.push(("page_token", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -31113,7 +31449,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -31188,14 +31527,14 @@ pub mod builder {
     ///[`ClientRolesExt::role_view`]: super::ClientRolesExt::role_view
     #[derive(Debug, Clone)]
     pub struct RoleView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         role_name: Result<String, String>,
     }
 
     impl<'a> RoleView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 role_name: Err("role_name was not initialized".to_string()),
             }
         }
@@ -31212,14 +31551,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/roles/{role_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Role>, Error<types::Error>> {
-            let Self { client, role_name } = self;
+            let Self {
+                __progenitor_client,
+                role_name,
+            } = self;
             let role_name = role_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/roles/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&role_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -31227,7 +31569,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -31247,19 +31592,23 @@ pub mod builder {
     ///[`ClientHiddenExt::session_me`]: super::ClientHiddenExt::session_me
     #[derive(Debug, Clone)]
     pub struct SessionMe<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> SessionMe<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `GET` request to `/session/me`
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/session/me", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url = format!("{}/session/me", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -31267,7 +31616,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -31287,7 +31639,7 @@ pub mod builder {
     ///[`ClientHiddenExt::session_me_groups`]: super::ClientHiddenExt::session_me_groups
     #[derive(Debug, Clone)]
     pub struct SessionMeGroups<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -31296,7 +31648,7 @@ pub mod builder {
     impl<'a> SessionMeGroups<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -31340,7 +31692,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -31348,7 +31700,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/session/me/groups", client.baseurl,);
+            let __progenitor_url = format!("{}/session/me/groups", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -31359,7 +31711,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -31368,7 +31720,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -31444,7 +31799,7 @@ pub mod builder {
     ///[`ClientSessionExt::session_sshkey_list`]: super::ClientSessionExt::session_sshkey_list
     #[derive(Debug, Clone)]
     pub struct SessionSshkeyList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameSortMode>, String>,
@@ -31453,7 +31808,7 @@ pub mod builder {
     impl<'a> SessionSshkeyList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -31497,7 +31852,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SshKeyResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -31505,7 +31860,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/session/me/sshkeys", client.baseurl,);
+            let __progenitor_url = format!("{}/session/me/sshkeys", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -31516,7 +31871,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -31525,7 +31880,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -31601,14 +31959,14 @@ pub mod builder {
     ///[`ClientSessionExt::session_sshkey_create`]: super::ClientSessionExt::session_sshkey_create
     #[derive(Debug, Clone)]
     pub struct SessionSshkeyCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::SshKeyCreate, String>,
     }
 
     impl<'a> SessionSshkeyCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::SshKeyCreate::default()),
             }
         }
@@ -31634,12 +31992,15 @@ pub mod builder {
 
         ///Sends a `POST` request to `/session/me/sshkeys`
         pub async fn send(self) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SshKeyCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/session/me/sshkeys", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/session/me/sshkeys", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -31648,7 +32009,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -31668,14 +32032,14 @@ pub mod builder {
     ///[`ClientSessionExt::session_sshkey_view`]: super::ClientSessionExt::session_sshkey_view
     #[derive(Debug, Clone)]
     pub struct SessionSshkeyView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         ssh_key_name: Result<types::Name, String>,
     }
 
     impl<'a> SessionSshkeyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 ssh_key_name: Err("ssh_key_name was not initialized".to_string()),
             }
         }
@@ -31693,16 +32057,16 @@ pub mod builder {
         ///Sends a `GET` request to `/session/me/sshkeys/{ssh_key_name}`
         pub async fn send(self) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 ssh_key_name,
             } = self;
             let ssh_key_name = ssh_key_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/session/me/sshkeys/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -31710,7 +32074,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -31730,14 +32097,14 @@ pub mod builder {
     ///[`ClientSessionExt::session_sshkey_delete`]: super::ClientSessionExt::session_sshkey_delete
     #[derive(Debug, Clone)]
     pub struct SessionSshkeyDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         ssh_key_name: Result<types::Name, String>,
     }
 
     impl<'a> SessionSshkeyDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 ssh_key_name: Err("ssh_key_name was not initialized".to_string()),
             }
         }
@@ -31755,16 +32122,16 @@ pub mod builder {
         ///Sends a `DELETE` request to `/session/me/sshkeys/{ssh_key_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 ssh_key_name,
             } = self;
             let ssh_key_name = ssh_key_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/session/me/sshkeys/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -31772,7 +32139,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -31792,14 +32162,14 @@ pub mod builder {
     ///[`ClientSystemExt::system_image_view_by_id`]: super::ClientSystemExt::system_image_view_by_id
     #[derive(Debug, Clone)]
     pub struct SystemImageViewById<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SystemImageViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -31816,14 +32186,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/by-id/images/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/by-id/images/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -31831,7 +32204,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -31851,14 +32227,14 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_view_by_id`]: super::ClientSystemExt::ip_pool_view_by_id
     #[derive(Debug, Clone)]
     pub struct IpPoolViewById<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> IpPoolViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -31875,14 +32251,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/by-id/ip-pools/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/by-id/ip-pools/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -31890,7 +32269,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -31910,14 +32292,14 @@ pub mod builder {
     ///[`ClientSystemExt::silo_view_by_id`]: super::ClientSystemExt::silo_view_by_id
     #[derive(Debug, Clone)]
     pub struct SiloViewById<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SiloViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -31934,14 +32316,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/by-id/silos/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/by-id/silos/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -31949,7 +32334,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -31969,7 +32357,7 @@ pub mod builder {
     ///[`ClientSystemExt::certificate_list`]: super::ClientSystemExt::certificate_list
     #[derive(Debug, Clone)]
     pub struct CertificateList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameSortMode>, String>,
@@ -31978,7 +32366,7 @@ pub mod builder {
     impl<'a> CertificateList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -32022,7 +32410,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::CertificateResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -32030,7 +32418,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/certificates", client.baseurl,);
+            let __progenitor_url = format!("{}/system/certificates", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -32041,7 +32429,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -32050,7 +32438,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -32126,14 +32517,14 @@ pub mod builder {
     ///[`ClientSystemExt::certificate_create`]: super::ClientSystemExt::certificate_create
     #[derive(Debug, Clone)]
     pub struct CertificateCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::CertificateCreate, String>,
     }
 
     impl<'a> CertificateCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::CertificateCreate::default()),
             }
         }
@@ -32161,12 +32552,15 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/certificates`
         pub async fn send(self) -> Result<ResponseValue<types::Certificate>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::CertificateCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/certificates", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/system/certificates", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -32175,7 +32569,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -32195,14 +32592,14 @@ pub mod builder {
     ///[`ClientSystemExt::certificate_view`]: super::ClientSystemExt::certificate_view
     #[derive(Debug, Clone)]
     pub struct CertificateView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         certificate: Result<types::NameOrId, String>,
     }
 
     impl<'a> CertificateView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 certificate: Err("certificate was not initialized".to_string()),
             }
         }
@@ -32220,16 +32617,16 @@ pub mod builder {
         ///Sends a `GET` request to `/system/certificates/{certificate}`
         pub async fn send(self) -> Result<ResponseValue<types::Certificate>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 certificate,
             } = self;
             let certificate = certificate.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/certificates/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&certificate.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -32237,7 +32634,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -32257,14 +32657,14 @@ pub mod builder {
     ///[`ClientSystemExt::certificate_delete`]: super::ClientSystemExt::certificate_delete
     #[derive(Debug, Clone)]
     pub struct CertificateDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         certificate: Result<types::NameOrId, String>,
     }
 
     impl<'a> CertificateDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 certificate: Err("certificate was not initialized".to_string()),
             }
         }
@@ -32282,16 +32682,16 @@ pub mod builder {
         ///Sends a `DELETE` request to `/system/certificates/{certificate}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 certificate,
             } = self;
             let certificate = certificate.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/certificates/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&certificate.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -32299,7 +32699,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -32319,7 +32722,7 @@ pub mod builder {
     ///[`ClientSystemExt::physical_disk_list`]: super::ClientSystemExt::physical_disk_list
     #[derive(Debug, Clone)]
     pub struct PhysicalDiskList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -32328,7 +32731,7 @@ pub mod builder {
     impl<'a> PhysicalDiskList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -32372,7 +32775,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::PhysicalDiskResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -32380,7 +32783,8 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/hardware/disks", client.baseurl,);
+            let __progenitor_url =
+                format!("{}/system/hardware/disks", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -32391,7 +32795,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -32400,7 +32804,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -32476,7 +32883,7 @@ pub mod builder {
     ///[`ClientSystemExt::rack_list`]: super::ClientSystemExt::rack_list
     #[derive(Debug, Clone)]
     pub struct RackList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -32485,7 +32892,7 @@ pub mod builder {
     impl<'a> RackList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -32529,7 +32936,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::RackResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -32537,7 +32944,8 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/hardware/racks", client.baseurl,);
+            let __progenitor_url =
+                format!("{}/system/hardware/racks", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -32548,7 +32956,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -32557,7 +32965,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -32633,14 +33044,14 @@ pub mod builder {
     ///[`ClientSystemExt::rack_view`]: super::ClientSystemExt::rack_view
     #[derive(Debug, Clone)]
     pub struct RackView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         rack_id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> RackView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 rack_id: Err("rack_id was not initialized".to_string()),
             }
         }
@@ -32657,14 +33068,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/hardware/racks/{rack_id}`
         pub async fn send(self) -> Result<ResponseValue<types::Rack>, Error<types::Error>> {
-            let Self { client, rack_id } = self;
+            let Self {
+                __progenitor_client,
+                rack_id,
+            } = self;
             let rack_id = rack_id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/hardware/racks/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&rack_id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -32672,7 +33086,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -32692,7 +33109,7 @@ pub mod builder {
     ///[`ClientSystemExt::sled_list`]: super::ClientSystemExt::sled_list
     #[derive(Debug, Clone)]
     pub struct SledList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -32701,7 +33118,7 @@ pub mod builder {
     impl<'a> SledList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -32745,7 +33162,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SledResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -32753,7 +33170,8 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/hardware/sleds", client.baseurl,);
+            let __progenitor_url =
+                format!("{}/system/hardware/sleds", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -32764,7 +33182,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -32773,7 +33191,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -32849,14 +33270,14 @@ pub mod builder {
     ///[`ClientSystemExt::sled_view`]: super::ClientSystemExt::sled_view
     #[derive(Debug, Clone)]
     pub struct SledView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         sled_id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SledView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 sled_id: Err("sled_id was not initialized".to_string()),
             }
         }
@@ -32873,14 +33294,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/hardware/sleds/{sled_id}`
         pub async fn send(self) -> Result<ResponseValue<types::Sled>, Error<types::Error>> {
-            let Self { client, sled_id } = self;
+            let Self {
+                __progenitor_client,
+                sled_id,
+            } = self;
             let sled_id = sled_id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/hardware/sleds/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&sled_id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -32888,7 +33312,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -32908,7 +33335,7 @@ pub mod builder {
     ///[`ClientSystemExt::sled_physical_disk_list`]: super::ClientSystemExt::sled_physical_disk_list
     #[derive(Debug, Clone)]
     pub struct SledPhysicalDiskList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         sled_id: Result<uuid::Uuid, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -32918,7 +33345,7 @@ pub mod builder {
     impl<'a> SledPhysicalDiskList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 sled_id: Err("sled_id was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -32973,7 +33400,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::PhysicalDiskResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 sled_id,
                 limit,
                 page_token,
@@ -32985,7 +33412,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/hardware/sleds/{}/disks",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&sled_id.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(3usize);
@@ -32998,7 +33425,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -33007,7 +33434,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -33083,7 +33513,7 @@ pub mod builder {
     ///[`ClientSystemExt::system_image_list`]: super::ClientSystemExt::system_image_list
     #[derive(Debug, Clone)]
     pub struct SystemImageList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameSortMode>, String>,
@@ -33092,7 +33522,7 @@ pub mod builder {
     impl<'a> SystemImageList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -33136,7 +33566,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::GlobalImageResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -33144,7 +33574,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/images", client.baseurl,);
+            let __progenitor_url = format!("{}/system/images", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -33155,7 +33585,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -33164,7 +33594,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -33240,14 +33673,14 @@ pub mod builder {
     ///[`ClientSystemExt::system_image_create`]: super::ClientSystemExt::system_image_create
     #[derive(Debug, Clone)]
     pub struct SystemImageCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::GlobalImageCreate, String>,
     }
 
     impl<'a> SystemImageCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::GlobalImageCreate::default()),
             }
         }
@@ -33275,12 +33708,15 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/images`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::GlobalImageCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/images", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/system/images", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -33289,7 +33725,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -33309,14 +33748,14 @@ pub mod builder {
     ///[`ClientSystemExt::system_image_view`]: super::ClientSystemExt::system_image_view
     #[derive(Debug, Clone)]
     pub struct SystemImageView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         image_name: Result<types::Name, String>,
     }
 
     impl<'a> SystemImageView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 image_name: Err("image_name was not initialized".to_string()),
             }
         }
@@ -33333,14 +33772,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/images/{image_name}`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-            let Self { client, image_name } = self;
+            let Self {
+                __progenitor_client,
+                image_name,
+            } = self;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/images/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&image_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -33348,7 +33790,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -33368,14 +33813,14 @@ pub mod builder {
     ///[`ClientSystemExt::system_image_delete`]: super::ClientSystemExt::system_image_delete
     #[derive(Debug, Clone)]
     pub struct SystemImageDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         image_name: Result<types::Name, String>,
     }
 
     impl<'a> SystemImageDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 image_name: Err("image_name was not initialized".to_string()),
             }
         }
@@ -33392,14 +33837,17 @@ pub mod builder {
 
         ///Sends a `DELETE` request to `/system/images/{image_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { client, image_name } = self;
+            let Self {
+                __progenitor_client,
+                image_name,
+            } = self;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/images/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&image_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -33407,7 +33855,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -33427,7 +33878,7 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_list`]: super::ClientSystemExt::ip_pool_list
     #[derive(Debug, Clone)]
     pub struct IpPoolList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameOrIdSortMode>, String>,
@@ -33436,7 +33887,7 @@ pub mod builder {
     impl<'a> IpPoolList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -33480,7 +33931,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::IpPoolResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -33488,7 +33939,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/ip-pools", client.baseurl,);
+            let __progenitor_url = format!("{}/system/ip-pools", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -33499,7 +33950,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -33508,7 +33959,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -33584,14 +34038,14 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_create`]: super::ClientSystemExt::ip_pool_create
     #[derive(Debug, Clone)]
     pub struct IpPoolCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::IpPoolCreate, String>,
     }
 
     impl<'a> IpPoolCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::IpPoolCreate::default()),
             }
         }
@@ -33617,12 +34071,15 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/ip-pools`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::IpPoolCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/ip-pools", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/system/ip-pools", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -33631,7 +34088,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -33651,14 +34111,14 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_view`]: super::ClientSystemExt::ip_pool_view
     #[derive(Debug, Clone)]
     pub struct IpPoolView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         pool_name: Result<types::Name, String>,
     }
 
     impl<'a> IpPoolView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
             }
         }
@@ -33675,14 +34135,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/ip-pools/{pool_name}`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-            let Self { client, pool_name } = self;
+            let Self {
+                __progenitor_client,
+                pool_name,
+            } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/ip-pools/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -33690,7 +34153,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -33710,7 +34176,7 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_update`]: super::ClientSystemExt::ip_pool_update
     #[derive(Debug, Clone)]
     pub struct IpPoolUpdate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         pool_name: Result<types::Name, String>,
         body: Result<types::builder::IpPoolUpdate, String>,
     }
@@ -33718,7 +34184,7 @@ pub mod builder {
     impl<'a> IpPoolUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 body: Ok(types::builder::IpPoolUpdate::default()),
             }
@@ -33756,7 +34222,7 @@ pub mod builder {
         ///Sends a `PUT` request to `/system/ip-pools/{pool_name}`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 pool_name,
                 body,
             } = self;
@@ -33766,10 +34232,10 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/ip-pools/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -33778,7 +34244,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -33798,14 +34267,14 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_delete`]: super::ClientSystemExt::ip_pool_delete
     #[derive(Debug, Clone)]
     pub struct IpPoolDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         pool_name: Result<types::Name, String>,
     }
 
     impl<'a> IpPoolDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
             }
         }
@@ -33822,14 +34291,17 @@ pub mod builder {
 
         ///Sends a `DELETE` request to `/system/ip-pools/{pool_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { client, pool_name } = self;
+            let Self {
+                __progenitor_client,
+                pool_name,
+            } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/ip-pools/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -33837,7 +34309,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -33857,7 +34332,7 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_range_list`]: super::ClientSystemExt::ip_pool_range_list
     #[derive(Debug, Clone)]
     pub struct IpPoolRangeList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         pool_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -33866,7 +34341,7 @@ pub mod builder {
     impl<'a> IpPoolRangeList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -33909,7 +34384,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 pool_name,
                 limit,
                 page_token,
@@ -33919,7 +34394,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/ip-pools/{}/ranges",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(2usize);
@@ -33929,7 +34404,7 @@ pub mod builder {
             if let Some(v) = &page_token {
                 __progenitor_query.push(("page_token", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -33938,7 +34413,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -34013,7 +34491,7 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_range_add`]: super::ClientSystemExt::ip_pool_range_add
     #[derive(Debug, Clone)]
     pub struct IpPoolRangeAdd<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         pool_name: Result<types::Name, String>,
         body: Result<types::IpRange, String>,
     }
@@ -34021,7 +34499,7 @@ pub mod builder {
     impl<'a> IpPoolRangeAdd<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
@@ -34050,7 +34528,7 @@ pub mod builder {
         ///Sends a `POST` request to `/system/ip-pools/{pool_name}/ranges/add`
         pub async fn send(self) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 pool_name,
                 body,
             } = self;
@@ -34058,10 +34536,10 @@ pub mod builder {
             let body = body.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/ip-pools/{}/ranges/add",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -34070,7 +34548,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -34090,7 +34571,7 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_range_remove`]: super::ClientSystemExt::ip_pool_range_remove
     #[derive(Debug, Clone)]
     pub struct IpPoolRangeRemove<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         pool_name: Result<types::Name, String>,
         body: Result<types::IpRange, String>,
     }
@@ -34098,7 +34579,7 @@ pub mod builder {
     impl<'a> IpPoolRangeRemove<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
@@ -34128,7 +34609,7 @@ pub mod builder {
         /// `/system/ip-pools/{pool_name}/ranges/remove`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 pool_name,
                 body,
             } = self;
@@ -34136,10 +34617,10 @@ pub mod builder {
             let body = body.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/ip-pools/{}/ranges/remove",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -34148,7 +34629,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -34168,19 +34652,24 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_service_view`]: super::ClientSystemExt::ip_pool_service_view
     #[derive(Debug, Clone)]
     pub struct IpPoolServiceView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> IpPoolServiceView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `GET` request to `/system/ip-pools-service`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/system/ip-pools-service", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url =
+                format!("{}/system/ip-pools-service", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -34188,7 +34677,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -34208,7 +34700,7 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_service_range_list`]: super::ClientSystemExt::ip_pool_service_range_list
     #[derive(Debug, Clone)]
     pub struct IpPoolServiceRangeList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
     }
@@ -34216,7 +34708,7 @@ pub mod builder {
     impl<'a> IpPoolServiceRangeList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
             }
@@ -34248,13 +34740,16 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/ip-pools-service/ranges", client.baseurl,);
+            let __progenitor_url = format!(
+                "{}/system/ip-pools-service/ranges",
+                __progenitor_client.baseurl,
+            );
             let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -34262,7 +34757,7 @@ pub mod builder {
             if let Some(v) = &page_token {
                 __progenitor_query.push(("page_token", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -34271,7 +34766,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -34346,14 +34844,14 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_service_range_add`]: super::ClientSystemExt::ip_pool_service_range_add
     #[derive(Debug, Clone)]
     pub struct IpPoolServiceRangeAdd<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::IpRange, String>,
     }
 
     impl<'a> IpPoolServiceRangeAdd<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -34370,11 +34868,16 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/ip-pools-service/ranges/add`
         pub async fn send(self) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let __progenitor_url =
-                format!("{}/system/ip-pools-service/ranges/add", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!(
+                "{}/system/ip-pools-service/ranges/add",
+                __progenitor_client.baseurl,
+            );
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -34383,7 +34886,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -34403,14 +34909,14 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_service_range_remove`]: super::ClientSystemExt::ip_pool_service_range_remove
     #[derive(Debug, Clone)]
     pub struct IpPoolServiceRangeRemove<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::IpRange, String>,
     }
 
     impl<'a> IpPoolServiceRangeRemove<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -34427,11 +34933,16 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/ip-pools-service/ranges/remove`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let __progenitor_url =
-                format!("{}/system/ip-pools-service/ranges/remove", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!(
+                "{}/system/ip-pools-service/ranges/remove",
+                __progenitor_client.baseurl,
+            );
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -34440,7 +34951,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -34460,7 +34974,7 @@ pub mod builder {
     ///[`ClientSystemExt::system_metric`]: super::ClientSystemExt::system_metric
     #[derive(Debug, Clone)]
     pub struct SystemMetric<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         metric_name: Result<types::SystemMetricName, String>,
         end_time: Result<Option<chrono::DateTime<chrono::offset::Utc>>, String>,
         id: Result<uuid::Uuid, String>,
@@ -34472,7 +34986,7 @@ pub mod builder {
     impl<'a> SystemMetric<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 metric_name: Err("metric_name was not initialized".to_string()),
                 end_time: Ok(None),
                 id: Err("id was not initialized".to_string()),
@@ -34551,7 +35065,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::MeasurementResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 metric_name,
                 end_time,
                 id,
@@ -34567,7 +35081,7 @@ pub mod builder {
             let start_time = start_time.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/metrics/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&metric_name.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(5usize);
@@ -34584,7 +35098,7 @@ pub mod builder {
             if let Some(v) = &start_time {
                 __progenitor_query.push(("start_time", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -34593,7 +35107,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -34613,21 +35130,25 @@ pub mod builder {
     ///[`ClientPolicyExt::system_policy_view`]: super::ClientPolicyExt::system_policy_view
     #[derive(Debug, Clone)]
     pub struct SystemPolicyView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> SystemPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `GET` request to `/system/policy`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/system/policy", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url = format!("{}/system/policy", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -34635,7 +35156,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -34655,14 +35179,14 @@ pub mod builder {
     ///[`ClientPolicyExt::system_policy_update`]: super::ClientPolicyExt::system_policy_update
     #[derive(Debug, Clone)]
     pub struct SystemPolicyUpdate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::FleetRolePolicy, String>,
     }
 
     impl<'a> SystemPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::FleetRolePolicy::default()),
             }
         }
@@ -34690,12 +35214,15 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::FleetRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/policy", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/system/policy", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -34704,7 +35231,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -34724,7 +35254,7 @@ pub mod builder {
     ///[`ClientSystemExt::saga_list`]: super::ClientSystemExt::saga_list
     #[derive(Debug, Clone)]
     pub struct SagaList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -34733,7 +35263,7 @@ pub mod builder {
     impl<'a> SagaList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -34777,7 +35307,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SagaResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -34785,7 +35315,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/sagas", client.baseurl,);
+            let __progenitor_url = format!("{}/system/sagas", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -34796,7 +35326,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -34805,7 +35335,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -34881,14 +35414,14 @@ pub mod builder {
     ///[`ClientSystemExt::saga_view`]: super::ClientSystemExt::saga_view
     #[derive(Debug, Clone)]
     pub struct SagaView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         saga_id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SagaView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 saga_id: Err("saga_id was not initialized".to_string()),
             }
         }
@@ -34905,14 +35438,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/sagas/{saga_id}`
         pub async fn send(self) -> Result<ResponseValue<types::Saga>, Error<types::Error>> {
-            let Self { client, saga_id } = self;
+            let Self {
+                __progenitor_client,
+                saga_id,
+            } = self;
             let saga_id = saga_id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/sagas/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&saga_id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -34920,7 +35456,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -34940,7 +35479,7 @@ pub mod builder {
     ///[`ClientSystemExt::silo_list`]: super::ClientSystemExt::silo_list
     #[derive(Debug, Clone)]
     pub struct SiloList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameOrIdSortMode>, String>,
@@ -34949,7 +35488,7 @@ pub mod builder {
     impl<'a> SiloList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -34993,7 +35532,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SiloResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -35001,7 +35540,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/silos", client.baseurl,);
+            let __progenitor_url = format!("{}/system/silos", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -35012,7 +35551,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -35021,7 +35560,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -35097,14 +35639,14 @@ pub mod builder {
     ///[`ClientSystemExt::silo_create`]: super::ClientSystemExt::silo_create
     #[derive(Debug, Clone)]
     pub struct SiloCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::SiloCreate, String>,
     }
 
     impl<'a> SiloCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::SiloCreate::default()),
             }
         }
@@ -35130,12 +35672,15 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/silos`
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SiloCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/silos", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/system/silos", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -35144,7 +35689,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -35164,14 +35712,14 @@ pub mod builder {
     ///[`ClientSystemExt::silo_view`]: super::ClientSystemExt::silo_view
     #[derive(Debug, Clone)]
     pub struct SiloView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
     }
 
     impl<'a> SiloView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
@@ -35188,14 +35736,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/silos/{silo_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-            let Self { client, silo_name } = self;
+            let Self {
+                __progenitor_client,
+                silo_name,
+            } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/silos/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -35203,7 +35754,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -35223,14 +35777,14 @@ pub mod builder {
     ///[`ClientSystemExt::silo_delete`]: super::ClientSystemExt::silo_delete
     #[derive(Debug, Clone)]
     pub struct SiloDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
     }
 
     impl<'a> SiloDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
@@ -35247,14 +35801,17 @@ pub mod builder {
 
         ///Sends a `DELETE` request to `/system/silos/{silo_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { client, silo_name } = self;
+            let Self {
+                __progenitor_client,
+                silo_name,
+            } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/silos/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -35262,7 +35819,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -35282,7 +35842,7 @@ pub mod builder {
     ///[`ClientSystemExt::silo_identity_provider_list`]: super::ClientSystemExt::silo_identity_provider_list
     #[derive(Debug, Clone)]
     pub struct SiloIdentityProviderList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -35292,7 +35852,7 @@ pub mod builder {
     impl<'a> SiloIdentityProviderList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -35349,7 +35909,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::IdentityProviderResultsPage>, Error<types::Error>>
         {
             let Self {
-                client,
+                __progenitor_client,
                 silo_name,
                 limit,
                 page_token,
@@ -35361,7 +35921,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/silos/{}/identity-providers",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(3usize);
@@ -35374,7 +35934,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -35383,7 +35943,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -35460,7 +36023,7 @@ pub mod builder {
     ///[`ClientSystemExt::local_idp_user_create`]: super::ClientSystemExt::local_idp_user_create
     #[derive(Debug, Clone)]
     pub struct LocalIdpUserCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         body: Result<types::builder::UserCreate, String>,
     }
@@ -35468,7 +36031,7 @@ pub mod builder {
     impl<'a> LocalIdpUserCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(types::builder::UserCreate::default()),
             }
@@ -35507,7 +36070,7 @@ pub mod builder {
         /// `/system/silos/{silo_name}/identity-providers/local/users`
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 silo_name,
                 body,
             } = self;
@@ -35517,10 +36080,10 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/silos/{}/identity-providers/local/users",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -35529,7 +36092,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -35549,7 +36115,7 @@ pub mod builder {
     ///[`ClientSystemExt::local_idp_user_delete`]: super::ClientSystemExt::local_idp_user_delete
     #[derive(Debug, Clone)]
     pub struct LocalIdpUserDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         user_id: Result<uuid::Uuid, String>,
     }
@@ -35557,7 +36123,7 @@ pub mod builder {
     impl<'a> LocalIdpUserDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 user_id: Err("user_id was not initialized".to_string()),
             }
@@ -35587,7 +36153,7 @@ pub mod builder {
         /// `/system/silos/{silo_name}/identity-providers/local/users/{user_id}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 silo_name,
                 user_id,
             } = self;
@@ -35595,11 +36161,11 @@ pub mod builder {
             let user_id = user_id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/silos/{}/identity-providers/local/users/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -35607,7 +36173,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -35627,7 +36196,7 @@ pub mod builder {
     ///[`ClientSystemExt::local_idp_user_set_password`]: super::ClientSystemExt::local_idp_user_set_password
     #[derive(Debug, Clone)]
     pub struct LocalIdpUserSetPassword<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         user_id: Result<uuid::Uuid, String>,
         body: Result<types::UserPassword, String>,
@@ -35636,7 +36205,7 @@ pub mod builder {
     impl<'a> LocalIdpUserSetPassword<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 user_id: Err("user_id was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
@@ -35678,7 +36247,7 @@ pub mod builder {
         /// set-password`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 silo_name,
                 user_id,
                 body,
@@ -35688,11 +36257,11 @@ pub mod builder {
             let body = body.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/silos/{}/identity-providers/local/users/{}/set-password",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -35701,7 +36270,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -35721,7 +36293,7 @@ pub mod builder {
     ///[`ClientSystemExt::saml_identity_provider_create`]: super::ClientSystemExt::saml_identity_provider_create
     #[derive(Debug, Clone)]
     pub struct SamlIdentityProviderCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         body: Result<types::builder::SamlIdentityProviderCreate, String>,
     }
@@ -35729,7 +36301,7 @@ pub mod builder {
     impl<'a> SamlIdentityProviderCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(types::builder::SamlIdentityProviderCreate::default()),
             }
@@ -35771,7 +36343,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SamlIdentityProvider>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 silo_name,
                 body,
             } = self;
@@ -35781,10 +36353,10 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/silos/{}/identity-providers/saml",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -35793,7 +36365,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -35813,7 +36388,7 @@ pub mod builder {
     ///[`ClientSystemExt::saml_identity_provider_view`]: super::ClientSystemExt::saml_identity_provider_view
     #[derive(Debug, Clone)]
     pub struct SamlIdentityProviderView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         provider_name: Result<types::Name, String>,
     }
@@ -35821,7 +36396,7 @@ pub mod builder {
     impl<'a> SamlIdentityProviderView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 provider_name: Err("provider_name was not initialized".to_string()),
             }
@@ -35853,7 +36428,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SamlIdentityProvider>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 silo_name,
                 provider_name,
             } = self;
@@ -35861,11 +36436,11 @@ pub mod builder {
             let provider_name = provider_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/silos/{}/identity-providers/saml/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -35873,7 +36448,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -35893,14 +36471,14 @@ pub mod builder {
     ///[`ClientSystemExt::silo_policy_view`]: super::ClientSystemExt::silo_policy_view
     #[derive(Debug, Clone)]
     pub struct SiloPolicyView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
     }
 
     impl<'a> SiloPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
@@ -35919,14 +36497,17 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-            let Self { client, silo_name } = self;
+            let Self {
+                __progenitor_client,
+                silo_name,
+            } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/silos/{}/policy",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -35934,7 +36515,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -35954,7 +36538,7 @@ pub mod builder {
     ///[`ClientSystemExt::silo_policy_update`]: super::ClientSystemExt::silo_policy_update
     #[derive(Debug, Clone)]
     pub struct SiloPolicyUpdate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         body: Result<types::builder::SiloRolePolicy, String>,
     }
@@ -35962,7 +36546,7 @@ pub mod builder {
     impl<'a> SiloPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(types::builder::SiloRolePolicy::default()),
             }
@@ -36002,7 +36586,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 silo_name,
                 body,
             } = self;
@@ -36012,10 +36596,10 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/silos/{}/policy",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -36024,7 +36608,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -36044,7 +36631,7 @@ pub mod builder {
     ///[`ClientSystemExt::silo_users_list`]: super::ClientSystemExt::silo_users_list
     #[derive(Debug, Clone)]
     pub struct SiloUsersList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -36054,7 +36641,7 @@ pub mod builder {
     impl<'a> SiloUsersList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -36109,7 +36696,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 silo_name,
                 limit,
                 page_token,
@@ -36121,7 +36708,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/silos/{}/users/all",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(3usize);
@@ -36134,7 +36721,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -36143,7 +36730,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -36219,7 +36809,7 @@ pub mod builder {
     ///[`ClientSystemExt::silo_user_view`]: super::ClientSystemExt::silo_user_view
     #[derive(Debug, Clone)]
     pub struct SiloUserView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         user_id: Result<uuid::Uuid, String>,
     }
@@ -36227,7 +36817,7 @@ pub mod builder {
     impl<'a> SiloUserView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 user_id: Err("user_id was not initialized".to_string()),
             }
@@ -36257,7 +36847,7 @@ pub mod builder {
         /// `/system/silos/{silo_name}/users/id/{user_id}`
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 silo_name,
                 user_id,
             } = self;
@@ -36265,11 +36855,11 @@ pub mod builder {
             let user_id = user_id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/silos/{}/users/id/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -36277,7 +36867,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -36297,7 +36890,7 @@ pub mod builder {
     ///[`ClientSystemExt::system_user_list`]: super::ClientSystemExt::system_user_list
     #[derive(Debug, Clone)]
     pub struct SystemUserList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameSortMode>, String>,
@@ -36306,7 +36899,7 @@ pub mod builder {
     impl<'a> SystemUserList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -36350,7 +36943,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::UserBuiltinResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -36358,7 +36951,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/user", client.baseurl,);
+            let __progenitor_url = format!("{}/system/user", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -36369,7 +36962,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -36378,7 +36971,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -36454,14 +37050,14 @@ pub mod builder {
     ///[`ClientSystemExt::system_user_view`]: super::ClientSystemExt::system_user_view
     #[derive(Debug, Clone)]
     pub struct SystemUserView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         user_name: Result<types::Name, String>,
     }
 
     impl<'a> SystemUserView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 user_name: Err("user_name was not initialized".to_string()),
             }
         }
@@ -36478,14 +37074,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/user/{user_name}`
         pub async fn send(self) -> Result<ResponseValue<types::UserBuiltin>, Error<types::Error>> {
-            let Self { client, user_name } = self;
+            let Self {
+                __progenitor_client,
+                user_name,
+            } = self;
             let user_name = user_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/user/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&user_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -36493,7 +37092,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -36513,7 +37115,7 @@ pub mod builder {
     ///[`ClientMetricsExt::timeseries_schema_get`]: super::ClientMetricsExt::timeseries_schema_get
     #[derive(Debug, Clone)]
     pub struct TimeseriesSchemaGet<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
     }
@@ -36521,7 +37123,7 @@ pub mod builder {
     impl<'a> TimeseriesSchemaGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
             }
@@ -36554,13 +37156,13 @@ pub mod builder {
         ) -> Result<ResponseValue<types::TimeseriesSchemaResultsPage>, Error<types::Error>>
         {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/timeseries/schema", client.baseurl,);
+            let __progenitor_url = format!("{}/timeseries/schema", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -36568,7 +37170,7 @@ pub mod builder {
             if let Some(v) = &page_token {
                 __progenitor_query.push(("page_token", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -36577,7 +37179,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -36652,7 +37257,7 @@ pub mod builder {
     ///[`ClientSilosExt::user_list`]: super::ClientSilosExt::user_list
     #[derive(Debug, Clone)]
     pub struct UserList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -36661,7 +37266,7 @@ pub mod builder {
     impl<'a> UserList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -36705,7 +37310,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -36713,7 +37318,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/users", client.baseurl,);
+            let __progenitor_url = format!("{}/users", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -36724,7 +37329,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -36733,7 +37338,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -36809,7 +37417,7 @@ pub mod builder {
     ///[`ClientDisksExt::disk_list_v1`]: super::ClientDisksExt::disk_list_v1
     #[derive(Debug, Clone)]
     pub struct DiskListV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         organization: Result<Option<types::NameOrId>, String>,
         page_token: Result<Option<String>, String>,
@@ -36820,7 +37428,7 @@ pub mod builder {
     impl<'a> DiskListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 organization: Ok(None),
                 page_token: Ok(None),
@@ -36888,7 +37496,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 organization,
                 page_token,
@@ -36900,7 +37508,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/disks", client.baseurl,);
+            let __progenitor_url = format!("{}/v1/disks", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(5usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -36917,7 +37525,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -36926,7 +37534,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -37004,7 +37615,7 @@ pub mod builder {
     ///[`ClientDisksExt::disk_create_v1`]: super::ClientDisksExt::disk_create_v1
     #[derive(Debug, Clone)]
     pub struct DiskCreateV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<types::NameOrId, String>,
         body: Result<types::builder::DiskCreate, String>,
@@ -37013,7 +37624,7 @@ pub mod builder {
     impl<'a> DiskCreateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization: Ok(None),
                 project: Err("project was not initialized".to_string()),
                 body: Ok(types::builder::DiskCreate::default()),
@@ -37063,7 +37674,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/disks`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization,
                 project,
                 body,
@@ -37073,13 +37684,13 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/disks", client.baseurl,);
+            let __progenitor_url = format!("{}/v1/disks", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
                 __progenitor_query.push(("organization", v.to_string()));
             }
             __progenitor_query.push(("project", project.to_string()));
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -37089,7 +37700,10 @@ pub mod builder {
                 .json(&body)
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -37109,7 +37723,7 @@ pub mod builder {
     ///[`ClientDisksExt::disk_view_v1`]: super::ClientDisksExt::disk_view_v1
     #[derive(Debug, Clone)]
     pub struct DiskViewV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         disk: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -37118,7 +37732,7 @@ pub mod builder {
     impl<'a> DiskViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 disk: Err("disk was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -37160,7 +37774,7 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/disks/{disk}`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 disk,
                 organization,
                 project,
@@ -37170,7 +37784,7 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/disks/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&disk.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(2usize);
@@ -37180,7 +37794,7 @@ pub mod builder {
             if let Some(v) = &project {
                 __progenitor_query.push(("project", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -37189,7 +37803,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -37209,7 +37826,7 @@ pub mod builder {
     ///[`ClientDisksExt::disk_delete_v1`]: super::ClientDisksExt::disk_delete_v1
     #[derive(Debug, Clone)]
     pub struct DiskDeleteV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         disk: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -37218,7 +37835,7 @@ pub mod builder {
     impl<'a> DiskDeleteV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 disk: Err("disk was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -37260,7 +37877,7 @@ pub mod builder {
         ///Sends a `DELETE` request to `/v1/disks/{disk}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 disk,
                 organization,
                 project,
@@ -37270,7 +37887,7 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/disks/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&disk.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(2usize);
@@ -37280,7 +37897,7 @@ pub mod builder {
             if let Some(v) = &project {
                 __progenitor_query.push(("project", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -37289,7 +37906,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -37309,7 +37929,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_list_v1`]: super::ClientInstancesExt::instance_list_v1
     #[derive(Debug, Clone)]
     pub struct InstanceListV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         organization: Result<Option<types::NameOrId>, String>,
         page_token: Result<Option<String>, String>,
@@ -37320,7 +37940,7 @@ pub mod builder {
     impl<'a> InstanceListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 organization: Ok(None),
                 page_token: Ok(None),
@@ -37388,7 +38008,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 organization,
                 page_token,
@@ -37400,7 +38020,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/instances", client.baseurl,);
+            let __progenitor_url = format!("{}/v1/instances", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(5usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -37417,7 +38037,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -37426,7 +38046,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -37504,7 +38127,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_create_v1`]: super::ClientInstancesExt::instance_create_v1
     #[derive(Debug, Clone)]
     pub struct InstanceCreateV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<types::NameOrId, String>,
         body: Result<types::builder::InstanceCreate, String>,
@@ -37513,7 +38136,7 @@ pub mod builder {
     impl<'a> InstanceCreateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization: Ok(None),
                 project: Err("project was not initialized".to_string()),
                 body: Ok(types::builder::InstanceCreate::default()),
@@ -37563,7 +38186,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization,
                 project,
                 body,
@@ -37573,13 +38196,13 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/instances", client.baseurl,);
+            let __progenitor_url = format!("{}/v1/instances", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
                 __progenitor_query.push(("organization", v.to_string()));
             }
             __progenitor_query.push(("project", project.to_string()));
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -37589,7 +38212,10 @@ pub mod builder {
                 .json(&body)
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -37609,7 +38235,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_view_v1`]: super::ClientInstancesExt::instance_view_v1
     #[derive(Debug, Clone)]
     pub struct InstanceViewV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -37618,7 +38244,7 @@ pub mod builder {
     impl<'a> InstanceViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -37660,7 +38286,7 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/instances/{instance}`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 instance,
                 organization,
                 project,
@@ -37670,7 +38296,7 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/instances/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&instance.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(2usize);
@@ -37680,7 +38306,7 @@ pub mod builder {
             if let Some(v) = &project {
                 __progenitor_query.push(("project", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -37689,7 +38315,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -37709,7 +38338,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_delete_v1`]: super::ClientInstancesExt::instance_delete_v1
     #[derive(Debug, Clone)]
     pub struct InstanceDeleteV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -37718,7 +38347,7 @@ pub mod builder {
     impl<'a> InstanceDeleteV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -37760,7 +38389,7 @@ pub mod builder {
         ///Sends a `DELETE` request to `/v1/instances/{instance}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 instance,
                 organization,
                 project,
@@ -37770,7 +38399,7 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/instances/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&instance.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(2usize);
@@ -37780,7 +38409,7 @@ pub mod builder {
             if let Some(v) = &project {
                 __progenitor_query.push(("project", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -37789,7 +38418,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -37809,7 +38441,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_disk_list_v1`]: super::ClientInstancesExt::instance_disk_list_v1
     #[derive(Debug, Clone)]
     pub struct InstanceDiskListV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         organization: Result<Option<types::NameOrId>, String>,
@@ -37821,7 +38453,7 @@ pub mod builder {
     impl<'a> InstanceDiskListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 instance: Err("instance was not initialized".to_string()),
                 limit: Ok(None),
                 organization: Ok(None),
@@ -37900,7 +38532,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 instance,
                 limit,
                 organization,
@@ -37916,7 +38548,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/instances/{}/disks",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&instance.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(5usize);
@@ -37935,7 +38567,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -37944,7 +38576,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -38022,7 +38657,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_disk_attach_v1`]: super::ClientInstancesExt::instance_disk_attach_v1
     #[derive(Debug, Clone)]
     pub struct InstanceDiskAttachV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38032,7 +38667,7 @@ pub mod builder {
     impl<'a> InstanceDiskAttachV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38094,7 +38729,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/disks/attach`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 instance,
                 organization,
                 project,
@@ -38108,7 +38743,7 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/instances/{}/disks/attach",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&instance.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(2usize);
@@ -38118,7 +38753,7 @@ pub mod builder {
             if let Some(v) = &project {
                 __progenitor_query.push(("project", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -38128,7 +38763,10 @@ pub mod builder {
                 .json(&body)
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 202u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -38148,7 +38786,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_disk_detach_v1`]: super::ClientInstancesExt::instance_disk_detach_v1
     #[derive(Debug, Clone)]
     pub struct InstanceDiskDetachV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38158,7 +38796,7 @@ pub mod builder {
     impl<'a> InstanceDiskDetachV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38220,7 +38858,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/disks/detach`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 instance,
                 organization,
                 project,
@@ -38234,7 +38872,7 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/instances/{}/disks/detach",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&instance.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(2usize);
@@ -38244,7 +38882,7 @@ pub mod builder {
             if let Some(v) = &project {
                 __progenitor_query.push(("project", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -38254,7 +38892,10 @@ pub mod builder {
                 .json(&body)
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 202u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -38274,7 +38915,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_migrate_v1`]: super::ClientInstancesExt::instance_migrate_v1
     #[derive(Debug, Clone)]
     pub struct InstanceMigrateV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38284,7 +38925,7 @@ pub mod builder {
     impl<'a> InstanceMigrateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38346,7 +38987,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/migrate`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 instance,
                 organization,
                 project,
@@ -38360,7 +39001,7 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/instances/{}/migrate",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&instance.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(2usize);
@@ -38370,7 +39011,7 @@ pub mod builder {
             if let Some(v) = &project {
                 __progenitor_query.push(("project", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -38380,7 +39021,10 @@ pub mod builder {
                 .json(&body)
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -38400,7 +39044,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_reboot_v1`]: super::ClientInstancesExt::instance_reboot_v1
     #[derive(Debug, Clone)]
     pub struct InstanceRebootV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38409,7 +39053,7 @@ pub mod builder {
     impl<'a> InstanceRebootV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38451,7 +39095,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/reboot`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 instance,
                 organization,
                 project,
@@ -38461,7 +39105,7 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/instances/{}/reboot",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&instance.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(2usize);
@@ -38471,7 +39115,7 @@ pub mod builder {
             if let Some(v) = &project {
                 __progenitor_query.push(("project", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -38480,7 +39124,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 202u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -38500,7 +39147,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_serial_console_v1`]: super::ClientInstancesExt::instance_serial_console_v1
     #[derive(Debug, Clone)]
     pub struct InstanceSerialConsoleV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         from_start: Result<Option<u64>, String>,
         max_bytes: Result<Option<u64>, String>,
@@ -38512,7 +39159,7 @@ pub mod builder {
     impl<'a> InstanceSerialConsoleV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 instance: Err("instance was not initialized".to_string()),
                 from_start: Ok(None),
                 max_bytes: Ok(None),
@@ -38592,7 +39239,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceSerialConsoleData>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 instance,
                 from_start,
                 max_bytes,
@@ -38608,7 +39255,7 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/instances/{}/serial-console",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&instance.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(5usize);
@@ -38627,7 +39274,7 @@ pub mod builder {
             if let Some(v) = &project {
                 __progenitor_query.push(("project", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -38636,7 +39283,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -38656,7 +39306,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_serial_console_stream_v1`]: super::ClientInstancesExt::instance_serial_console_stream_v1
     #[derive(Debug, Clone)]
     pub struct InstanceSerialConsoleStreamV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38665,7 +39315,7 @@ pub mod builder {
     impl<'a> InstanceSerialConsoleStreamV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38710,7 +39360,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
             let Self {
-                client,
+                __progenitor_client,
                 instance,
                 organization,
                 project,
@@ -38720,7 +39370,7 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/instances/{}/serial-console/stream",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&instance.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(2usize);
@@ -38730,7 +39380,7 @@ pub mod builder {
             if let Some(v) = &project {
                 __progenitor_query.push(("project", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .query(&__progenitor_query)
@@ -38745,7 +39395,10 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 101u16 => ResponseValue::upgrade(__progenitor_response).await,
@@ -38760,7 +39413,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_start_v1`]: super::ClientInstancesExt::instance_start_v1
     #[derive(Debug, Clone)]
     pub struct InstanceStartV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38769,7 +39422,7 @@ pub mod builder {
     impl<'a> InstanceStartV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38811,7 +39464,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/start`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 instance,
                 organization,
                 project,
@@ -38821,7 +39474,7 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/instances/{}/start",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&instance.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(2usize);
@@ -38831,7 +39484,7 @@ pub mod builder {
             if let Some(v) = &project {
                 __progenitor_query.push(("project", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -38840,7 +39493,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 202u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -38860,7 +39516,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_stop_v1`]: super::ClientInstancesExt::instance_stop_v1
     #[derive(Debug, Clone)]
     pub struct InstanceStopV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38869,7 +39525,7 @@ pub mod builder {
     impl<'a> InstanceStopV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38911,7 +39567,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/stop`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 instance,
                 organization,
                 project,
@@ -38921,7 +39577,7 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/instances/{}/stop",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&instance.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(2usize);
@@ -38931,7 +39587,7 @@ pub mod builder {
             if let Some(v) = &project {
                 __progenitor_query.push(("project", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -38940,7 +39596,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 202u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -38960,7 +39619,7 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_list_v1`]: super::ClientOrganizationsExt::organization_list_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationListV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameOrIdSortMode>, String>,
@@ -38969,7 +39628,7 @@ pub mod builder {
     impl<'a> OrganizationListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -39013,7 +39672,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -39021,7 +39680,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/organizations", client.baseurl,);
+            let __progenitor_url = format!("{}/v1/organizations", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -39032,7 +39691,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -39041,7 +39700,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -39117,14 +39779,14 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_create_v1`]: super::ClientOrganizationsExt::organization_create_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationCreateV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::OrganizationCreate, String>,
     }
 
     impl<'a> OrganizationCreateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::OrganizationCreate::default()),
             }
         }
@@ -39152,12 +39814,15 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/organizations`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/organizations", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/v1/organizations", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -39166,7 +39831,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -39186,14 +39854,14 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_view_v1`]: super::ClientOrganizationsExt::organization_view_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationViewV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
     }
 
     impl<'a> OrganizationViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization: Err("organization was not initialized".to_string()),
             }
         }
@@ -39211,16 +39879,16 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/organizations/{organization}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization,
             } = self;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/organizations/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -39228,7 +39896,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -39248,7 +39919,7 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_update_v1`]: super::ClientOrganizationsExt::organization_update_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationUpdateV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
         body: Result<types::builder::OrganizationUpdate, String>,
     }
@@ -39256,7 +39927,7 @@ pub mod builder {
     impl<'a> OrganizationUpdateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization: Err("organization was not initialized".to_string()),
                 body: Ok(types::builder::OrganizationUpdate::default()),
             }
@@ -39296,7 +39967,7 @@ pub mod builder {
         ///Sends a `PUT` request to `/v1/organizations/{organization}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization,
                 body,
             } = self;
@@ -39306,10 +39977,10 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/organizations/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -39318,7 +39989,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -39338,14 +40012,14 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_delete_v1`]: super::ClientOrganizationsExt::organization_delete_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationDeleteV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
     }
 
     impl<'a> OrganizationDeleteV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization: Err("organization was not initialized".to_string()),
             }
         }
@@ -39363,16 +40037,16 @@ pub mod builder {
         ///Sends a `DELETE` request to `/v1/organizations/{organization}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization,
             } = self;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/organizations/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -39380,7 +40054,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -39400,14 +40077,14 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_policy_view_v1`]: super::ClientOrganizationsExt::organization_policy_view_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationPolicyViewV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
     }
 
     impl<'a> OrganizationPolicyViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization: Err("organization was not initialized".to_string()),
             }
         }
@@ -39427,16 +40104,16 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization,
             } = self;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/organizations/{}/policy",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -39444,7 +40121,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -39464,7 +40144,7 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_policy_update_v1`]: super::ClientOrganizationsExt::organization_policy_update_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationPolicyUpdateV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
         body: Result<types::builder::OrganizationRolePolicy, String>,
     }
@@ -39472,7 +40152,7 @@ pub mod builder {
     impl<'a> OrganizationPolicyUpdateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization: Err("organization was not initialized".to_string()),
                 body: Ok(types::builder::OrganizationRolePolicy::default()),
             }
@@ -39514,7 +40194,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization,
                 body,
             } = self;
@@ -39524,10 +40204,10 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/organizations/{}/policy",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -39536,7 +40216,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -39556,7 +40239,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_list_v1`]: super::ClientProjectsExt::project_list_v1
     #[derive(Debug, Clone)]
     pub struct ProjectListV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         organization: Result<Option<types::NameOrId>, String>,
         page_token: Result<Option<String>, String>,
@@ -39566,7 +40249,7 @@ pub mod builder {
     impl<'a> ProjectListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 organization: Ok(None),
                 page_token: Ok(None),
@@ -39622,7 +40305,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 organization,
                 page_token,
@@ -39632,7 +40315,7 @@ pub mod builder {
             let organization = organization.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/projects", client.baseurl,);
+            let __progenitor_url = format!("{}/v1/projects", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(4usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -39646,7 +40329,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -39655,7 +40338,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -39732,7 +40418,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_create_v1`]: super::ClientProjectsExt::project_create_v1
     #[derive(Debug, Clone)]
     pub struct ProjectCreateV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
         body: Result<types::builder::ProjectCreate, String>,
     }
@@ -39740,7 +40426,7 @@ pub mod builder {
     impl<'a> ProjectCreateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization: Err("organization was not initialized".to_string()),
                 body: Ok(types::builder::ProjectCreate::default()),
             }
@@ -39778,7 +40464,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/projects`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization,
                 body,
             } = self;
@@ -39786,10 +40472,10 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/projects", client.baseurl,);
+            let __progenitor_url = format!("{}/v1/projects", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(1usize);
             __progenitor_query.push(("organization", organization.to_string()));
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -39799,7 +40485,10 @@ pub mod builder {
                 .json(&body)
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -39819,7 +40508,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_view_v1`]: super::ClientProjectsExt::project_view_v1
     #[derive(Debug, Clone)]
     pub struct ProjectViewV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
     }
@@ -39827,7 +40516,7 @@ pub mod builder {
     impl<'a> ProjectViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
             }
@@ -39857,7 +40546,7 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/projects/{project}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 project,
                 organization,
             } = self;
@@ -39865,14 +40554,14 @@ pub mod builder {
             let organization = organization.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/projects/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&project.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
                 __progenitor_query.push(("organization", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -39881,7 +40570,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -39901,7 +40593,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_update_v1`]: super::ClientProjectsExt::project_update_v1
     #[derive(Debug, Clone)]
     pub struct ProjectUpdateV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         body: Result<types::builder::ProjectUpdate, String>,
@@ -39910,7 +40602,7 @@ pub mod builder {
     impl<'a> ProjectUpdateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
                 body: Ok(types::builder::ProjectUpdate::default()),
@@ -39960,7 +40652,7 @@ pub mod builder {
         ///Sends a `PUT` request to `/v1/projects/{project}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 project,
                 organization,
                 body,
@@ -39972,14 +40664,14 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/projects/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&project.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
                 __progenitor_query.push(("organization", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -39989,7 +40681,10 @@ pub mod builder {
                 .json(&body)
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -40009,7 +40704,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_delete_v1`]: super::ClientProjectsExt::project_delete_v1
     #[derive(Debug, Clone)]
     pub struct ProjectDeleteV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
     }
@@ -40017,7 +40712,7 @@ pub mod builder {
     impl<'a> ProjectDeleteV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
             }
@@ -40047,7 +40742,7 @@ pub mod builder {
         ///Sends a `DELETE` request to `/v1/projects/{project}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 project,
                 organization,
             } = self;
@@ -40055,14 +40750,14 @@ pub mod builder {
             let organization = organization.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/projects/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&project.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
                 __progenitor_query.push(("organization", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -40071,7 +40766,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -40091,7 +40789,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_policy_view_v1`]: super::ClientProjectsExt::project_policy_view_v1
     #[derive(Debug, Clone)]
     pub struct ProjectPolicyViewV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
     }
@@ -40099,7 +40797,7 @@ pub mod builder {
     impl<'a> ProjectPolicyViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
             }
@@ -40131,7 +40829,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 project,
                 organization,
             } = self;
@@ -40139,14 +40837,14 @@ pub mod builder {
             let organization = organization.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/projects/{}/policy",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&project.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
                 __progenitor_query.push(("organization", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -40155,7 +40853,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -40175,7 +40876,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_policy_update_v1`]: super::ClientProjectsExt::project_policy_update_v1
     #[derive(Debug, Clone)]
     pub struct ProjectPolicyUpdateV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         body: Result<types::builder::ProjectRolePolicy, String>,
@@ -40184,7 +40885,7 @@ pub mod builder {
     impl<'a> ProjectPolicyUpdateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
                 body: Ok(types::builder::ProjectRolePolicy::default()),
@@ -40238,7 +40939,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 project,
                 organization,
                 body,
@@ -40250,14 +40951,14 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/projects/{}/policy",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&project.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
                 __progenitor_query.push(("organization", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -40267,7 +40968,10 @@ pub mod builder {
                 .json(&body)
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -40287,7 +40991,7 @@ pub mod builder {
     ///[`ClientSystemExt::system_component_version_list`]: super::ClientSystemExt::system_component_version_list
     #[derive(Debug, Clone)]
     pub struct SystemComponentVersionList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -40296,7 +41000,7 @@ pub mod builder {
     impl<'a> SystemComponentVersionList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -40341,7 +41045,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::UpdateableComponentResultsPage>, Error<types::Error>>
         {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -40349,7 +41053,10 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/system/update/components", client.baseurl,);
+            let __progenitor_url = format!(
+                "{}/v1/system/update/components",
+                __progenitor_client.baseurl,
+            );
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -40360,7 +41067,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -40369,7 +41076,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -40446,7 +41156,7 @@ pub mod builder {
     ///[`ClientSystemExt::update_deployments_list`]: super::ClientSystemExt::update_deployments_list
     #[derive(Debug, Clone)]
     pub struct UpdateDeploymentsList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -40455,7 +41165,7 @@ pub mod builder {
     impl<'a> UpdateDeploymentsList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -40500,7 +41210,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::UpdateDeploymentResultsPage>, Error<types::Error>>
         {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -40508,7 +41218,10 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/system/update/deployments", client.baseurl,);
+            let __progenitor_url = format!(
+                "{}/v1/system/update/deployments",
+                __progenitor_client.baseurl,
+            );
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -40519,7 +41232,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -40528,7 +41241,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -40604,14 +41320,14 @@ pub mod builder {
     ///[`ClientSystemExt::update_deployment_view`]: super::ClientSystemExt::update_deployment_view
     #[derive(Debug, Clone)]
     pub struct UpdateDeploymentView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> UpdateDeploymentView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -40630,14 +41346,17 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/system/update/deployments/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -40645,7 +41364,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -40665,19 +41387,24 @@ pub mod builder {
     ///[`ClientSystemExt::system_update_refresh`]: super::ClientSystemExt::system_update_refresh
     #[derive(Debug, Clone)]
     pub struct SystemUpdateRefresh<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> SystemUpdateRefresh<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `POST` request to `/v1/system/update/refresh`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/v1/system/update/refresh", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url =
+                format!("{}/v1/system/update/refresh", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -40685,7 +41412,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -40705,14 +41435,14 @@ pub mod builder {
     ///[`ClientSystemExt::system_update_start`]: super::ClientSystemExt::system_update_start
     #[derive(Debug, Clone)]
     pub struct SystemUpdateStart<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::SystemUpdateStart, String>,
     }
 
     impl<'a> SystemUpdateStart<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::SystemUpdateStart::default()),
             }
         }
@@ -40742,12 +41472,16 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SystemUpdateStart>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/system/update/start", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url =
+                format!("{}/v1/system/update/start", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -40756,7 +41490,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 202u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -40776,19 +41513,24 @@ pub mod builder {
     ///[`ClientSystemExt::system_update_stop`]: super::ClientSystemExt::system_update_stop
     #[derive(Debug, Clone)]
     pub struct SystemUpdateStop<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> SystemUpdateStop<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `POST` request to `/v1/system/update/stop`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/v1/system/update/stop", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url =
+                format!("{}/v1/system/update/stop", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -40796,7 +41538,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -40816,7 +41561,7 @@ pub mod builder {
     ///[`ClientSystemExt::system_update_list`]: super::ClientSystemExt::system_update_list
     #[derive(Debug, Clone)]
     pub struct SystemUpdateList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -40825,7 +41570,7 @@ pub mod builder {
     impl<'a> SystemUpdateList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -40869,7 +41614,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SystemUpdateResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -40877,7 +41622,8 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/system/update/updates", client.baseurl,);
+            let __progenitor_url =
+                format!("{}/v1/system/update/updates", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -40888,7 +41634,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -40897,7 +41643,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -40973,14 +41722,14 @@ pub mod builder {
     ///[`ClientSystemExt::system_update_view`]: super::ClientSystemExt::system_update_view
     #[derive(Debug, Clone)]
     pub struct SystemUpdateView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         version: Result<types::SemverVersion, String>,
     }
 
     impl<'a> SystemUpdateView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 version: Err("version was not initialized".to_string()),
             }
         }
@@ -40997,14 +41746,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/v1/system/update/updates/{version}`
         pub async fn send(self) -> Result<ResponseValue<types::SystemUpdate>, Error<types::Error>> {
-            let Self { client, version } = self;
+            let Self {
+                __progenitor_client,
+                version,
+            } = self;
             let version = version.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/system/update/updates/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&version.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -41012,7 +41764,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -41032,14 +41787,14 @@ pub mod builder {
     ///[`ClientSystemExt::system_update_components_list`]: super::ClientSystemExt::system_update_components_list
     #[derive(Debug, Clone)]
     pub struct SystemUpdateComponentsList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         version: Result<types::SemverVersion, String>,
     }
 
     impl<'a> SystemUpdateComponentsList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 version: Err("version was not initialized".to_string()),
             }
         }
@@ -41059,14 +41814,17 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::ComponentUpdateResultsPage>, Error<types::Error>> {
-            let Self { client, version } = self;
+            let Self {
+                __progenitor_client,
+                version,
+            } = self;
             let version = version.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/system/update/updates/{}/components",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&version.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -41074,7 +41832,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -41094,21 +41855,26 @@ pub mod builder {
     ///[`ClientSystemExt::system_version`]: super::ClientSystemExt::system_version
     #[derive(Debug, Clone)]
     pub struct SystemVersion<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> SystemVersion<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `GET` request to `/v1/system/update/version`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SystemVersion>, Error<types::Error>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/v1/system/update/version", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url =
+                format!("{}/v1/system/update/version", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -41116,7 +41882,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,

--- a/progenitor-impl/tests/output/nexus-builder.out
+++ b/progenitor-impl/tests/output/nexus-builder.out
@@ -20827,14 +20827,14 @@ pub mod builder {
     ///[`Client::disk_view_by_id`]: super::Client::disk_view_by_id
     #[derive(Debug, Clone)]
     pub struct DiskViewById<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> DiskViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -20851,14 +20851,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/disks/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/by-id/disks/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -20866,7 +20869,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -20886,14 +20892,14 @@ pub mod builder {
     ///[`Client::image_view_by_id`]: super::Client::image_view_by_id
     #[derive(Debug, Clone)]
     pub struct ImageViewById<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> ImageViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -20910,14 +20916,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/images/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/by-id/images/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -20925,7 +20934,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -20945,14 +20957,14 @@ pub mod builder {
     ///[`Client::instance_view_by_id`]: super::Client::instance_view_by_id
     #[derive(Debug, Clone)]
     pub struct InstanceViewById<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> InstanceViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -20969,14 +20981,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/instances/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/by-id/instances/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -20984,7 +20999,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -21004,14 +21022,14 @@ pub mod builder {
     ///[`Client::instance_network_interface_view_by_id`]: super::Client::instance_network_interface_view_by_id
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceViewById<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> InstanceNetworkInterfaceViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21030,14 +21048,17 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/by-id/network-interfaces/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -21045,7 +21066,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -21065,14 +21089,14 @@ pub mod builder {
     ///[`Client::organization_view_by_id`]: super::Client::organization_view_by_id
     #[derive(Debug, Clone)]
     pub struct OrganizationViewById<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> OrganizationViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21089,14 +21113,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/organizations/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/by-id/organizations/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -21104,7 +21131,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -21124,14 +21154,14 @@ pub mod builder {
     ///[`Client::project_view_by_id`]: super::Client::project_view_by_id
     #[derive(Debug, Clone)]
     pub struct ProjectViewById<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> ProjectViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21148,14 +21178,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/projects/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/by-id/projects/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -21163,7 +21196,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -21183,14 +21219,14 @@ pub mod builder {
     ///[`Client::snapshot_view_by_id`]: super::Client::snapshot_view_by_id
     #[derive(Debug, Clone)]
     pub struct SnapshotViewById<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SnapshotViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21207,14 +21243,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/snapshots/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/by-id/snapshots/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -21222,7 +21261,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -21242,14 +21284,14 @@ pub mod builder {
     ///[`Client::vpc_router_route_view_by_id`]: super::Client::vpc_router_route_view_by_id
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteViewById<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcRouterRouteViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21266,14 +21308,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/vpc-router-routes/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/by-id/vpc-router-routes/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -21281,7 +21326,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -21301,14 +21349,14 @@ pub mod builder {
     ///[`Client::vpc_router_view_by_id`]: super::Client::vpc_router_view_by_id
     #[derive(Debug, Clone)]
     pub struct VpcRouterViewById<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcRouterViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21325,14 +21373,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/vpc-routers/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/by-id/vpc-routers/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -21340,7 +21391,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -21360,14 +21414,14 @@ pub mod builder {
     ///[`Client::vpc_subnet_view_by_id`]: super::Client::vpc_subnet_view_by_id
     #[derive(Debug, Clone)]
     pub struct VpcSubnetViewById<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcSubnetViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21384,14 +21438,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/vpc-subnets/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/by-id/vpc-subnets/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -21399,7 +21456,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -21419,14 +21479,14 @@ pub mod builder {
     ///[`Client::vpc_view_by_id`]: super::Client::vpc_view_by_id
     #[derive(Debug, Clone)]
     pub struct VpcViewById<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21443,14 +21503,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/vpcs/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/by-id/vpcs/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -21458,7 +21521,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -21478,14 +21544,14 @@ pub mod builder {
     ///[`Client::device_auth_request`]: super::Client::device_auth_request
     #[derive(Debug, Clone)]
     pub struct DeviceAuthRequest<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::DeviceAuthRequest, String>,
     }
 
     impl<'a> DeviceAuthRequest<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::DeviceAuthRequest::default()),
             }
         }
@@ -21513,17 +21579,23 @@ pub mod builder {
 
         ///Sends a `POST` request to `/device/auth`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::DeviceAuthRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/device/auth", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/device/auth", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .form_urlencoded(&body)?
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
@@ -21539,14 +21611,14 @@ pub mod builder {
     ///[`Client::device_auth_confirm`]: super::Client::device_auth_confirm
     #[derive(Debug, Clone)]
     pub struct DeviceAuthConfirm<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::DeviceAuthVerify, String>,
     }
 
     impl<'a> DeviceAuthConfirm<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::DeviceAuthVerify::default()),
             }
         }
@@ -21574,12 +21646,15 @@ pub mod builder {
 
         ///Sends a `POST` request to `/device/confirm`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::DeviceAuthVerify>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/device/confirm", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/device/confirm", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -21588,7 +21663,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -21608,14 +21686,14 @@ pub mod builder {
     ///[`Client::device_access_token`]: super::Client::device_access_token
     #[derive(Debug, Clone)]
     pub struct DeviceAccessToken<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::DeviceAccessTokenRequest, String>,
     }
 
     impl<'a> DeviceAccessToken<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::DeviceAccessTokenRequest::default()),
             }
         }
@@ -21642,17 +21720,23 @@ pub mod builder {
 
         ///Sends a `POST` request to `/device/token`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::DeviceAccessTokenRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/device/token", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/device/token", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .form_urlencoded(&body)?
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
@@ -21668,7 +21752,7 @@ pub mod builder {
     ///[`Client::group_list`]: super::Client::group_list
     #[derive(Debug, Clone)]
     pub struct GroupList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -21677,7 +21761,7 @@ pub mod builder {
     impl<'a> GroupList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -21721,7 +21805,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -21729,7 +21813,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/groups", client.baseurl,);
+            let __progenitor_url = format!("{}/groups", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -21740,7 +21824,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -21749,7 +21833,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -21825,14 +21912,14 @@ pub mod builder {
     ///[`Client::login_spoof`]: super::Client::login_spoof
     #[derive(Debug, Clone)]
     pub struct LoginSpoof<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::SpoofLoginBody, String>,
     }
 
     impl<'a> LoginSpoof<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::SpoofLoginBody::default()),
             }
         }
@@ -21858,12 +21945,15 @@ pub mod builder {
 
         ///Sends a `POST` request to `/login`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SpoofLoginBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/login", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/login", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -21872,7 +21962,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -21892,7 +21985,7 @@ pub mod builder {
     ///[`Client::login_local`]: super::Client::login_local
     #[derive(Debug, Clone)]
     pub struct LoginLocal<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         body: Result<types::builder::UsernamePasswordCredentials, String>,
     }
@@ -21900,7 +21993,7 @@ pub mod builder {
     impl<'a> LoginLocal<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(types::builder::UsernamePasswordCredentials::default()),
             }
@@ -21939,7 +22032,7 @@ pub mod builder {
         ///Sends a `POST` request to `/login/{silo_name}/local`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 silo_name,
                 body,
             } = self;
@@ -21949,11 +22042,18 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/login/{}/local",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let __progenitor_request = client.client.post(__progenitor_url).json(&body).build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_request = __progenitor_client
+                .client
+                .post(__progenitor_url)
+                .json(&body)
+                .build()?;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
@@ -21973,7 +22073,7 @@ pub mod builder {
     ///[`Client::login_saml_begin`]: super::Client::login_saml_begin
     #[derive(Debug, Clone)]
     pub struct LoginSamlBegin<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         provider_name: Result<types::Name, String>,
     }
@@ -21981,7 +22081,7 @@ pub mod builder {
     impl<'a> LoginSamlBegin<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 provider_name: Err("provider_name was not initialized".to_string()),
             }
@@ -22010,7 +22110,7 @@ pub mod builder {
         ///Sends a `GET` request to `/login/{silo_name}/saml/{provider_name}`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 silo_name,
                 provider_name,
             } = self;
@@ -22018,12 +22118,15 @@ pub mod builder {
             let provider_name = provider_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/login/{}/saml/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let __progenitor_request = client.client.get(__progenitor_url).build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_request = __progenitor_client.client.get(__progenitor_url).build()?;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
@@ -22043,7 +22146,7 @@ pub mod builder {
     ///[`Client::login_saml`]: super::Client::login_saml
     #[derive(Debug)]
     pub struct LoginSaml<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         provider_name: Result<types::Name, String>,
         body: Result<reqwest::Body, String>,
@@ -22052,7 +22155,7 @@ pub mod builder {
     impl<'a> LoginSaml<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 provider_name: Err("provider_name was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
@@ -22092,7 +22195,7 @@ pub mod builder {
         ///Sends a `POST` request to `/login/{silo_name}/saml/{provider_name}`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 silo_name,
                 provider_name,
                 body,
@@ -22102,11 +22205,11 @@ pub mod builder {
             let body = body.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/login/{}/saml/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -22115,7 +22218,10 @@ pub mod builder {
                 )
                 .body(body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
@@ -22135,19 +22241,23 @@ pub mod builder {
     ///[`Client::logout`]: super::Client::logout
     #[derive(Debug, Clone)]
     pub struct Logout<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> Logout<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `POST` request to `/logout`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/logout", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url = format!("{}/logout", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -22155,7 +22265,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -22175,7 +22288,7 @@ pub mod builder {
     ///[`Client::organization_list`]: super::Client::organization_list
     #[derive(Debug, Clone)]
     pub struct OrganizationList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameOrIdSortMode>, String>,
@@ -22184,7 +22297,7 @@ pub mod builder {
     impl<'a> OrganizationList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -22228,7 +22341,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -22236,7 +22349,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/organizations", client.baseurl,);
+            let __progenitor_url = format!("{}/organizations", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -22247,7 +22360,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -22256,7 +22369,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -22332,14 +22448,14 @@ pub mod builder {
     ///[`Client::organization_create`]: super::Client::organization_create
     #[derive(Debug, Clone)]
     pub struct OrganizationCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::OrganizationCreate, String>,
     }
 
     impl<'a> OrganizationCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::OrganizationCreate::default()),
             }
         }
@@ -22367,12 +22483,15 @@ pub mod builder {
 
         ///Sends a `POST` request to `/organizations`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/organizations", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/organizations", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -22381,7 +22500,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -22401,14 +22523,14 @@ pub mod builder {
     ///[`Client::organization_view`]: super::Client::organization_view
     #[derive(Debug, Clone)]
     pub struct OrganizationView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
     }
 
     impl<'a> OrganizationView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
@@ -22426,16 +22548,16 @@ pub mod builder {
         ///Sends a `GET` request to `/organizations/{organization_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -22443,7 +22565,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -22463,7 +22588,7 @@ pub mod builder {
     ///[`Client::organization_update`]: super::Client::organization_update
     #[derive(Debug, Clone)]
     pub struct OrganizationUpdate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         body: Result<types::builder::OrganizationUpdate, String>,
     }
@@ -22471,7 +22596,7 @@ pub mod builder {
     impl<'a> OrganizationUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 body: Ok(types::builder::OrganizationUpdate::default()),
             }
@@ -22511,7 +22636,7 @@ pub mod builder {
         ///Sends a `PUT` request to `/organizations/{organization_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 body,
             } = self;
@@ -22521,10 +22646,10 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -22533,7 +22658,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -22553,14 +22681,14 @@ pub mod builder {
     ///[`Client::organization_delete`]: super::Client::organization_delete
     #[derive(Debug, Clone)]
     pub struct OrganizationDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
     }
 
     impl<'a> OrganizationDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
@@ -22578,16 +22706,16 @@ pub mod builder {
         ///Sends a `DELETE` request to `/organizations/{organization_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -22595,7 +22723,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -22615,14 +22746,14 @@ pub mod builder {
     ///[`Client::organization_policy_view`]: super::Client::organization_policy_view
     #[derive(Debug, Clone)]
     pub struct OrganizationPolicyView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
     }
 
     impl<'a> OrganizationPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
@@ -22642,16 +22773,16 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/policy",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -22659,7 +22790,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -22679,7 +22813,7 @@ pub mod builder {
     ///[`Client::organization_policy_update`]: super::Client::organization_policy_update
     #[derive(Debug, Clone)]
     pub struct OrganizationPolicyUpdate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         body: Result<types::builder::OrganizationRolePolicy, String>,
     }
@@ -22687,7 +22821,7 @@ pub mod builder {
     impl<'a> OrganizationPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 body: Ok(types::builder::OrganizationRolePolicy::default()),
             }
@@ -22729,7 +22863,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 body,
             } = self;
@@ -22739,10 +22873,10 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/policy",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -22751,7 +22885,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -22771,7 +22908,7 @@ pub mod builder {
     ///[`Client::project_list`]: super::Client::project_list
     #[derive(Debug, Clone)]
     pub struct ProjectList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -22781,7 +22918,7 @@ pub mod builder {
     impl<'a> ProjectList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -22837,7 +22974,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 limit,
                 page_token,
@@ -22849,7 +22986,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(3usize);
@@ -22862,7 +22999,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -22871,7 +23008,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -22948,7 +23088,7 @@ pub mod builder {
     ///[`Client::project_create`]: super::Client::project_create
     #[derive(Debug, Clone)]
     pub struct ProjectCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         body: Result<types::builder::ProjectCreate, String>,
     }
@@ -22956,7 +23096,7 @@ pub mod builder {
     impl<'a> ProjectCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 body: Ok(types::builder::ProjectCreate::default()),
             }
@@ -22995,7 +23135,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 body,
             } = self;
@@ -23005,10 +23145,10 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -23017,7 +23157,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -23037,7 +23180,7 @@ pub mod builder {
     ///[`Client::project_view`]: super::Client::project_view
     #[derive(Debug, Clone)]
     pub struct ProjectView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
     }
@@ -23045,7 +23188,7 @@ pub mod builder {
     impl<'a> ProjectView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
             }
@@ -23075,7 +23218,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
             } = self;
@@ -23083,11 +23226,11 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -23095,7 +23238,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -23115,7 +23261,7 @@ pub mod builder {
     ///[`Client::project_update`]: super::Client::project_update
     #[derive(Debug, Clone)]
     pub struct ProjectUpdate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::ProjectUpdate, String>,
@@ -23124,7 +23270,7 @@ pub mod builder {
     impl<'a> ProjectUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::ProjectUpdate::default()),
@@ -23174,7 +23320,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 body,
@@ -23186,11 +23332,11 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -23199,7 +23345,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -23219,7 +23368,7 @@ pub mod builder {
     ///[`Client::project_delete`]: super::Client::project_delete
     #[derive(Debug, Clone)]
     pub struct ProjectDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
     }
@@ -23227,7 +23376,7 @@ pub mod builder {
     impl<'a> ProjectDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
             }
@@ -23257,7 +23406,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
             } = self;
@@ -23265,11 +23414,11 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -23277,7 +23426,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -23297,7 +23449,7 @@ pub mod builder {
     ///[`Client::disk_list`]: super::Client::disk_list
     #[derive(Debug, Clone)]
     pub struct DiskList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -23308,7 +23460,7 @@ pub mod builder {
     impl<'a> DiskList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -23375,7 +23527,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 limit,
@@ -23389,7 +23541,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/disks",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
@@ -23403,7 +23555,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -23412,7 +23564,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -23489,7 +23644,7 @@ pub mod builder {
     ///[`Client::disk_create`]: super::Client::disk_create
     #[derive(Debug, Clone)]
     pub struct DiskCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::DiskCreate, String>,
@@ -23498,7 +23653,7 @@ pub mod builder {
     impl<'a> DiskCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::DiskCreate::default()),
@@ -23548,7 +23703,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}/disks`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 body,
@@ -23560,11 +23715,11 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/disks",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -23573,7 +23728,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -23593,7 +23751,7 @@ pub mod builder {
     ///[`Client::disk_view`]: super::Client::disk_view
     #[derive(Debug, Clone)]
     pub struct DiskView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         disk_name: Result<types::Name, String>,
@@ -23602,7 +23760,7 @@ pub mod builder {
     impl<'a> DiskView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 disk_name: Err("disk_name was not initialized".to_string()),
@@ -23644,7 +23802,7 @@ pub mod builder {
         /// {disk_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 disk_name,
@@ -23654,12 +23812,12 @@ pub mod builder {
             let disk_name = disk_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/disks/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -23667,7 +23825,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -23687,7 +23848,7 @@ pub mod builder {
     ///[`Client::disk_delete`]: super::Client::disk_delete
     #[derive(Debug, Clone)]
     pub struct DiskDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         disk_name: Result<types::Name, String>,
@@ -23696,7 +23857,7 @@ pub mod builder {
     impl<'a> DiskDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 disk_name: Err("disk_name was not initialized".to_string()),
@@ -23738,7 +23899,7 @@ pub mod builder {
         /// {disk_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 disk_name,
@@ -23748,12 +23909,12 @@ pub mod builder {
             let disk_name = disk_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/disks/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -23761,7 +23922,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -23781,7 +23945,7 @@ pub mod builder {
     ///[`Client::disk_metrics_list`]: super::Client::disk_metrics_list
     #[derive(Debug, Clone)]
     pub struct DiskMetricsList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         disk_name: Result<types::Name, String>,
@@ -23795,7 +23959,7 @@ pub mod builder {
     impl<'a> DiskMetricsList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 disk_name: Err("disk_name was not initialized".to_string()),
@@ -23898,7 +24062,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::MeasurementResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 disk_name,
@@ -23918,7 +24082,7 @@ pub mod builder {
             let start_time = start_time.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/disks/{}/metrics/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
@@ -23937,7 +24101,7 @@ pub mod builder {
             if let Some(v) = &start_time {
                 __progenitor_query.push(("start_time", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -23946,7 +24110,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -24025,7 +24192,7 @@ pub mod builder {
     ///[`Client::image_list`]: super::Client::image_list
     #[derive(Debug, Clone)]
     pub struct ImageList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -24036,7 +24203,7 @@ pub mod builder {
     impl<'a> ImageList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -24103,7 +24270,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ImageResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 limit,
@@ -24117,7 +24284,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/images",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
@@ -24131,7 +24298,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -24140,7 +24307,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -24217,7 +24387,7 @@ pub mod builder {
     ///[`Client::image_create`]: super::Client::image_create
     #[derive(Debug, Clone)]
     pub struct ImageCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::ImageCreate, String>,
@@ -24226,7 +24396,7 @@ pub mod builder {
     impl<'a> ImageCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::ImageCreate::default()),
@@ -24276,7 +24446,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}/images`
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 body,
@@ -24288,11 +24458,11 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/images",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -24301,7 +24471,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -24321,7 +24494,7 @@ pub mod builder {
     ///[`Client::image_view`]: super::Client::image_view
     #[derive(Debug, Clone)]
     pub struct ImageView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         image_name: Result<types::Name, String>,
@@ -24330,7 +24503,7 @@ pub mod builder {
     impl<'a> ImageView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 image_name: Err("image_name was not initialized".to_string()),
@@ -24372,7 +24545,7 @@ pub mod builder {
         /// {image_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 image_name,
@@ -24382,12 +24555,12 @@ pub mod builder {
             let image_name = image_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/images/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -24395,7 +24568,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -24415,7 +24591,7 @@ pub mod builder {
     ///[`Client::image_delete`]: super::Client::image_delete
     #[derive(Debug, Clone)]
     pub struct ImageDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         image_name: Result<types::Name, String>,
@@ -24424,7 +24600,7 @@ pub mod builder {
     impl<'a> ImageDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 image_name: Err("image_name was not initialized".to_string()),
@@ -24466,7 +24642,7 @@ pub mod builder {
         /// {image_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 image_name,
@@ -24476,12 +24652,12 @@ pub mod builder {
             let image_name = image_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/images/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -24489,7 +24665,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -24509,7 +24688,7 @@ pub mod builder {
     ///[`Client::instance_list`]: super::Client::instance_list
     #[derive(Debug, Clone)]
     pub struct InstanceList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -24520,7 +24699,7 @@ pub mod builder {
     impl<'a> InstanceList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -24588,7 +24767,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 limit,
@@ -24602,7 +24781,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
@@ -24616,7 +24795,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -24625,7 +24804,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -24703,7 +24885,7 @@ pub mod builder {
     ///[`Client::instance_create`]: super::Client::instance_create
     #[derive(Debug, Clone)]
     pub struct InstanceCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::InstanceCreate, String>,
@@ -24712,7 +24894,7 @@ pub mod builder {
     impl<'a> InstanceCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::InstanceCreate::default()),
@@ -24763,7 +24945,7 @@ pub mod builder {
         /// instances`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 body,
@@ -24775,11 +24957,11 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -24788,7 +24970,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -24808,7 +24993,7 @@ pub mod builder {
     ///[`Client::instance_view`]: super::Client::instance_view
     #[derive(Debug, Clone)]
     pub struct InstanceView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -24817,7 +25002,7 @@ pub mod builder {
     impl<'a> InstanceView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -24859,7 +25044,7 @@ pub mod builder {
         /// instances/{instance_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -24869,12 +25054,12 @@ pub mod builder {
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -24882,7 +25067,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -24902,7 +25090,7 @@ pub mod builder {
     ///[`Client::instance_delete`]: super::Client::instance_delete
     #[derive(Debug, Clone)]
     pub struct InstanceDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -24911,7 +25099,7 @@ pub mod builder {
     impl<'a> InstanceDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -24953,7 +25141,7 @@ pub mod builder {
         /// instances/{instance_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -24963,12 +25151,12 @@ pub mod builder {
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -24976,7 +25164,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -24996,7 +25187,7 @@ pub mod builder {
     ///[`Client::instance_disk_list`]: super::Client::instance_disk_list
     #[derive(Debug, Clone)]
     pub struct InstanceDiskList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25008,7 +25199,7 @@ pub mod builder {
     impl<'a> InstanceDiskList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25087,7 +25278,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25103,7 +25294,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
@@ -25118,7 +25309,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -25127,7 +25318,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -25205,7 +25399,7 @@ pub mod builder {
     ///[`Client::instance_disk_attach`]: super::Client::instance_disk_attach
     #[derive(Debug, Clone)]
     pub struct InstanceDiskAttach<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25215,7 +25409,7 @@ pub mod builder {
     impl<'a> InstanceDiskAttach<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25277,7 +25471,7 @@ pub mod builder {
         /// instances/{instance_name}/disks/attach`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25291,12 +25485,12 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks/attach",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -25305,7 +25499,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 202u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -25325,7 +25522,7 @@ pub mod builder {
     ///[`Client::instance_disk_detach`]: super::Client::instance_disk_detach
     #[derive(Debug, Clone)]
     pub struct InstanceDiskDetach<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25335,7 +25532,7 @@ pub mod builder {
     impl<'a> InstanceDiskDetach<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25397,7 +25594,7 @@ pub mod builder {
         /// instances/{instance_name}/disks/detach`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25411,12 +25608,12 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks/detach",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -25425,7 +25622,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 202u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -25445,7 +25645,7 @@ pub mod builder {
     ///[`Client::instance_external_ip_list`]: super::Client::instance_external_ip_list
     #[derive(Debug, Clone)]
     pub struct InstanceExternalIpList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25454,7 +25654,7 @@ pub mod builder {
     impl<'a> InstanceExternalIpList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25498,7 +25698,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ExternalIpResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25508,12 +25708,12 @@ pub mod builder {
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/external-ips",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -25521,7 +25721,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -25541,7 +25744,7 @@ pub mod builder {
     ///[`Client::instance_migrate`]: super::Client::instance_migrate
     #[derive(Debug, Clone)]
     pub struct InstanceMigrate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25551,7 +25754,7 @@ pub mod builder {
     impl<'a> InstanceMigrate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25613,7 +25816,7 @@ pub mod builder {
         /// instances/{instance_name}/migrate`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25627,12 +25830,12 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/migrate",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -25641,7 +25844,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -25661,7 +25867,7 @@ pub mod builder {
     ///[`Client::instance_network_interface_list`]: super::Client::instance_network_interface_list
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25673,7 +25879,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25753,7 +25959,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::NetworkInterfaceResultsPage>, Error<types::Error>>
         {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25769,7 +25975,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
@@ -25784,7 +25990,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -25793,7 +25999,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -25871,7 +26080,7 @@ pub mod builder {
     ///[`Client::instance_network_interface_create`]: super::Client::instance_network_interface_create
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25881,7 +26090,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25947,7 +26156,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25961,12 +26170,12 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -25975,7 +26184,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -25995,7 +26207,7 @@ pub mod builder {
     ///[`Client::instance_network_interface_view`]: super::Client::instance_network_interface_view
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26005,7 +26217,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26060,7 +26272,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26072,13 +26284,13 @@ pub mod builder {
             let interface_name = interface_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -26086,7 +26298,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -26106,7 +26321,7 @@ pub mod builder {
     ///[`Client::instance_network_interface_update`]: super::Client::instance_network_interface_update
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceUpdate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26117,7 +26332,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26194,7 +26409,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26210,13 +26425,13 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -26225,7 +26440,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -26245,7 +26463,7 @@ pub mod builder {
     ///[`Client::instance_network_interface_delete`]: super::Client::instance_network_interface_delete
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26255,7 +26473,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26308,7 +26526,7 @@ pub mod builder {
         /// instances/{instance_name}/network-interfaces/{interface_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26320,13 +26538,13 @@ pub mod builder {
             let interface_name = interface_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -26334,7 +26552,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -26354,7 +26575,7 @@ pub mod builder {
     ///[`Client::instance_reboot`]: super::Client::instance_reboot
     #[derive(Debug, Clone)]
     pub struct InstanceReboot<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26363,7 +26584,7 @@ pub mod builder {
     impl<'a> InstanceReboot<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26405,7 +26626,7 @@ pub mod builder {
         /// instances/{instance_name}/reboot`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26415,12 +26636,12 @@ pub mod builder {
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/reboot",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -26428,7 +26649,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 202u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -26448,7 +26672,7 @@ pub mod builder {
     ///[`Client::instance_serial_console`]: super::Client::instance_serial_console
     #[derive(Debug, Clone)]
     pub struct InstanceSerialConsole<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26460,7 +26684,7 @@ pub mod builder {
     impl<'a> InstanceSerialConsole<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26540,7 +26764,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceSerialConsoleData>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26556,7 +26780,7 @@ pub mod builder {
             let most_recent = most_recent.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/serial-console",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
@@ -26571,7 +26795,7 @@ pub mod builder {
             if let Some(v) = &most_recent {
                 __progenitor_query.push(("most_recent", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -26580,7 +26804,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -26600,7 +26827,7 @@ pub mod builder {
     ///[`Client::instance_serial_console_stream`]: super::Client::instance_serial_console_stream
     #[derive(Debug, Clone)]
     pub struct InstanceSerialConsoleStream<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26609,7 +26836,7 @@ pub mod builder {
     impl<'a> InstanceSerialConsoleStream<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26653,7 +26880,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26663,12 +26890,12 @@ pub mod builder {
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/serial-console/stream",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(reqwest::header::CONNECTION, "Upgrade")
@@ -26682,7 +26909,10 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 101u16 => ResponseValue::upgrade(__progenitor_response).await,
@@ -26697,7 +26927,7 @@ pub mod builder {
     ///[`Client::instance_start`]: super::Client::instance_start
     #[derive(Debug, Clone)]
     pub struct InstanceStart<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26706,7 +26936,7 @@ pub mod builder {
     impl<'a> InstanceStart<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26748,7 +26978,7 @@ pub mod builder {
         /// instances/{instance_name}/start`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26758,12 +26988,12 @@ pub mod builder {
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/start",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -26771,7 +27001,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 202u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -26791,7 +27024,7 @@ pub mod builder {
     ///[`Client::instance_stop`]: super::Client::instance_stop
     #[derive(Debug, Clone)]
     pub struct InstanceStop<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26800,7 +27033,7 @@ pub mod builder {
     impl<'a> InstanceStop<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26842,7 +27075,7 @@ pub mod builder {
         /// instances/{instance_name}/stop`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26852,12 +27085,12 @@ pub mod builder {
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/stop",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -26865,7 +27098,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 202u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -26885,7 +27121,7 @@ pub mod builder {
     ///[`Client::project_policy_view`]: super::Client::project_policy_view
     #[derive(Debug, Clone)]
     pub struct ProjectPolicyView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
     }
@@ -26893,7 +27129,7 @@ pub mod builder {
     impl<'a> ProjectPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
             }
@@ -26925,7 +27161,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
             } = self;
@@ -26933,11 +27169,11 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/policy",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -26945,7 +27181,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -26965,7 +27204,7 @@ pub mod builder {
     ///[`Client::project_policy_update`]: super::Client::project_policy_update
     #[derive(Debug, Clone)]
     pub struct ProjectPolicyUpdate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::ProjectRolePolicy, String>,
@@ -26974,7 +27213,7 @@ pub mod builder {
     impl<'a> ProjectPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::ProjectRolePolicy::default()),
@@ -27028,7 +27267,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 body,
@@ -27040,11 +27279,11 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/policy",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -27053,7 +27292,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -27073,7 +27315,7 @@ pub mod builder {
     ///[`Client::snapshot_list`]: super::Client::snapshot_list
     #[derive(Debug, Clone)]
     pub struct SnapshotList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -27084,7 +27326,7 @@ pub mod builder {
     impl<'a> SnapshotList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -27152,7 +27394,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SnapshotResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 limit,
@@ -27166,7 +27408,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/snapshots",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
@@ -27180,7 +27422,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -27189,7 +27431,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -27267,7 +27512,7 @@ pub mod builder {
     ///[`Client::snapshot_create`]: super::Client::snapshot_create
     #[derive(Debug, Clone)]
     pub struct SnapshotCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::SnapshotCreate, String>,
@@ -27276,7 +27521,7 @@ pub mod builder {
     impl<'a> SnapshotCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::SnapshotCreate::default()),
@@ -27327,7 +27572,7 @@ pub mod builder {
         /// snapshots`
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 body,
@@ -27339,11 +27584,11 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/snapshots",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -27352,7 +27597,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -27372,7 +27620,7 @@ pub mod builder {
     ///[`Client::snapshot_view`]: super::Client::snapshot_view
     #[derive(Debug, Clone)]
     pub struct SnapshotView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         snapshot_name: Result<types::Name, String>,
@@ -27381,7 +27629,7 @@ pub mod builder {
     impl<'a> SnapshotView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 snapshot_name: Err("snapshot_name was not initialized".to_string()),
@@ -27423,7 +27671,7 @@ pub mod builder {
         /// snapshots/{snapshot_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 snapshot_name,
@@ -27433,12 +27681,12 @@ pub mod builder {
             let snapshot_name = snapshot_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/snapshots/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -27446,7 +27694,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -27466,7 +27717,7 @@ pub mod builder {
     ///[`Client::snapshot_delete`]: super::Client::snapshot_delete
     #[derive(Debug, Clone)]
     pub struct SnapshotDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         snapshot_name: Result<types::Name, String>,
@@ -27475,7 +27726,7 @@ pub mod builder {
     impl<'a> SnapshotDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 snapshot_name: Err("snapshot_name was not initialized".to_string()),
@@ -27517,7 +27768,7 @@ pub mod builder {
         /// snapshots/{snapshot_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 snapshot_name,
@@ -27527,12 +27778,12 @@ pub mod builder {
             let snapshot_name = snapshot_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/snapshots/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -27540,7 +27791,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -27560,7 +27814,7 @@ pub mod builder {
     ///[`Client::vpc_list`]: super::Client::vpc_list
     #[derive(Debug, Clone)]
     pub struct VpcList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -27571,7 +27825,7 @@ pub mod builder {
     impl<'a> VpcList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -27638,7 +27892,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 limit,
@@ -27652,7 +27906,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
@@ -27666,7 +27920,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -27675,7 +27929,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -27752,7 +28009,7 @@ pub mod builder {
     ///[`Client::vpc_create`]: super::Client::vpc_create
     #[derive(Debug, Clone)]
     pub struct VpcCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::VpcCreate, String>,
@@ -27761,7 +28018,7 @@ pub mod builder {
     impl<'a> VpcCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::VpcCreate::default()),
@@ -27811,7 +28068,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs`
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 body,
@@ -27823,11 +28080,11 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -27836,7 +28093,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -27856,7 +28116,7 @@ pub mod builder {
     ///[`Client::vpc_view`]: super::Client::vpc_view
     #[derive(Debug, Clone)]
     pub struct VpcView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -27865,7 +28125,7 @@ pub mod builder {
     impl<'a> VpcView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -27907,7 +28167,7 @@ pub mod builder {
         /// {vpc_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -27917,12 +28177,12 @@ pub mod builder {
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -27930,7 +28190,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -27950,7 +28213,7 @@ pub mod builder {
     ///[`Client::vpc_update`]: super::Client::vpc_update
     #[derive(Debug, Clone)]
     pub struct VpcUpdate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -27960,7 +28223,7 @@ pub mod builder {
     impl<'a> VpcUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28022,7 +28285,7 @@ pub mod builder {
         /// {vpc_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28036,12 +28299,12 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -28050,7 +28313,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -28070,7 +28336,7 @@ pub mod builder {
     ///[`Client::vpc_delete`]: super::Client::vpc_delete
     #[derive(Debug, Clone)]
     pub struct VpcDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28079,7 +28345,7 @@ pub mod builder {
     impl<'a> VpcDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28121,7 +28387,7 @@ pub mod builder {
         /// {vpc_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28131,12 +28397,12 @@ pub mod builder {
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -28144,7 +28410,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -28164,7 +28433,7 @@ pub mod builder {
     ///[`Client::vpc_firewall_rules_view`]: super::Client::vpc_firewall_rules_view
     #[derive(Debug, Clone)]
     pub struct VpcFirewallRulesView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28173,7 +28442,7 @@ pub mod builder {
     impl<'a> VpcFirewallRulesView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28217,7 +28486,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcFirewallRules>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28227,12 +28496,12 @@ pub mod builder {
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -28240,7 +28509,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -28260,7 +28532,7 @@ pub mod builder {
     ///[`Client::vpc_firewall_rules_update`]: super::Client::vpc_firewall_rules_update
     #[derive(Debug, Clone)]
     pub struct VpcFirewallRulesUpdate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28270,7 +28542,7 @@ pub mod builder {
     impl<'a> VpcFirewallRulesUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28335,7 +28607,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcFirewallRules>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28349,12 +28621,12 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -28363,7 +28635,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -28383,7 +28658,7 @@ pub mod builder {
     ///[`Client::vpc_router_list`]: super::Client::vpc_router_list
     #[derive(Debug, Clone)]
     pub struct VpcRouterList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28395,7 +28670,7 @@ pub mod builder {
     impl<'a> VpcRouterList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28474,7 +28749,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcRouterResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28490,7 +28765,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
@@ -28505,7 +28780,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -28514,7 +28789,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -28592,7 +28870,7 @@ pub mod builder {
     ///[`Client::vpc_router_create`]: super::Client::vpc_router_create
     #[derive(Debug, Clone)]
     pub struct VpcRouterCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28602,7 +28880,7 @@ pub mod builder {
     impl<'a> VpcRouterCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28664,7 +28942,7 @@ pub mod builder {
         /// {vpc_name}/routers`
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28678,12 +28956,12 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -28692,7 +28970,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -28712,7 +28993,7 @@ pub mod builder {
     ///[`Client::vpc_router_view`]: super::Client::vpc_router_view
     #[derive(Debug, Clone)]
     pub struct VpcRouterView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28722,7 +29003,7 @@ pub mod builder {
     impl<'a> VpcRouterView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28775,7 +29056,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28787,13 +29068,13 @@ pub mod builder {
             let router_name = router_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -28801,7 +29082,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -28821,7 +29105,7 @@ pub mod builder {
     ///[`Client::vpc_router_update`]: super::Client::vpc_router_update
     #[derive(Debug, Clone)]
     pub struct VpcRouterUpdate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28832,7 +29116,7 @@ pub mod builder {
     impl<'a> VpcRouterUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28905,7 +29189,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28921,13 +29205,13 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -28936,7 +29220,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -28956,7 +29243,7 @@ pub mod builder {
     ///[`Client::vpc_router_delete`]: super::Client::vpc_router_delete
     #[derive(Debug, Clone)]
     pub struct VpcRouterDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28966,7 +29253,7 @@ pub mod builder {
     impl<'a> VpcRouterDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29019,7 +29306,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29031,13 +29318,13 @@ pub mod builder {
             let router_name = router_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -29045,7 +29332,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -29065,7 +29355,7 @@ pub mod builder {
     ///[`Client::vpc_router_route_list`]: super::Client::vpc_router_route_list
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29078,7 +29368,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29168,7 +29458,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::RouterRouteResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29186,7 +29476,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
@@ -29202,7 +29492,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -29211,7 +29501,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -29289,7 +29582,7 @@ pub mod builder {
     ///[`Client::vpc_router_route_create`]: super::Client::vpc_router_route_create
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29300,7 +29593,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29375,7 +29668,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}/routes`
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29391,13 +29684,13 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -29406,7 +29699,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -29426,7 +29722,7 @@ pub mod builder {
     ///[`Client::vpc_router_route_view`]: super::Client::vpc_router_route_view
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29437,7 +29733,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29501,7 +29797,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}/routes/{route_name}`
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29515,14 +29811,14 @@ pub mod builder {
             let route_name = route_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -29530,7 +29826,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -29550,7 +29849,7 @@ pub mod builder {
     ///[`Client::vpc_router_route_update`]: super::Client::vpc_router_route_update
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteUpdate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29562,7 +29861,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29648,7 +29947,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}/routes/{route_name}`
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29666,14 +29965,14 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -29682,7 +29981,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -29702,7 +30004,7 @@ pub mod builder {
     ///[`Client::vpc_router_route_delete`]: super::Client::vpc_router_route_delete
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29713,7 +30015,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29777,7 +30079,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}/routes/{route_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29791,14 +30093,14 @@ pub mod builder {
             let route_name = route_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -29806,7 +30108,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -29826,7 +30131,7 @@ pub mod builder {
     ///[`Client::vpc_subnet_list`]: super::Client::vpc_subnet_list
     #[derive(Debug, Clone)]
     pub struct VpcSubnetList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29838,7 +30143,7 @@ pub mod builder {
     impl<'a> VpcSubnetList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29917,7 +30222,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcSubnetResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29933,7 +30238,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
@@ -29948,7 +30253,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -29957,7 +30262,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -30035,7 +30343,7 @@ pub mod builder {
     ///[`Client::vpc_subnet_create`]: super::Client::vpc_subnet_create
     #[derive(Debug, Clone)]
     pub struct VpcSubnetCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30045,7 +30353,7 @@ pub mod builder {
     impl<'a> VpcSubnetCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30107,7 +30415,7 @@ pub mod builder {
         /// {vpc_name}/subnets`
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30121,12 +30429,12 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -30135,7 +30443,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -30155,7 +30466,7 @@ pub mod builder {
     ///[`Client::vpc_subnet_view`]: super::Client::vpc_subnet_view
     #[derive(Debug, Clone)]
     pub struct VpcSubnetView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30165,7 +30476,7 @@ pub mod builder {
     impl<'a> VpcSubnetView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30218,7 +30529,7 @@ pub mod builder {
         /// {vpc_name}/subnets/{subnet_name}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30230,13 +30541,13 @@ pub mod builder {
             let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -30244,7 +30555,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -30264,7 +30578,7 @@ pub mod builder {
     ///[`Client::vpc_subnet_update`]: super::Client::vpc_subnet_update
     #[derive(Debug, Clone)]
     pub struct VpcSubnetUpdate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30275,7 +30589,7 @@ pub mod builder {
     impl<'a> VpcSubnetUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30348,7 +30662,7 @@ pub mod builder {
         /// {vpc_name}/subnets/{subnet_name}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30364,13 +30678,13 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -30379,7 +30693,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -30399,7 +30716,7 @@ pub mod builder {
     ///[`Client::vpc_subnet_delete`]: super::Client::vpc_subnet_delete
     #[derive(Debug, Clone)]
     pub struct VpcSubnetDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30409,7 +30726,7 @@ pub mod builder {
     impl<'a> VpcSubnetDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30462,7 +30779,7 @@ pub mod builder {
         /// {vpc_name}/subnets/{subnet_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30474,13 +30791,13 @@ pub mod builder {
             let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -30488,7 +30805,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -30508,7 +30828,7 @@ pub mod builder {
     ///[`Client::vpc_subnet_list_network_interfaces`]: super::Client::vpc_subnet_list_network_interfaces
     #[derive(Debug, Clone)]
     pub struct VpcSubnetListNetworkInterfaces<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30521,7 +30841,7 @@ pub mod builder {
     impl<'a> VpcSubnetListNetworkInterfaces<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30612,7 +30932,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::NetworkInterfaceResultsPage>, Error<types::Error>>
         {
             let Self {
-                client,
+                __progenitor_client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30630,7 +30950,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}/network-interfaces",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
@@ -30646,7 +30966,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -30655,7 +30975,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -30733,21 +31056,25 @@ pub mod builder {
     ///[`Client::policy_view`]: super::Client::policy_view
     #[derive(Debug, Clone)]
     pub struct PolicyView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> PolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `GET` request to `/policy`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/policy", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url = format!("{}/policy", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -30755,7 +31082,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -30775,14 +31105,14 @@ pub mod builder {
     ///[`Client::policy_update`]: super::Client::policy_update
     #[derive(Debug, Clone)]
     pub struct PolicyUpdate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::SiloRolePolicy, String>,
     }
 
     impl<'a> PolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::SiloRolePolicy::default()),
             }
         }
@@ -30810,12 +31140,15 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SiloRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/policy", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/policy", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -30824,7 +31157,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -30844,7 +31180,7 @@ pub mod builder {
     ///[`Client::role_list`]: super::Client::role_list
     #[derive(Debug, Clone)]
     pub struct RoleList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
     }
@@ -30852,7 +31188,7 @@ pub mod builder {
     impl<'a> RoleList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
             }
@@ -30884,13 +31220,13 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::RoleResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/roles", client.baseurl,);
+            let __progenitor_url = format!("{}/roles", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -30898,7 +31234,7 @@ pub mod builder {
             if let Some(v) = &page_token {
                 __progenitor_query.push(("page_token", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -30907,7 +31243,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -30982,14 +31321,14 @@ pub mod builder {
     ///[`Client::role_view`]: super::Client::role_view
     #[derive(Debug, Clone)]
     pub struct RoleView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         role_name: Result<String, String>,
     }
 
     impl<'a> RoleView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 role_name: Err("role_name was not initialized".to_string()),
             }
         }
@@ -31006,14 +31345,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/roles/{role_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Role>, Error<types::Error>> {
-            let Self { client, role_name } = self;
+            let Self {
+                __progenitor_client,
+                role_name,
+            } = self;
             let role_name = role_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/roles/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&role_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -31021,7 +31363,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -31041,19 +31386,23 @@ pub mod builder {
     ///[`Client::session_me`]: super::Client::session_me
     #[derive(Debug, Clone)]
     pub struct SessionMe<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> SessionMe<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `GET` request to `/session/me`
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/session/me", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url = format!("{}/session/me", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -31061,7 +31410,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -31081,7 +31433,7 @@ pub mod builder {
     ///[`Client::session_me_groups`]: super::Client::session_me_groups
     #[derive(Debug, Clone)]
     pub struct SessionMeGroups<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -31090,7 +31442,7 @@ pub mod builder {
     impl<'a> SessionMeGroups<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -31134,7 +31486,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -31142,7 +31494,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/session/me/groups", client.baseurl,);
+            let __progenitor_url = format!("{}/session/me/groups", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -31153,7 +31505,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -31162,7 +31514,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -31238,7 +31593,7 @@ pub mod builder {
     ///[`Client::session_sshkey_list`]: super::Client::session_sshkey_list
     #[derive(Debug, Clone)]
     pub struct SessionSshkeyList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameSortMode>, String>,
@@ -31247,7 +31602,7 @@ pub mod builder {
     impl<'a> SessionSshkeyList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -31291,7 +31646,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SshKeyResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -31299,7 +31654,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/session/me/sshkeys", client.baseurl,);
+            let __progenitor_url = format!("{}/session/me/sshkeys", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -31310,7 +31665,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -31319,7 +31674,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -31395,14 +31753,14 @@ pub mod builder {
     ///[`Client::session_sshkey_create`]: super::Client::session_sshkey_create
     #[derive(Debug, Clone)]
     pub struct SessionSshkeyCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::SshKeyCreate, String>,
     }
 
     impl<'a> SessionSshkeyCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::SshKeyCreate::default()),
             }
         }
@@ -31428,12 +31786,15 @@ pub mod builder {
 
         ///Sends a `POST` request to `/session/me/sshkeys`
         pub async fn send(self) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SshKeyCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/session/me/sshkeys", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/session/me/sshkeys", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -31442,7 +31803,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -31462,14 +31826,14 @@ pub mod builder {
     ///[`Client::session_sshkey_view`]: super::Client::session_sshkey_view
     #[derive(Debug, Clone)]
     pub struct SessionSshkeyView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         ssh_key_name: Result<types::Name, String>,
     }
 
     impl<'a> SessionSshkeyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 ssh_key_name: Err("ssh_key_name was not initialized".to_string()),
             }
         }
@@ -31487,16 +31851,16 @@ pub mod builder {
         ///Sends a `GET` request to `/session/me/sshkeys/{ssh_key_name}`
         pub async fn send(self) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 ssh_key_name,
             } = self;
             let ssh_key_name = ssh_key_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/session/me/sshkeys/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -31504,7 +31868,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -31524,14 +31891,14 @@ pub mod builder {
     ///[`Client::session_sshkey_delete`]: super::Client::session_sshkey_delete
     #[derive(Debug, Clone)]
     pub struct SessionSshkeyDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         ssh_key_name: Result<types::Name, String>,
     }
 
     impl<'a> SessionSshkeyDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 ssh_key_name: Err("ssh_key_name was not initialized".to_string()),
             }
         }
@@ -31549,16 +31916,16 @@ pub mod builder {
         ///Sends a `DELETE` request to `/session/me/sshkeys/{ssh_key_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 ssh_key_name,
             } = self;
             let ssh_key_name = ssh_key_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/session/me/sshkeys/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -31566,7 +31933,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -31586,14 +31956,14 @@ pub mod builder {
     ///[`Client::system_image_view_by_id`]: super::Client::system_image_view_by_id
     #[derive(Debug, Clone)]
     pub struct SystemImageViewById<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SystemImageViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -31610,14 +31980,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/by-id/images/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/by-id/images/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -31625,7 +31998,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -31645,14 +32021,14 @@ pub mod builder {
     ///[`Client::ip_pool_view_by_id`]: super::Client::ip_pool_view_by_id
     #[derive(Debug, Clone)]
     pub struct IpPoolViewById<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> IpPoolViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -31669,14 +32045,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/by-id/ip-pools/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/by-id/ip-pools/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -31684,7 +32063,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -31704,14 +32086,14 @@ pub mod builder {
     ///[`Client::silo_view_by_id`]: super::Client::silo_view_by_id
     #[derive(Debug, Clone)]
     pub struct SiloViewById<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SiloViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -31728,14 +32110,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/by-id/silos/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/by-id/silos/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -31743,7 +32128,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -31763,7 +32151,7 @@ pub mod builder {
     ///[`Client::certificate_list`]: super::Client::certificate_list
     #[derive(Debug, Clone)]
     pub struct CertificateList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameSortMode>, String>,
@@ -31772,7 +32160,7 @@ pub mod builder {
     impl<'a> CertificateList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -31816,7 +32204,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::CertificateResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -31824,7 +32212,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/certificates", client.baseurl,);
+            let __progenitor_url = format!("{}/system/certificates", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -31835,7 +32223,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -31844,7 +32232,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -31920,14 +32311,14 @@ pub mod builder {
     ///[`Client::certificate_create`]: super::Client::certificate_create
     #[derive(Debug, Clone)]
     pub struct CertificateCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::CertificateCreate, String>,
     }
 
     impl<'a> CertificateCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::CertificateCreate::default()),
             }
         }
@@ -31955,12 +32346,15 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/certificates`
         pub async fn send(self) -> Result<ResponseValue<types::Certificate>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::CertificateCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/certificates", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/system/certificates", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -31969,7 +32363,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -31989,14 +32386,14 @@ pub mod builder {
     ///[`Client::certificate_view`]: super::Client::certificate_view
     #[derive(Debug, Clone)]
     pub struct CertificateView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         certificate: Result<types::NameOrId, String>,
     }
 
     impl<'a> CertificateView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 certificate: Err("certificate was not initialized".to_string()),
             }
         }
@@ -32014,16 +32411,16 @@ pub mod builder {
         ///Sends a `GET` request to `/system/certificates/{certificate}`
         pub async fn send(self) -> Result<ResponseValue<types::Certificate>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 certificate,
             } = self;
             let certificate = certificate.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/certificates/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&certificate.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -32031,7 +32428,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -32051,14 +32451,14 @@ pub mod builder {
     ///[`Client::certificate_delete`]: super::Client::certificate_delete
     #[derive(Debug, Clone)]
     pub struct CertificateDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         certificate: Result<types::NameOrId, String>,
     }
 
     impl<'a> CertificateDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 certificate: Err("certificate was not initialized".to_string()),
             }
         }
@@ -32076,16 +32476,16 @@ pub mod builder {
         ///Sends a `DELETE` request to `/system/certificates/{certificate}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 certificate,
             } = self;
             let certificate = certificate.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/certificates/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&certificate.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -32093,7 +32493,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -32113,7 +32516,7 @@ pub mod builder {
     ///[`Client::physical_disk_list`]: super::Client::physical_disk_list
     #[derive(Debug, Clone)]
     pub struct PhysicalDiskList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -32122,7 +32525,7 @@ pub mod builder {
     impl<'a> PhysicalDiskList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -32166,7 +32569,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::PhysicalDiskResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -32174,7 +32577,8 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/hardware/disks", client.baseurl,);
+            let __progenitor_url =
+                format!("{}/system/hardware/disks", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -32185,7 +32589,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -32194,7 +32598,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -32270,7 +32677,7 @@ pub mod builder {
     ///[`Client::rack_list`]: super::Client::rack_list
     #[derive(Debug, Clone)]
     pub struct RackList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -32279,7 +32686,7 @@ pub mod builder {
     impl<'a> RackList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -32323,7 +32730,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::RackResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -32331,7 +32738,8 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/hardware/racks", client.baseurl,);
+            let __progenitor_url =
+                format!("{}/system/hardware/racks", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -32342,7 +32750,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -32351,7 +32759,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -32427,14 +32838,14 @@ pub mod builder {
     ///[`Client::rack_view`]: super::Client::rack_view
     #[derive(Debug, Clone)]
     pub struct RackView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         rack_id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> RackView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 rack_id: Err("rack_id was not initialized".to_string()),
             }
         }
@@ -32451,14 +32862,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/hardware/racks/{rack_id}`
         pub async fn send(self) -> Result<ResponseValue<types::Rack>, Error<types::Error>> {
-            let Self { client, rack_id } = self;
+            let Self {
+                __progenitor_client,
+                rack_id,
+            } = self;
             let rack_id = rack_id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/hardware/racks/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&rack_id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -32466,7 +32880,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -32486,7 +32903,7 @@ pub mod builder {
     ///[`Client::sled_list`]: super::Client::sled_list
     #[derive(Debug, Clone)]
     pub struct SledList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -32495,7 +32912,7 @@ pub mod builder {
     impl<'a> SledList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -32539,7 +32956,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SledResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -32547,7 +32964,8 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/hardware/sleds", client.baseurl,);
+            let __progenitor_url =
+                format!("{}/system/hardware/sleds", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -32558,7 +32976,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -32567,7 +32985,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -32643,14 +33064,14 @@ pub mod builder {
     ///[`Client::sled_view`]: super::Client::sled_view
     #[derive(Debug, Clone)]
     pub struct SledView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         sled_id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SledView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 sled_id: Err("sled_id was not initialized".to_string()),
             }
         }
@@ -32667,14 +33088,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/hardware/sleds/{sled_id}`
         pub async fn send(self) -> Result<ResponseValue<types::Sled>, Error<types::Error>> {
-            let Self { client, sled_id } = self;
+            let Self {
+                __progenitor_client,
+                sled_id,
+            } = self;
             let sled_id = sled_id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/hardware/sleds/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&sled_id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -32682,7 +33106,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -32702,7 +33129,7 @@ pub mod builder {
     ///[`Client::sled_physical_disk_list`]: super::Client::sled_physical_disk_list
     #[derive(Debug, Clone)]
     pub struct SledPhysicalDiskList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         sled_id: Result<uuid::Uuid, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -32712,7 +33139,7 @@ pub mod builder {
     impl<'a> SledPhysicalDiskList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 sled_id: Err("sled_id was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -32767,7 +33194,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::PhysicalDiskResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 sled_id,
                 limit,
                 page_token,
@@ -32779,7 +33206,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/hardware/sleds/{}/disks",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&sled_id.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(3usize);
@@ -32792,7 +33219,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -32801,7 +33228,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -32877,7 +33307,7 @@ pub mod builder {
     ///[`Client::system_image_list`]: super::Client::system_image_list
     #[derive(Debug, Clone)]
     pub struct SystemImageList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameSortMode>, String>,
@@ -32886,7 +33316,7 @@ pub mod builder {
     impl<'a> SystemImageList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -32930,7 +33360,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::GlobalImageResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -32938,7 +33368,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/images", client.baseurl,);
+            let __progenitor_url = format!("{}/system/images", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -32949,7 +33379,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -32958,7 +33388,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -33034,14 +33467,14 @@ pub mod builder {
     ///[`Client::system_image_create`]: super::Client::system_image_create
     #[derive(Debug, Clone)]
     pub struct SystemImageCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::GlobalImageCreate, String>,
     }
 
     impl<'a> SystemImageCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::GlobalImageCreate::default()),
             }
         }
@@ -33069,12 +33502,15 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/images`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::GlobalImageCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/images", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/system/images", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -33083,7 +33519,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -33103,14 +33542,14 @@ pub mod builder {
     ///[`Client::system_image_view`]: super::Client::system_image_view
     #[derive(Debug, Clone)]
     pub struct SystemImageView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         image_name: Result<types::Name, String>,
     }
 
     impl<'a> SystemImageView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 image_name: Err("image_name was not initialized".to_string()),
             }
         }
@@ -33127,14 +33566,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/images/{image_name}`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-            let Self { client, image_name } = self;
+            let Self {
+                __progenitor_client,
+                image_name,
+            } = self;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/images/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&image_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -33142,7 +33584,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -33162,14 +33607,14 @@ pub mod builder {
     ///[`Client::system_image_delete`]: super::Client::system_image_delete
     #[derive(Debug, Clone)]
     pub struct SystemImageDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         image_name: Result<types::Name, String>,
     }
 
     impl<'a> SystemImageDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 image_name: Err("image_name was not initialized".to_string()),
             }
         }
@@ -33186,14 +33631,17 @@ pub mod builder {
 
         ///Sends a `DELETE` request to `/system/images/{image_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { client, image_name } = self;
+            let Self {
+                __progenitor_client,
+                image_name,
+            } = self;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/images/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&image_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -33201,7 +33649,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -33221,7 +33672,7 @@ pub mod builder {
     ///[`Client::ip_pool_list`]: super::Client::ip_pool_list
     #[derive(Debug, Clone)]
     pub struct IpPoolList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameOrIdSortMode>, String>,
@@ -33230,7 +33681,7 @@ pub mod builder {
     impl<'a> IpPoolList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -33274,7 +33725,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::IpPoolResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -33282,7 +33733,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/ip-pools", client.baseurl,);
+            let __progenitor_url = format!("{}/system/ip-pools", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -33293,7 +33744,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -33302,7 +33753,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -33378,14 +33832,14 @@ pub mod builder {
     ///[`Client::ip_pool_create`]: super::Client::ip_pool_create
     #[derive(Debug, Clone)]
     pub struct IpPoolCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::IpPoolCreate, String>,
     }
 
     impl<'a> IpPoolCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::IpPoolCreate::default()),
             }
         }
@@ -33411,12 +33865,15 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/ip-pools`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::IpPoolCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/ip-pools", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/system/ip-pools", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -33425,7 +33882,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -33445,14 +33905,14 @@ pub mod builder {
     ///[`Client::ip_pool_view`]: super::Client::ip_pool_view
     #[derive(Debug, Clone)]
     pub struct IpPoolView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         pool_name: Result<types::Name, String>,
     }
 
     impl<'a> IpPoolView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
             }
         }
@@ -33469,14 +33929,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/ip-pools/{pool_name}`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-            let Self { client, pool_name } = self;
+            let Self {
+                __progenitor_client,
+                pool_name,
+            } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/ip-pools/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -33484,7 +33947,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -33504,7 +33970,7 @@ pub mod builder {
     ///[`Client::ip_pool_update`]: super::Client::ip_pool_update
     #[derive(Debug, Clone)]
     pub struct IpPoolUpdate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         pool_name: Result<types::Name, String>,
         body: Result<types::builder::IpPoolUpdate, String>,
     }
@@ -33512,7 +33978,7 @@ pub mod builder {
     impl<'a> IpPoolUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 body: Ok(types::builder::IpPoolUpdate::default()),
             }
@@ -33550,7 +34016,7 @@ pub mod builder {
         ///Sends a `PUT` request to `/system/ip-pools/{pool_name}`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 pool_name,
                 body,
             } = self;
@@ -33560,10 +34026,10 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/ip-pools/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -33572,7 +34038,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -33592,14 +34061,14 @@ pub mod builder {
     ///[`Client::ip_pool_delete`]: super::Client::ip_pool_delete
     #[derive(Debug, Clone)]
     pub struct IpPoolDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         pool_name: Result<types::Name, String>,
     }
 
     impl<'a> IpPoolDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
             }
         }
@@ -33616,14 +34085,17 @@ pub mod builder {
 
         ///Sends a `DELETE` request to `/system/ip-pools/{pool_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { client, pool_name } = self;
+            let Self {
+                __progenitor_client,
+                pool_name,
+            } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/ip-pools/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -33631,7 +34103,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -33651,7 +34126,7 @@ pub mod builder {
     ///[`Client::ip_pool_range_list`]: super::Client::ip_pool_range_list
     #[derive(Debug, Clone)]
     pub struct IpPoolRangeList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         pool_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -33660,7 +34135,7 @@ pub mod builder {
     impl<'a> IpPoolRangeList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -33703,7 +34178,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 pool_name,
                 limit,
                 page_token,
@@ -33713,7 +34188,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/ip-pools/{}/ranges",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(2usize);
@@ -33723,7 +34198,7 @@ pub mod builder {
             if let Some(v) = &page_token {
                 __progenitor_query.push(("page_token", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -33732,7 +34207,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -33807,7 +34285,7 @@ pub mod builder {
     ///[`Client::ip_pool_range_add`]: super::Client::ip_pool_range_add
     #[derive(Debug, Clone)]
     pub struct IpPoolRangeAdd<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         pool_name: Result<types::Name, String>,
         body: Result<types::IpRange, String>,
     }
@@ -33815,7 +34293,7 @@ pub mod builder {
     impl<'a> IpPoolRangeAdd<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
@@ -33844,7 +34322,7 @@ pub mod builder {
         ///Sends a `POST` request to `/system/ip-pools/{pool_name}/ranges/add`
         pub async fn send(self) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 pool_name,
                 body,
             } = self;
@@ -33852,10 +34330,10 @@ pub mod builder {
             let body = body.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/ip-pools/{}/ranges/add",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -33864,7 +34342,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -33884,7 +34365,7 @@ pub mod builder {
     ///[`Client::ip_pool_range_remove`]: super::Client::ip_pool_range_remove
     #[derive(Debug, Clone)]
     pub struct IpPoolRangeRemove<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         pool_name: Result<types::Name, String>,
         body: Result<types::IpRange, String>,
     }
@@ -33892,7 +34373,7 @@ pub mod builder {
     impl<'a> IpPoolRangeRemove<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
@@ -33922,7 +34403,7 @@ pub mod builder {
         /// `/system/ip-pools/{pool_name}/ranges/remove`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 pool_name,
                 body,
             } = self;
@@ -33930,10 +34411,10 @@ pub mod builder {
             let body = body.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/ip-pools/{}/ranges/remove",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -33942,7 +34423,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -33962,19 +34446,24 @@ pub mod builder {
     ///[`Client::ip_pool_service_view`]: super::Client::ip_pool_service_view
     #[derive(Debug, Clone)]
     pub struct IpPoolServiceView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> IpPoolServiceView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `GET` request to `/system/ip-pools-service`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/system/ip-pools-service", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url =
+                format!("{}/system/ip-pools-service", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -33982,7 +34471,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -34002,7 +34494,7 @@ pub mod builder {
     ///[`Client::ip_pool_service_range_list`]: super::Client::ip_pool_service_range_list
     #[derive(Debug, Clone)]
     pub struct IpPoolServiceRangeList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
     }
@@ -34010,7 +34502,7 @@ pub mod builder {
     impl<'a> IpPoolServiceRangeList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
             }
@@ -34042,13 +34534,16 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/ip-pools-service/ranges", client.baseurl,);
+            let __progenitor_url = format!(
+                "{}/system/ip-pools-service/ranges",
+                __progenitor_client.baseurl,
+            );
             let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -34056,7 +34551,7 @@ pub mod builder {
             if let Some(v) = &page_token {
                 __progenitor_query.push(("page_token", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -34065,7 +34560,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -34140,14 +34638,14 @@ pub mod builder {
     ///[`Client::ip_pool_service_range_add`]: super::Client::ip_pool_service_range_add
     #[derive(Debug, Clone)]
     pub struct IpPoolServiceRangeAdd<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::IpRange, String>,
     }
 
     impl<'a> IpPoolServiceRangeAdd<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -34164,11 +34662,16 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/ip-pools-service/ranges/add`
         pub async fn send(self) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let __progenitor_url =
-                format!("{}/system/ip-pools-service/ranges/add", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!(
+                "{}/system/ip-pools-service/ranges/add",
+                __progenitor_client.baseurl,
+            );
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -34177,7 +34680,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -34197,14 +34703,14 @@ pub mod builder {
     ///[`Client::ip_pool_service_range_remove`]: super::Client::ip_pool_service_range_remove
     #[derive(Debug, Clone)]
     pub struct IpPoolServiceRangeRemove<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::IpRange, String>,
     }
 
     impl<'a> IpPoolServiceRangeRemove<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -34221,11 +34727,16 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/ip-pools-service/ranges/remove`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let __progenitor_url =
-                format!("{}/system/ip-pools-service/ranges/remove", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!(
+                "{}/system/ip-pools-service/ranges/remove",
+                __progenitor_client.baseurl,
+            );
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -34234,7 +34745,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -34254,7 +34768,7 @@ pub mod builder {
     ///[`Client::system_metric`]: super::Client::system_metric
     #[derive(Debug, Clone)]
     pub struct SystemMetric<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         metric_name: Result<types::SystemMetricName, String>,
         end_time: Result<Option<chrono::DateTime<chrono::offset::Utc>>, String>,
         id: Result<uuid::Uuid, String>,
@@ -34266,7 +34780,7 @@ pub mod builder {
     impl<'a> SystemMetric<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 metric_name: Err("metric_name was not initialized".to_string()),
                 end_time: Ok(None),
                 id: Err("id was not initialized".to_string()),
@@ -34345,7 +34859,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::MeasurementResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 metric_name,
                 end_time,
                 id,
@@ -34361,7 +34875,7 @@ pub mod builder {
             let start_time = start_time.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/metrics/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&metric_name.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(5usize);
@@ -34378,7 +34892,7 @@ pub mod builder {
             if let Some(v) = &start_time {
                 __progenitor_query.push(("start_time", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -34387,7 +34901,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -34407,21 +34924,25 @@ pub mod builder {
     ///[`Client::system_policy_view`]: super::Client::system_policy_view
     #[derive(Debug, Clone)]
     pub struct SystemPolicyView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> SystemPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `GET` request to `/system/policy`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/system/policy", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url = format!("{}/system/policy", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -34429,7 +34950,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -34449,14 +34973,14 @@ pub mod builder {
     ///[`Client::system_policy_update`]: super::Client::system_policy_update
     #[derive(Debug, Clone)]
     pub struct SystemPolicyUpdate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::FleetRolePolicy, String>,
     }
 
     impl<'a> SystemPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::FleetRolePolicy::default()),
             }
         }
@@ -34484,12 +35008,15 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::FleetRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/policy", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/system/policy", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -34498,7 +35025,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -34518,7 +35048,7 @@ pub mod builder {
     ///[`Client::saga_list`]: super::Client::saga_list
     #[derive(Debug, Clone)]
     pub struct SagaList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -34527,7 +35057,7 @@ pub mod builder {
     impl<'a> SagaList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -34571,7 +35101,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SagaResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -34579,7 +35109,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/sagas", client.baseurl,);
+            let __progenitor_url = format!("{}/system/sagas", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -34590,7 +35120,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -34599,7 +35129,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -34675,14 +35208,14 @@ pub mod builder {
     ///[`Client::saga_view`]: super::Client::saga_view
     #[derive(Debug, Clone)]
     pub struct SagaView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         saga_id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SagaView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 saga_id: Err("saga_id was not initialized".to_string()),
             }
         }
@@ -34699,14 +35232,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/sagas/{saga_id}`
         pub async fn send(self) -> Result<ResponseValue<types::Saga>, Error<types::Error>> {
-            let Self { client, saga_id } = self;
+            let Self {
+                __progenitor_client,
+                saga_id,
+            } = self;
             let saga_id = saga_id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/sagas/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&saga_id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -34714,7 +35250,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -34734,7 +35273,7 @@ pub mod builder {
     ///[`Client::silo_list`]: super::Client::silo_list
     #[derive(Debug, Clone)]
     pub struct SiloList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameOrIdSortMode>, String>,
@@ -34743,7 +35282,7 @@ pub mod builder {
     impl<'a> SiloList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -34787,7 +35326,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SiloResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -34795,7 +35334,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/silos", client.baseurl,);
+            let __progenitor_url = format!("{}/system/silos", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -34806,7 +35345,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -34815,7 +35354,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -34891,14 +35433,14 @@ pub mod builder {
     ///[`Client::silo_create`]: super::Client::silo_create
     #[derive(Debug, Clone)]
     pub struct SiloCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::SiloCreate, String>,
     }
 
     impl<'a> SiloCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::SiloCreate::default()),
             }
         }
@@ -34924,12 +35466,15 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/silos`
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SiloCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/silos", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/system/silos", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -34938,7 +35483,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -34958,14 +35506,14 @@ pub mod builder {
     ///[`Client::silo_view`]: super::Client::silo_view
     #[derive(Debug, Clone)]
     pub struct SiloView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
     }
 
     impl<'a> SiloView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
@@ -34982,14 +35530,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/silos/{silo_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-            let Self { client, silo_name } = self;
+            let Self {
+                __progenitor_client,
+                silo_name,
+            } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/silos/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -34997,7 +35548,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -35017,14 +35571,14 @@ pub mod builder {
     ///[`Client::silo_delete`]: super::Client::silo_delete
     #[derive(Debug, Clone)]
     pub struct SiloDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
     }
 
     impl<'a> SiloDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
@@ -35041,14 +35595,17 @@ pub mod builder {
 
         ///Sends a `DELETE` request to `/system/silos/{silo_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { client, silo_name } = self;
+            let Self {
+                __progenitor_client,
+                silo_name,
+            } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/silos/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -35056,7 +35613,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -35076,7 +35636,7 @@ pub mod builder {
     ///[`Client::silo_identity_provider_list`]: super::Client::silo_identity_provider_list
     #[derive(Debug, Clone)]
     pub struct SiloIdentityProviderList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -35086,7 +35646,7 @@ pub mod builder {
     impl<'a> SiloIdentityProviderList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -35143,7 +35703,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::IdentityProviderResultsPage>, Error<types::Error>>
         {
             let Self {
-                client,
+                __progenitor_client,
                 silo_name,
                 limit,
                 page_token,
@@ -35155,7 +35715,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/silos/{}/identity-providers",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(3usize);
@@ -35168,7 +35728,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -35177,7 +35737,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -35254,7 +35817,7 @@ pub mod builder {
     ///[`Client::local_idp_user_create`]: super::Client::local_idp_user_create
     #[derive(Debug, Clone)]
     pub struct LocalIdpUserCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         body: Result<types::builder::UserCreate, String>,
     }
@@ -35262,7 +35825,7 @@ pub mod builder {
     impl<'a> LocalIdpUserCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(types::builder::UserCreate::default()),
             }
@@ -35301,7 +35864,7 @@ pub mod builder {
         /// `/system/silos/{silo_name}/identity-providers/local/users`
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 silo_name,
                 body,
             } = self;
@@ -35311,10 +35874,10 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/silos/{}/identity-providers/local/users",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -35323,7 +35886,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -35343,7 +35909,7 @@ pub mod builder {
     ///[`Client::local_idp_user_delete`]: super::Client::local_idp_user_delete
     #[derive(Debug, Clone)]
     pub struct LocalIdpUserDelete<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         user_id: Result<uuid::Uuid, String>,
     }
@@ -35351,7 +35917,7 @@ pub mod builder {
     impl<'a> LocalIdpUserDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 user_id: Err("user_id was not initialized".to_string()),
             }
@@ -35381,7 +35947,7 @@ pub mod builder {
         /// `/system/silos/{silo_name}/identity-providers/local/users/{user_id}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 silo_name,
                 user_id,
             } = self;
@@ -35389,11 +35955,11 @@ pub mod builder {
             let user_id = user_id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/silos/{}/identity-providers/local/users/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -35401,7 +35967,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -35421,7 +35990,7 @@ pub mod builder {
     ///[`Client::local_idp_user_set_password`]: super::Client::local_idp_user_set_password
     #[derive(Debug, Clone)]
     pub struct LocalIdpUserSetPassword<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         user_id: Result<uuid::Uuid, String>,
         body: Result<types::UserPassword, String>,
@@ -35430,7 +35999,7 @@ pub mod builder {
     impl<'a> LocalIdpUserSetPassword<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 user_id: Err("user_id was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
@@ -35472,7 +36041,7 @@ pub mod builder {
         /// set-password`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 silo_name,
                 user_id,
                 body,
@@ -35482,11 +36051,11 @@ pub mod builder {
             let body = body.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/silos/{}/identity-providers/local/users/{}/set-password",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -35495,7 +36064,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -35515,7 +36087,7 @@ pub mod builder {
     ///[`Client::saml_identity_provider_create`]: super::Client::saml_identity_provider_create
     #[derive(Debug, Clone)]
     pub struct SamlIdentityProviderCreate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         body: Result<types::builder::SamlIdentityProviderCreate, String>,
     }
@@ -35523,7 +36095,7 @@ pub mod builder {
     impl<'a> SamlIdentityProviderCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(types::builder::SamlIdentityProviderCreate::default()),
             }
@@ -35565,7 +36137,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SamlIdentityProvider>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 silo_name,
                 body,
             } = self;
@@ -35575,10 +36147,10 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/silos/{}/identity-providers/saml",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -35587,7 +36159,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -35607,7 +36182,7 @@ pub mod builder {
     ///[`Client::saml_identity_provider_view`]: super::Client::saml_identity_provider_view
     #[derive(Debug, Clone)]
     pub struct SamlIdentityProviderView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         provider_name: Result<types::Name, String>,
     }
@@ -35615,7 +36190,7 @@ pub mod builder {
     impl<'a> SamlIdentityProviderView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 provider_name: Err("provider_name was not initialized".to_string()),
             }
@@ -35647,7 +36222,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SamlIdentityProvider>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 silo_name,
                 provider_name,
             } = self;
@@ -35655,11 +36230,11 @@ pub mod builder {
             let provider_name = provider_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/silos/{}/identity-providers/saml/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -35667,7 +36242,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -35687,14 +36265,14 @@ pub mod builder {
     ///[`Client::silo_policy_view`]: super::Client::silo_policy_view
     #[derive(Debug, Clone)]
     pub struct SiloPolicyView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
     }
 
     impl<'a> SiloPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
@@ -35713,14 +36291,17 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-            let Self { client, silo_name } = self;
+            let Self {
+                __progenitor_client,
+                silo_name,
+            } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/silos/{}/policy",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -35728,7 +36309,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -35748,7 +36332,7 @@ pub mod builder {
     ///[`Client::silo_policy_update`]: super::Client::silo_policy_update
     #[derive(Debug, Clone)]
     pub struct SiloPolicyUpdate<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         body: Result<types::builder::SiloRolePolicy, String>,
     }
@@ -35756,7 +36340,7 @@ pub mod builder {
     impl<'a> SiloPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(types::builder::SiloRolePolicy::default()),
             }
@@ -35796,7 +36380,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 silo_name,
                 body,
             } = self;
@@ -35806,10 +36390,10 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/silos/{}/policy",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -35818,7 +36402,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -35838,7 +36425,7 @@ pub mod builder {
     ///[`Client::silo_users_list`]: super::Client::silo_users_list
     #[derive(Debug, Clone)]
     pub struct SiloUsersList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -35848,7 +36435,7 @@ pub mod builder {
     impl<'a> SiloUsersList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -35903,7 +36490,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 silo_name,
                 limit,
                 page_token,
@@ -35915,7 +36502,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/silos/{}/users/all",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(3usize);
@@ -35928,7 +36515,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -35937,7 +36524,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -36013,7 +36603,7 @@ pub mod builder {
     ///[`Client::silo_user_view`]: super::Client::silo_user_view
     #[derive(Debug, Clone)]
     pub struct SiloUserView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         user_id: Result<uuid::Uuid, String>,
     }
@@ -36021,7 +36611,7 @@ pub mod builder {
     impl<'a> SiloUserView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 user_id: Err("user_id was not initialized".to_string()),
             }
@@ -36051,7 +36641,7 @@ pub mod builder {
         /// `/system/silos/{silo_name}/users/id/{user_id}`
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 silo_name,
                 user_id,
             } = self;
@@ -36059,11 +36649,11 @@ pub mod builder {
             let user_id = user_id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/silos/{}/users/id/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -36071,7 +36661,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -36091,7 +36684,7 @@ pub mod builder {
     ///[`Client::system_user_list`]: super::Client::system_user_list
     #[derive(Debug, Clone)]
     pub struct SystemUserList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameSortMode>, String>,
@@ -36100,7 +36693,7 @@ pub mod builder {
     impl<'a> SystemUserList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -36144,7 +36737,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::UserBuiltinResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -36152,7 +36745,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/user", client.baseurl,);
+            let __progenitor_url = format!("{}/system/user", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -36163,7 +36756,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -36172,7 +36765,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -36248,14 +36844,14 @@ pub mod builder {
     ///[`Client::system_user_view`]: super::Client::system_user_view
     #[derive(Debug, Clone)]
     pub struct SystemUserView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         user_name: Result<types::Name, String>,
     }
 
     impl<'a> SystemUserView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 user_name: Err("user_name was not initialized".to_string()),
             }
         }
@@ -36272,14 +36868,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/user/{user_name}`
         pub async fn send(self) -> Result<ResponseValue<types::UserBuiltin>, Error<types::Error>> {
-            let Self { client, user_name } = self;
+            let Self {
+                __progenitor_client,
+                user_name,
+            } = self;
             let user_name = user_name.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/system/user/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&user_name.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -36287,7 +36886,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -36307,7 +36909,7 @@ pub mod builder {
     ///[`Client::timeseries_schema_get`]: super::Client::timeseries_schema_get
     #[derive(Debug, Clone)]
     pub struct TimeseriesSchemaGet<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
     }
@@ -36315,7 +36917,7 @@ pub mod builder {
     impl<'a> TimeseriesSchemaGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
             }
@@ -36348,13 +36950,13 @@ pub mod builder {
         ) -> Result<ResponseValue<types::TimeseriesSchemaResultsPage>, Error<types::Error>>
         {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/timeseries/schema", client.baseurl,);
+            let __progenitor_url = format!("{}/timeseries/schema", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -36362,7 +36964,7 @@ pub mod builder {
             if let Some(v) = &page_token {
                 __progenitor_query.push(("page_token", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -36371,7 +36973,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -36446,7 +37051,7 @@ pub mod builder {
     ///[`Client::user_list`]: super::Client::user_list
     #[derive(Debug, Clone)]
     pub struct UserList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -36455,7 +37060,7 @@ pub mod builder {
     impl<'a> UserList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -36499,7 +37104,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -36507,7 +37112,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/users", client.baseurl,);
+            let __progenitor_url = format!("{}/users", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -36518,7 +37123,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -36527,7 +37132,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -36603,7 +37211,7 @@ pub mod builder {
     ///[`Client::disk_list_v1`]: super::Client::disk_list_v1
     #[derive(Debug, Clone)]
     pub struct DiskListV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         organization: Result<Option<types::NameOrId>, String>,
         page_token: Result<Option<String>, String>,
@@ -36614,7 +37222,7 @@ pub mod builder {
     impl<'a> DiskListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 organization: Ok(None),
                 page_token: Ok(None),
@@ -36682,7 +37290,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 organization,
                 page_token,
@@ -36694,7 +37302,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/disks", client.baseurl,);
+            let __progenitor_url = format!("{}/v1/disks", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(5usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -36711,7 +37319,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -36720,7 +37328,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -36798,7 +37409,7 @@ pub mod builder {
     ///[`Client::disk_create_v1`]: super::Client::disk_create_v1
     #[derive(Debug, Clone)]
     pub struct DiskCreateV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<types::NameOrId, String>,
         body: Result<types::builder::DiskCreate, String>,
@@ -36807,7 +37418,7 @@ pub mod builder {
     impl<'a> DiskCreateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization: Ok(None),
                 project: Err("project was not initialized".to_string()),
                 body: Ok(types::builder::DiskCreate::default()),
@@ -36857,7 +37468,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/disks`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization,
                 project,
                 body,
@@ -36867,13 +37478,13 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/disks", client.baseurl,);
+            let __progenitor_url = format!("{}/v1/disks", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
                 __progenitor_query.push(("organization", v.to_string()));
             }
             __progenitor_query.push(("project", project.to_string()));
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -36883,7 +37494,10 @@ pub mod builder {
                 .json(&body)
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -36903,7 +37517,7 @@ pub mod builder {
     ///[`Client::disk_view_v1`]: super::Client::disk_view_v1
     #[derive(Debug, Clone)]
     pub struct DiskViewV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         disk: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -36912,7 +37526,7 @@ pub mod builder {
     impl<'a> DiskViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 disk: Err("disk was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -36954,7 +37568,7 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/disks/{disk}`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 disk,
                 organization,
                 project,
@@ -36964,7 +37578,7 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/disks/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&disk.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(2usize);
@@ -36974,7 +37588,7 @@ pub mod builder {
             if let Some(v) = &project {
                 __progenitor_query.push(("project", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -36983,7 +37597,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -37003,7 +37620,7 @@ pub mod builder {
     ///[`Client::disk_delete_v1`]: super::Client::disk_delete_v1
     #[derive(Debug, Clone)]
     pub struct DiskDeleteV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         disk: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -37012,7 +37629,7 @@ pub mod builder {
     impl<'a> DiskDeleteV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 disk: Err("disk was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -37054,7 +37671,7 @@ pub mod builder {
         ///Sends a `DELETE` request to `/v1/disks/{disk}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 disk,
                 organization,
                 project,
@@ -37064,7 +37681,7 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/disks/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&disk.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(2usize);
@@ -37074,7 +37691,7 @@ pub mod builder {
             if let Some(v) = &project {
                 __progenitor_query.push(("project", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -37083,7 +37700,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -37103,7 +37723,7 @@ pub mod builder {
     ///[`Client::instance_list_v1`]: super::Client::instance_list_v1
     #[derive(Debug, Clone)]
     pub struct InstanceListV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         organization: Result<Option<types::NameOrId>, String>,
         page_token: Result<Option<String>, String>,
@@ -37114,7 +37734,7 @@ pub mod builder {
     impl<'a> InstanceListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 organization: Ok(None),
                 page_token: Ok(None),
@@ -37182,7 +37802,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 organization,
                 page_token,
@@ -37194,7 +37814,7 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/instances", client.baseurl,);
+            let __progenitor_url = format!("{}/v1/instances", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(5usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -37211,7 +37831,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -37220,7 +37840,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -37298,7 +37921,7 @@ pub mod builder {
     ///[`Client::instance_create_v1`]: super::Client::instance_create_v1
     #[derive(Debug, Clone)]
     pub struct InstanceCreateV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<types::NameOrId, String>,
         body: Result<types::builder::InstanceCreate, String>,
@@ -37307,7 +37930,7 @@ pub mod builder {
     impl<'a> InstanceCreateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization: Ok(None),
                 project: Err("project was not initialized".to_string()),
                 body: Ok(types::builder::InstanceCreate::default()),
@@ -37357,7 +37980,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization,
                 project,
                 body,
@@ -37367,13 +37990,13 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/instances", client.baseurl,);
+            let __progenitor_url = format!("{}/v1/instances", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
                 __progenitor_query.push(("organization", v.to_string()));
             }
             __progenitor_query.push(("project", project.to_string()));
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -37383,7 +38006,10 @@ pub mod builder {
                 .json(&body)
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -37403,7 +38029,7 @@ pub mod builder {
     ///[`Client::instance_view_v1`]: super::Client::instance_view_v1
     #[derive(Debug, Clone)]
     pub struct InstanceViewV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -37412,7 +38038,7 @@ pub mod builder {
     impl<'a> InstanceViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -37454,7 +38080,7 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/instances/{instance}`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 instance,
                 organization,
                 project,
@@ -37464,7 +38090,7 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/instances/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&instance.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(2usize);
@@ -37474,7 +38100,7 @@ pub mod builder {
             if let Some(v) = &project {
                 __progenitor_query.push(("project", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -37483,7 +38109,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -37503,7 +38132,7 @@ pub mod builder {
     ///[`Client::instance_delete_v1`]: super::Client::instance_delete_v1
     #[derive(Debug, Clone)]
     pub struct InstanceDeleteV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -37512,7 +38141,7 @@ pub mod builder {
     impl<'a> InstanceDeleteV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -37554,7 +38183,7 @@ pub mod builder {
         ///Sends a `DELETE` request to `/v1/instances/{instance}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 instance,
                 organization,
                 project,
@@ -37564,7 +38193,7 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/instances/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&instance.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(2usize);
@@ -37574,7 +38203,7 @@ pub mod builder {
             if let Some(v) = &project {
                 __progenitor_query.push(("project", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -37583,7 +38212,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -37603,7 +38235,7 @@ pub mod builder {
     ///[`Client::instance_disk_list_v1`]: super::Client::instance_disk_list_v1
     #[derive(Debug, Clone)]
     pub struct InstanceDiskListV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         organization: Result<Option<types::NameOrId>, String>,
@@ -37615,7 +38247,7 @@ pub mod builder {
     impl<'a> InstanceDiskListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 instance: Err("instance was not initialized".to_string()),
                 limit: Ok(None),
                 organization: Ok(None),
@@ -37694,7 +38326,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 instance,
                 limit,
                 organization,
@@ -37710,7 +38342,7 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/instances/{}/disks",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&instance.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(5usize);
@@ -37729,7 +38361,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -37738,7 +38370,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -37816,7 +38451,7 @@ pub mod builder {
     ///[`Client::instance_disk_attach_v1`]: super::Client::instance_disk_attach_v1
     #[derive(Debug, Clone)]
     pub struct InstanceDiskAttachV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -37826,7 +38461,7 @@ pub mod builder {
     impl<'a> InstanceDiskAttachV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -37888,7 +38523,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/disks/attach`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 instance,
                 organization,
                 project,
@@ -37902,7 +38537,7 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/instances/{}/disks/attach",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&instance.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(2usize);
@@ -37912,7 +38547,7 @@ pub mod builder {
             if let Some(v) = &project {
                 __progenitor_query.push(("project", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -37922,7 +38557,10 @@ pub mod builder {
                 .json(&body)
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 202u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -37942,7 +38580,7 @@ pub mod builder {
     ///[`Client::instance_disk_detach_v1`]: super::Client::instance_disk_detach_v1
     #[derive(Debug, Clone)]
     pub struct InstanceDiskDetachV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -37952,7 +38590,7 @@ pub mod builder {
     impl<'a> InstanceDiskDetachV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38014,7 +38652,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/disks/detach`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 instance,
                 organization,
                 project,
@@ -38028,7 +38666,7 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/instances/{}/disks/detach",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&instance.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(2usize);
@@ -38038,7 +38676,7 @@ pub mod builder {
             if let Some(v) = &project {
                 __progenitor_query.push(("project", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -38048,7 +38686,10 @@ pub mod builder {
                 .json(&body)
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 202u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -38068,7 +38709,7 @@ pub mod builder {
     ///[`Client::instance_migrate_v1`]: super::Client::instance_migrate_v1
     #[derive(Debug, Clone)]
     pub struct InstanceMigrateV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38078,7 +38719,7 @@ pub mod builder {
     impl<'a> InstanceMigrateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38140,7 +38781,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/migrate`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 instance,
                 organization,
                 project,
@@ -38154,7 +38795,7 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/instances/{}/migrate",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&instance.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(2usize);
@@ -38164,7 +38805,7 @@ pub mod builder {
             if let Some(v) = &project {
                 __progenitor_query.push(("project", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -38174,7 +38815,10 @@ pub mod builder {
                 .json(&body)
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -38194,7 +38838,7 @@ pub mod builder {
     ///[`Client::instance_reboot_v1`]: super::Client::instance_reboot_v1
     #[derive(Debug, Clone)]
     pub struct InstanceRebootV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38203,7 +38847,7 @@ pub mod builder {
     impl<'a> InstanceRebootV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38245,7 +38889,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/reboot`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 instance,
                 organization,
                 project,
@@ -38255,7 +38899,7 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/instances/{}/reboot",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&instance.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(2usize);
@@ -38265,7 +38909,7 @@ pub mod builder {
             if let Some(v) = &project {
                 __progenitor_query.push(("project", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -38274,7 +38918,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 202u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -38294,7 +38941,7 @@ pub mod builder {
     ///[`Client::instance_serial_console_v1`]: super::Client::instance_serial_console_v1
     #[derive(Debug, Clone)]
     pub struct InstanceSerialConsoleV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         from_start: Result<Option<u64>, String>,
         max_bytes: Result<Option<u64>, String>,
@@ -38306,7 +38953,7 @@ pub mod builder {
     impl<'a> InstanceSerialConsoleV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 instance: Err("instance was not initialized".to_string()),
                 from_start: Ok(None),
                 max_bytes: Ok(None),
@@ -38386,7 +39033,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceSerialConsoleData>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 instance,
                 from_start,
                 max_bytes,
@@ -38402,7 +39049,7 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/instances/{}/serial-console",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&instance.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(5usize);
@@ -38421,7 +39068,7 @@ pub mod builder {
             if let Some(v) = &project {
                 __progenitor_query.push(("project", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -38430,7 +39077,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -38450,7 +39100,7 @@ pub mod builder {
     ///[`Client::instance_serial_console_stream_v1`]: super::Client::instance_serial_console_stream_v1
     #[derive(Debug, Clone)]
     pub struct InstanceSerialConsoleStreamV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38459,7 +39109,7 @@ pub mod builder {
     impl<'a> InstanceSerialConsoleStreamV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38504,7 +39154,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
             let Self {
-                client,
+                __progenitor_client,
                 instance,
                 organization,
                 project,
@@ -38514,7 +39164,7 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/instances/{}/serial-console/stream",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&instance.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(2usize);
@@ -38524,7 +39174,7 @@ pub mod builder {
             if let Some(v) = &project {
                 __progenitor_query.push(("project", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .query(&__progenitor_query)
@@ -38539,7 +39189,10 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 101u16 => ResponseValue::upgrade(__progenitor_response).await,
@@ -38554,7 +39207,7 @@ pub mod builder {
     ///[`Client::instance_start_v1`]: super::Client::instance_start_v1
     #[derive(Debug, Clone)]
     pub struct InstanceStartV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38563,7 +39216,7 @@ pub mod builder {
     impl<'a> InstanceStartV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38605,7 +39258,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/start`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 instance,
                 organization,
                 project,
@@ -38615,7 +39268,7 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/instances/{}/start",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&instance.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(2usize);
@@ -38625,7 +39278,7 @@ pub mod builder {
             if let Some(v) = &project {
                 __progenitor_query.push(("project", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -38634,7 +39287,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 202u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -38654,7 +39310,7 @@ pub mod builder {
     ///[`Client::instance_stop_v1`]: super::Client::instance_stop_v1
     #[derive(Debug, Clone)]
     pub struct InstanceStopV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38663,7 +39319,7 @@ pub mod builder {
     impl<'a> InstanceStopV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38705,7 +39361,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/stop`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 instance,
                 organization,
                 project,
@@ -38715,7 +39371,7 @@ pub mod builder {
             let project = project.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/instances/{}/stop",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&instance.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(2usize);
@@ -38725,7 +39381,7 @@ pub mod builder {
             if let Some(v) = &project {
                 __progenitor_query.push(("project", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -38734,7 +39390,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 202u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -38754,7 +39413,7 @@ pub mod builder {
     ///[`Client::organization_list_v1`]: super::Client::organization_list_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationListV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameOrIdSortMode>, String>,
@@ -38763,7 +39422,7 @@ pub mod builder {
     impl<'a> OrganizationListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -38807,7 +39466,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -38815,7 +39474,7 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/organizations", client.baseurl,);
+            let __progenitor_url = format!("{}/v1/organizations", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -38826,7 +39485,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -38835,7 +39494,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -38911,14 +39573,14 @@ pub mod builder {
     ///[`Client::organization_create_v1`]: super::Client::organization_create_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationCreateV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::OrganizationCreate, String>,
     }
 
     impl<'a> OrganizationCreateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::OrganizationCreate::default()),
             }
         }
@@ -38946,12 +39608,15 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/organizations`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/organizations", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/v1/organizations", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -38960,7 +39625,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -38980,14 +39648,14 @@ pub mod builder {
     ///[`Client::organization_view_v1`]: super::Client::organization_view_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationViewV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
     }
 
     impl<'a> OrganizationViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization: Err("organization was not initialized".to_string()),
             }
         }
@@ -39005,16 +39673,16 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/organizations/{organization}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization,
             } = self;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/organizations/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -39022,7 +39690,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -39042,7 +39713,7 @@ pub mod builder {
     ///[`Client::organization_update_v1`]: super::Client::organization_update_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationUpdateV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
         body: Result<types::builder::OrganizationUpdate, String>,
     }
@@ -39050,7 +39721,7 @@ pub mod builder {
     impl<'a> OrganizationUpdateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization: Err("organization was not initialized".to_string()),
                 body: Ok(types::builder::OrganizationUpdate::default()),
             }
@@ -39090,7 +39761,7 @@ pub mod builder {
         ///Sends a `PUT` request to `/v1/organizations/{organization}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization,
                 body,
             } = self;
@@ -39100,10 +39771,10 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/organizations/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -39112,7 +39783,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -39132,14 +39806,14 @@ pub mod builder {
     ///[`Client::organization_delete_v1`]: super::Client::organization_delete_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationDeleteV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
     }
 
     impl<'a> OrganizationDeleteV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization: Err("organization was not initialized".to_string()),
             }
         }
@@ -39157,16 +39831,16 @@ pub mod builder {
         ///Sends a `DELETE` request to `/v1/organizations/{organization}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization,
             } = self;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/organizations/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -39174,7 +39848,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -39194,14 +39871,14 @@ pub mod builder {
     ///[`Client::organization_policy_view_v1`]: super::Client::organization_policy_view_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationPolicyViewV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
     }
 
     impl<'a> OrganizationPolicyViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization: Err("organization was not initialized".to_string()),
             }
         }
@@ -39221,16 +39898,16 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization,
             } = self;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/organizations/{}/policy",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -39238,7 +39915,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -39258,7 +39938,7 @@ pub mod builder {
     ///[`Client::organization_policy_update_v1`]: super::Client::organization_policy_update_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationPolicyUpdateV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
         body: Result<types::builder::OrganizationRolePolicy, String>,
     }
@@ -39266,7 +39946,7 @@ pub mod builder {
     impl<'a> OrganizationPolicyUpdateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization: Err("organization was not initialized".to_string()),
                 body: Ok(types::builder::OrganizationRolePolicy::default()),
             }
@@ -39308,7 +39988,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization,
                 body,
             } = self;
@@ -39318,10 +39998,10 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/organizations/{}/policy",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -39330,7 +40010,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -39350,7 +40033,7 @@ pub mod builder {
     ///[`Client::project_list_v1`]: super::Client::project_list_v1
     #[derive(Debug, Clone)]
     pub struct ProjectListV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         organization: Result<Option<types::NameOrId>, String>,
         page_token: Result<Option<String>, String>,
@@ -39360,7 +40043,7 @@ pub mod builder {
     impl<'a> ProjectListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 organization: Ok(None),
                 page_token: Ok(None),
@@ -39416,7 +40099,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 organization,
                 page_token,
@@ -39426,7 +40109,7 @@ pub mod builder {
             let organization = organization.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/projects", client.baseurl,);
+            let __progenitor_url = format!("{}/v1/projects", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(4usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -39440,7 +40123,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -39449,7 +40132,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -39526,7 +40212,7 @@ pub mod builder {
     ///[`Client::project_create_v1`]: super::Client::project_create_v1
     #[derive(Debug, Clone)]
     pub struct ProjectCreateV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
         body: Result<types::builder::ProjectCreate, String>,
     }
@@ -39534,7 +40220,7 @@ pub mod builder {
     impl<'a> ProjectCreateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 organization: Err("organization was not initialized".to_string()),
                 body: Ok(types::builder::ProjectCreate::default()),
             }
@@ -39572,7 +40258,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/projects`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 organization,
                 body,
             } = self;
@@ -39580,10 +40266,10 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/projects", client.baseurl,);
+            let __progenitor_url = format!("{}/v1/projects", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(1usize);
             __progenitor_query.push(("organization", organization.to_string()));
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -39593,7 +40279,10 @@ pub mod builder {
                 .json(&body)
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -39613,7 +40302,7 @@ pub mod builder {
     ///[`Client::project_view_v1`]: super::Client::project_view_v1
     #[derive(Debug, Clone)]
     pub struct ProjectViewV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
     }
@@ -39621,7 +40310,7 @@ pub mod builder {
     impl<'a> ProjectViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
             }
@@ -39651,7 +40340,7 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/projects/{project}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 project,
                 organization,
             } = self;
@@ -39659,14 +40348,14 @@ pub mod builder {
             let organization = organization.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/projects/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&project.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
                 __progenitor_query.push(("organization", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -39675,7 +40364,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -39695,7 +40387,7 @@ pub mod builder {
     ///[`Client::project_update_v1`]: super::Client::project_update_v1
     #[derive(Debug, Clone)]
     pub struct ProjectUpdateV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         body: Result<types::builder::ProjectUpdate, String>,
@@ -39704,7 +40396,7 @@ pub mod builder {
     impl<'a> ProjectUpdateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
                 body: Ok(types::builder::ProjectUpdate::default()),
@@ -39754,7 +40446,7 @@ pub mod builder {
         ///Sends a `PUT` request to `/v1/projects/{project}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 project,
                 organization,
                 body,
@@ -39766,14 +40458,14 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/projects/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&project.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
                 __progenitor_query.push(("organization", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -39783,7 +40475,10 @@ pub mod builder {
                 .json(&body)
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -39803,7 +40498,7 @@ pub mod builder {
     ///[`Client::project_delete_v1`]: super::Client::project_delete_v1
     #[derive(Debug, Clone)]
     pub struct ProjectDeleteV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
     }
@@ -39811,7 +40506,7 @@ pub mod builder {
     impl<'a> ProjectDeleteV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
             }
@@ -39841,7 +40536,7 @@ pub mod builder {
         ///Sends a `DELETE` request to `/v1/projects/{project}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 project,
                 organization,
             } = self;
@@ -39849,14 +40544,14 @@ pub mod builder {
             let organization = organization.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/projects/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&project.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
                 __progenitor_query.push(("organization", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .delete(__progenitor_url)
                 .header(
@@ -39865,7 +40560,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -39885,7 +40583,7 @@ pub mod builder {
     ///[`Client::project_policy_view_v1`]: super::Client::project_policy_view_v1
     #[derive(Debug, Clone)]
     pub struct ProjectPolicyViewV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
     }
@@ -39893,7 +40591,7 @@ pub mod builder {
     impl<'a> ProjectPolicyViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
             }
@@ -39925,7 +40623,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 project,
                 organization,
             } = self;
@@ -39933,14 +40631,14 @@ pub mod builder {
             let organization = organization.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/projects/{}/policy",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&project.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
                 __progenitor_query.push(("organization", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -39949,7 +40647,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -39969,7 +40670,7 @@ pub mod builder {
     ///[`Client::project_policy_update_v1`]: super::Client::project_policy_update_v1
     #[derive(Debug, Clone)]
     pub struct ProjectPolicyUpdateV1<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         body: Result<types::builder::ProjectRolePolicy, String>,
@@ -39978,7 +40679,7 @@ pub mod builder {
     impl<'a> ProjectPolicyUpdateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
                 body: Ok(types::builder::ProjectRolePolicy::default()),
@@ -40032,7 +40733,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 project,
                 organization,
                 body,
@@ -40044,14 +40745,14 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/projects/{}/policy",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&project.to_string()),
             );
             let mut __progenitor_query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
                 __progenitor_query.push(("organization", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -40061,7 +40762,10 @@ pub mod builder {
                 .json(&body)
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -40081,7 +40785,7 @@ pub mod builder {
     ///[`Client::system_component_version_list`]: super::Client::system_component_version_list
     #[derive(Debug, Clone)]
     pub struct SystemComponentVersionList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -40090,7 +40794,7 @@ pub mod builder {
     impl<'a> SystemComponentVersionList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -40135,7 +40839,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::UpdateableComponentResultsPage>, Error<types::Error>>
         {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -40143,7 +40847,10 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/system/update/components", client.baseurl,);
+            let __progenitor_url = format!(
+                "{}/v1/system/update/components",
+                __progenitor_client.baseurl,
+            );
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -40154,7 +40861,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -40163,7 +40870,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -40240,7 +40950,7 @@ pub mod builder {
     ///[`Client::update_deployments_list`]: super::Client::update_deployments_list
     #[derive(Debug, Clone)]
     pub struct UpdateDeploymentsList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -40249,7 +40959,7 @@ pub mod builder {
     impl<'a> UpdateDeploymentsList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -40294,7 +41004,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::UpdateDeploymentResultsPage>, Error<types::Error>>
         {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -40302,7 +41012,10 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/system/update/deployments", client.baseurl,);
+            let __progenitor_url = format!(
+                "{}/v1/system/update/deployments",
+                __progenitor_client.baseurl,
+            );
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -40313,7 +41026,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -40322,7 +41035,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -40398,14 +41114,14 @@ pub mod builder {
     ///[`Client::update_deployment_view`]: super::Client::update_deployment_view
     #[derive(Debug, Clone)]
     pub struct UpdateDeploymentView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> UpdateDeploymentView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -40424,14 +41140,17 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
-            let Self { client, id } = self;
+            let Self {
+                __progenitor_client,
+                id,
+            } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/system/update/deployments/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -40439,7 +41158,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -40459,19 +41181,24 @@ pub mod builder {
     ///[`Client::system_update_refresh`]: super::Client::system_update_refresh
     #[derive(Debug, Clone)]
     pub struct SystemUpdateRefresh<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> SystemUpdateRefresh<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `POST` request to `/v1/system/update/refresh`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/v1/system/update/refresh", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url =
+                format!("{}/v1/system/update/refresh", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -40479,7 +41206,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -40499,14 +41229,14 @@ pub mod builder {
     ///[`Client::system_update_start`]: super::Client::system_update_start
     #[derive(Debug, Clone)]
     pub struct SystemUpdateStart<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::SystemUpdateStart, String>,
     }
 
     impl<'a> SystemUpdateStart<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::SystemUpdateStart::default()),
             }
         }
@@ -40536,12 +41266,16 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SystemUpdateStart>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/system/update/start", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url =
+                format!("{}/v1/system/update/start", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -40550,7 +41284,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 202u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -40570,19 +41307,24 @@ pub mod builder {
     ///[`Client::system_update_stop`]: super::Client::system_update_stop
     #[derive(Debug, Clone)]
     pub struct SystemUpdateStop<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> SystemUpdateStop<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `POST` request to `/v1/system/update/stop`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/v1/system/update/stop", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url =
+                format!("{}/v1/system/update/stop", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -40590,7 +41332,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -40610,7 +41355,7 @@ pub mod builder {
     ///[`Client::system_update_list`]: super::Client::system_update_list
     #[derive(Debug, Clone)]
     pub struct SystemUpdateList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -40619,7 +41364,7 @@ pub mod builder {
     impl<'a> SystemUpdateList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -40663,7 +41408,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SystemUpdateResultsPage>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 limit,
                 page_token,
                 sort_by,
@@ -40671,7 +41416,8 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/system/update/updates", client.baseurl,);
+            let __progenitor_url =
+                format!("{}/v1/system/update/updates", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
                 __progenitor_query.push(("limit", v.to_string()));
@@ -40682,7 +41428,7 @@ pub mod builder {
             if let Some(v) = &sort_by {
                 __progenitor_query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -40691,7 +41437,10 @@ pub mod builder {
                 )
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -40767,14 +41516,14 @@ pub mod builder {
     ///[`Client::system_update_view`]: super::Client::system_update_view
     #[derive(Debug, Clone)]
     pub struct SystemUpdateView<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         version: Result<types::SemverVersion, String>,
     }
 
     impl<'a> SystemUpdateView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 version: Err("version was not initialized".to_string()),
             }
         }
@@ -40791,14 +41540,17 @@ pub mod builder {
 
         ///Sends a `GET` request to `/v1/system/update/updates/{version}`
         pub async fn send(self) -> Result<ResponseValue<types::SystemUpdate>, Error<types::Error>> {
-            let Self { client, version } = self;
+            let Self {
+                __progenitor_client,
+                version,
+            } = self;
             let version = version.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/system/update/updates/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&version.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -40806,7 +41558,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -40826,14 +41581,14 @@ pub mod builder {
     ///[`Client::system_update_components_list`]: super::Client::system_update_components_list
     #[derive(Debug, Clone)]
     pub struct SystemUpdateComponentsList<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         version: Result<types::SemverVersion, String>,
     }
 
     impl<'a> SystemUpdateComponentsList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 version: Err("version was not initialized".to_string()),
             }
         }
@@ -40853,14 +41608,17 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::ComponentUpdateResultsPage>, Error<types::Error>> {
-            let Self { client, version } = self;
+            let Self {
+                __progenitor_client,
+                version,
+            } = self;
             let version = version.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/v1/system/update/updates/{}/components",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&version.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -40868,7 +41626,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -40888,21 +41649,26 @@ pub mod builder {
     ///[`Client::system_version`]: super::Client::system_version
     #[derive(Debug, Clone)]
     pub struct SystemVersion<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> SystemVersion<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `GET` request to `/v1/system/update/version`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SystemVersion>, Error<types::Error>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/v1/system/update/version", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url =
+                format!("{}/v1/system/update/version", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -40910,7 +41676,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,

--- a/progenitor-impl/tests/output/param-overrides-builder-tagged.out
+++ b/progenitor-impl/tests/output/param-overrides-builder-tagged.out
@@ -104,7 +104,7 @@ pub mod builder {
     ///[`Client::key_get`]: super::Client::key_get
     #[derive(Debug, Clone)]
     pub struct KeyGet<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         key: Result<Option<bool>, String>,
         unique_key: Result<Option<String>, String>,
     }
@@ -112,7 +112,7 @@ pub mod builder {
     impl<'a> KeyGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 key: Ok(None),
                 unique_key: Ok(None),
             }
@@ -143,13 +143,13 @@ pub mod builder {
         ///Sends a `GET` request to `/key`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self {
-                client,
+                __progenitor_client,
                 key,
                 unique_key,
             } = self;
             let key = key.map_err(Error::InvalidRequest)?;
             let unique_key = unique_key.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/key", client.baseurl,);
+            let __progenitor_url = format!("{}/key", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &key {
                 __progenitor_query.push(("key", v.to_string()));
@@ -157,12 +157,15 @@ pub mod builder {
             if let Some(v) = &unique_key {
                 __progenitor_query.push(("uniqueKey", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(__progenitor_response)),

--- a/progenitor-impl/tests/output/param-overrides-builder.out
+++ b/progenitor-impl/tests/output/param-overrides-builder.out
@@ -104,7 +104,7 @@ pub mod builder {
     ///[`Client::key_get`]: super::Client::key_get
     #[derive(Debug, Clone)]
     pub struct KeyGet<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         key: Result<Option<bool>, String>,
         unique_key: Result<Option<String>, String>,
     }
@@ -112,7 +112,7 @@ pub mod builder {
     impl<'a> KeyGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 key: Ok(None),
                 unique_key: Ok(None),
             }
@@ -143,13 +143,13 @@ pub mod builder {
         ///Sends a `GET` request to `/key`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self {
-                client,
+                __progenitor_client,
                 key,
                 unique_key,
             } = self;
             let key = key.map_err(Error::InvalidRequest)?;
             let unique_key = unique_key.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/key", client.baseurl,);
+            let __progenitor_url = format!("{}/key", __progenitor_client.baseurl,);
             let mut __progenitor_query = Vec::with_capacity(2usize);
             if let Some(v) = &key {
                 __progenitor_query.push(("key", v.to_string()));
@@ -157,12 +157,15 @@ pub mod builder {
             if let Some(v) = &unique_key {
                 __progenitor_query.push(("uniqueKey", v.to_string()));
             }
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .query(&__progenitor_query)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => Ok(ResponseValue::empty(__progenitor_response)),

--- a/progenitor-impl/tests/output/propolis-server-builder-tagged.out
+++ b/progenitor-impl/tests/output/propolis-server-builder-tagged.out
@@ -2113,21 +2113,25 @@ pub mod builder {
     ///[`Client::instance_get`]: super::Client::instance_get
     #[derive(Debug, Clone)]
     pub struct InstanceGet<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> InstanceGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `GET` request to `/instance`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/instance", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url = format!("{}/instance", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -2135,7 +2139,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -2155,14 +2162,14 @@ pub mod builder {
     ///[`Client::instance_ensure`]: super::Client::instance_ensure
     #[derive(Debug, Clone)]
     pub struct InstanceEnsure<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::InstanceEnsureRequest, String>,
     }
 
     impl<'a> InstanceEnsure<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::InstanceEnsureRequest::default()),
             }
         }
@@ -2192,12 +2199,15 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::InstanceEnsureResponse>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceEnsureRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/instance", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/instance", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -2206,7 +2216,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -2226,7 +2239,7 @@ pub mod builder {
     ///[`Client::instance_issue_crucible_snapshot_request`]: super::Client::instance_issue_crucible_snapshot_request
     #[derive(Debug, Clone)]
     pub struct InstanceIssueCrucibleSnapshotRequest<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
         snapshot_id: Result<uuid::Uuid, String>,
     }
@@ -2234,7 +2247,7 @@ pub mod builder {
     impl<'a> InstanceIssueCrucibleSnapshotRequest<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
                 snapshot_id: Err("snapshot_id was not initialized".to_string()),
             }
@@ -2264,7 +2277,7 @@ pub mod builder {
         /// `/instance/disk/{id}/snapshot/{snapshot_id}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 id,
                 snapshot_id,
             } = self;
@@ -2272,11 +2285,11 @@ pub mod builder {
             let snapshot_id = snapshot_id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/instance/disk/{}/snapshot/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
                 encode_path(&snapshot_id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -2284,7 +2297,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -2304,14 +2320,14 @@ pub mod builder {
     ///[`Client::instance_migrate_status`]: super::Client::instance_migrate_status
     #[derive(Debug, Clone)]
     pub struct InstanceMigrateStatus<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::InstanceMigrateStatusRequest, String>,
     }
 
     impl<'a> InstanceMigrateStatus<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::InstanceMigrateStatusRequest::default()),
             }
         }
@@ -2341,12 +2357,16 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceMigrateStatusResponse>, Error<types::Error>>
         {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceMigrateStatusRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/instance/migrate/status", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url =
+                format!("{}/instance/migrate/status", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -2355,7 +2375,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -2375,21 +2398,25 @@ pub mod builder {
     ///[`Client::instance_serial`]: super::Client::instance_serial
     #[derive(Debug, Clone)]
     pub struct InstanceSerial<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> InstanceSerial<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `GET` request to `/instance/serial`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/instance/serial", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url = format!("{}/instance/serial", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(reqwest::header::CONNECTION, "Upgrade")
@@ -2403,7 +2430,10 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 101u16 => ResponseValue::upgrade(__progenitor_response).await,
@@ -2418,14 +2448,14 @@ pub mod builder {
     ///[`Client::instance_state_put`]: super::Client::instance_state_put
     #[derive(Debug, Clone)]
     pub struct InstanceStatePut<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::InstanceStateRequested, String>,
     }
 
     impl<'a> InstanceStatePut<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -2442,10 +2472,13 @@ pub mod builder {
 
         ///Sends a `PUT` request to `/instance/state`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/instance/state", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/instance/state", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -2454,7 +2487,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -2474,14 +2510,14 @@ pub mod builder {
     ///[`Client::instance_state_monitor`]: super::Client::instance_state_monitor
     #[derive(Debug, Clone)]
     pub struct InstanceStateMonitor<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::InstanceStateMonitorRequest, String>,
     }
 
     impl<'a> InstanceStateMonitor<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::InstanceStateMonitorRequest::default()),
             }
         }
@@ -2511,12 +2547,16 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceStateMonitorResponse>, Error<types::Error>>
         {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceStateMonitorRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/instance/state-monitor", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url =
+                format!("{}/instance/state-monitor", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -2525,7 +2565,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,

--- a/progenitor-impl/tests/output/propolis-server-builder.out
+++ b/progenitor-impl/tests/output/propolis-server-builder.out
@@ -2119,21 +2119,25 @@ pub mod builder {
     ///[`Client::instance_get`]: super::Client::instance_get
     #[derive(Debug, Clone)]
     pub struct InstanceGet<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> InstanceGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `GET` request to `/instance`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/instance", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url = format!("{}/instance", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -2141,7 +2145,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -2161,14 +2168,14 @@ pub mod builder {
     ///[`Client::instance_ensure`]: super::Client::instance_ensure
     #[derive(Debug, Clone)]
     pub struct InstanceEnsure<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::InstanceEnsureRequest, String>,
     }
 
     impl<'a> InstanceEnsure<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::InstanceEnsureRequest::default()),
             }
         }
@@ -2198,12 +2205,15 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::InstanceEnsureResponse>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceEnsureRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/instance", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/instance", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -2212,7 +2222,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 201u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -2232,7 +2245,7 @@ pub mod builder {
     ///[`Client::instance_issue_crucible_snapshot_request`]: super::Client::instance_issue_crucible_snapshot_request
     #[derive(Debug, Clone)]
     pub struct InstanceIssueCrucibleSnapshotRequest<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
         snapshot_id: Result<uuid::Uuid, String>,
     }
@@ -2240,7 +2253,7 @@ pub mod builder {
     impl<'a> InstanceIssueCrucibleSnapshotRequest<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 id: Err("id was not initialized".to_string()),
                 snapshot_id: Err("snapshot_id was not initialized".to_string()),
             }
@@ -2270,7 +2283,7 @@ pub mod builder {
         /// `/instance/disk/{id}/snapshot/{snapshot_id}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                client,
+                __progenitor_client,
                 id,
                 snapshot_id,
             } = self;
@@ -2278,11 +2291,11 @@ pub mod builder {
             let snapshot_id = snapshot_id.map_err(Error::InvalidRequest)?;
             let __progenitor_url = format!(
                 "{}/instance/disk/{}/snapshot/{}",
-                client.baseurl,
+                __progenitor_client.baseurl,
                 encode_path(&id.to_string()),
                 encode_path(&snapshot_id.to_string()),
             );
-            let __progenitor_request = client
+            let __progenitor_request = __progenitor_client
                 .client
                 .post(__progenitor_url)
                 .header(
@@ -2290,7 +2303,10 @@ pub mod builder {
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -2310,14 +2326,14 @@ pub mod builder {
     ///[`Client::instance_migrate_status`]: super::Client::instance_migrate_status
     #[derive(Debug, Clone)]
     pub struct InstanceMigrateStatus<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::InstanceMigrateStatusRequest, String>,
     }
 
     impl<'a> InstanceMigrateStatus<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::InstanceMigrateStatusRequest::default()),
             }
         }
@@ -2347,12 +2363,16 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceMigrateStatusResponse>, Error<types::Error>>
         {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceMigrateStatusRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/instance/migrate/status", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url =
+                format!("{}/instance/migrate/status", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -2361,7 +2381,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,
@@ -2381,21 +2404,25 @@ pub mod builder {
     ///[`Client::instance_serial`]: super::Client::instance_serial
     #[derive(Debug, Clone)]
     pub struct InstanceSerial<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
     }
 
     impl<'a> InstanceSerial<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client }
+            Self {
+                __progenitor_client: client,
+            }
         }
 
         ///Sends a `GET` request to `/instance/serial`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
-            let Self { client } = self;
-            let __progenitor_url = format!("{}/instance/serial", client.baseurl,);
-            let __progenitor_request = client
+            let Self {
+                __progenitor_client,
+            } = self;
+            let __progenitor_url = format!("{}/instance/serial", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(reqwest::header::CONNECTION, "Upgrade")
@@ -2409,7 +2436,10 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 101u16 => ResponseValue::upgrade(__progenitor_response).await,
@@ -2424,14 +2454,14 @@ pub mod builder {
     ///[`Client::instance_state_put`]: super::Client::instance_state_put
     #[derive(Debug, Clone)]
     pub struct InstanceStatePut<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::InstanceStateRequested, String>,
     }
 
     impl<'a> InstanceStatePut<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -2448,10 +2478,13 @@ pub mod builder {
 
         ///Sends a `PUT` request to `/instance/state`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/instance/state", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url = format!("{}/instance/state", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .put(__progenitor_url)
                 .header(
@@ -2460,7 +2493,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 204u16 => Ok(ResponseValue::empty(__progenitor_response)),
@@ -2480,14 +2516,14 @@ pub mod builder {
     ///[`Client::instance_state_monitor`]: super::Client::instance_state_monitor
     #[derive(Debug, Clone)]
     pub struct InstanceStateMonitor<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::InstanceStateMonitorRequest, String>,
     }
 
     impl<'a> InstanceStateMonitor<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::InstanceStateMonitorRequest::default()),
             }
         }
@@ -2517,12 +2553,16 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceStateMonitorResponse>, Error<types::Error>>
         {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceStateMonitorRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/instance/state-monitor", client.baseurl,);
-            let __progenitor_request = client
+            let __progenitor_url =
+                format!("{}/instance/state-monitor", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
                 .client
                 .get(__progenitor_url)
                 .header(
@@ -2531,7 +2571,10 @@ pub mod builder {
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200u16 => ResponseValue::from_response(__progenitor_response).await,

--- a/progenitor-impl/tests/output/test_default_params_builder.out
+++ b/progenitor-impl/tests/output/test_default_params_builder.out
@@ -309,14 +309,14 @@ pub mod builder {
     ///[`Client::default_params`]: super::Client::default_params
     #[derive(Debug, Clone)]
     pub struct DefaultParams<'a> {
-        client: &'a super::Client,
+        __progenitor_client: &'a super::Client,
         body: Result<types::builder::BodyWithDefaults, String>,
     }
 
     impl<'a> DefaultParams<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                client,
+                __progenitor_client: client,
                 body: Ok(types::builder::BodyWithDefaults::default()),
             }
         }
@@ -344,13 +344,23 @@ pub mod builder {
 
         ///Sends a `POST` request to `/`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-            let Self { client, body } = self;
+            let Self {
+                __progenitor_client,
+                body,
+            } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::BodyWithDefaults>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/", client.baseurl,);
-            let __progenitor_request = client.client.post(__progenitor_url).json(&body).build()?;
-            let __progenitor_result = client.client.execute(__progenitor_request).await;
+            let __progenitor_url = format!("{}/", __progenitor_client.baseurl,);
+            let __progenitor_request = __progenitor_client
+                .client
+                .post(__progenitor_url)
+                .json(&body)
+                .build()?;
+            let __progenitor_result = __progenitor_client
+                .client
+                .execute(__progenitor_request)
+                .await;
             let __progenitor_response = __progenitor_result?;
             match __progenitor_response.status().as_u16() {
                 200..=299 => Ok(ResponseValue::stream(__progenitor_response)),


### PR DESCRIPTION
This PR resolves https://github.com/oxidecomputer/progenitor/issues/288 and is essentially an extension of https://github.com/oxidecomputer/progenitor/pull/599. It renames the internal `client` variable name to `__progenitor_client`, while still preserving the corresponding `client` name for the public param of the `new` function.

There are (currently) three commits, this first of which (https://github.com/oxidecomputer/progenitor/pull/600/commits/112217c91a69934828692a476be395a222bec443) is most interesting. The others consist of some local var renames and updates to the test fixtures.

This PR was tested with the input from https://github.com/oxidecomputer/progenitor/issues/288. Relevant snippets of new codegen from that input:

```rust
    #[derive(Debug, Clone)]
    pub struct ListTimeEntries<'a> {
        __progenitor_client: &'a super::Client,
        client: Result<Option<String>, String>,
    }
    impl<'a> ListTimeEntries<'a> {
        pub fn new(client: &'a super::Client) -> Self {
            Self {
                __progenitor_client: client,
                client: Ok(None),
            }
        }
        pub fn client<V>(mut self, value: V) -> Self
        where
            V: std::convert::TryInto<String>,
        {
            self
                .client = value
                .try_into()
                .map(Some)
                .map_err(|_| "conversion to `String` for client failed".to_string());
            self
        }
        ///Sends a `GET` request to `/time_entries`
        pub async fn send(
            self,
        ) -> Result<ResponseValue<Vec<types::TimeEntry>>, Error<()>> {
            let Self { __progenitor_client, client } = self;
            let client = client.map_err(Error::InvalidRequest)?;
            let __progenitor_url = format!(
                "{}/time_entries", __progenitor_client.baseurl,
            );
            let mut __progenitor_query = Vec::with_capacity(1usize);
            if let Some(v) = &client {
                __progenitor_query.push(("client", v.to_string()));
            }
            let __progenitor_request = __progenitor_client
                .client
                .get(__progenitor_url)
                .header(
                    reqwest::header::ACCEPT,
                    reqwest::header::HeaderValue::from_static("application/json"),
                )
                .query(&__progenitor_query)
                .build()?;
        ...
```