### PR TITLE
Generate unique internal var names and add tests for name collisions.

### DIFF
--- a/progenitor-impl/src/util.rs
+++ b/progenitor-impl/src/util.rs
@@ -123,3 +123,21 @@ pub(crate) fn sanitize(input: &str, case: Case) -> String {
         format!("{}_", out)
     }
 }
+
+/// Given a desired name and a slice of proc_macro2::Ident, generate a new
+/// Ident that is unique from the slice.
+pub(crate) fn unique_ident_from(
+    name: &str,
+    identities: &[proc_macro2::Ident],
+) -> proc_macro2::Ident {
+    let mut name = name.to_string();
+
+    loop {
+        name.insert_str(0, "_");
+        let ident = quote::format_ident!("{}", name);
+
+        if !identities.contains(&ident) {
+            return ident;
+        }
+    }
+}

--- a/progenitor-impl/src/util.rs
+++ b/progenitor-impl/src/util.rs
@@ -133,11 +133,12 @@ pub(crate) fn unique_ident_from(
     let mut name = name.to_string();
 
     loop {
-        name.insert_str(0, "_");
         let ident = quote::format_ident!("{}", name);
 
         if !identities.contains(&ident) {
             return ident;
         }
+
+        name.insert_str(0, "_");
     }
 }

--- a/progenitor-impl/tests/output/buildomat-builder-tagged.out
+++ b/progenitor-impl/tests/output/buildomat-builder-tagged.out
@@ -1863,38 +1863,31 @@ pub mod builder {
     ///[`Client::control_hold`]: super::Client::control_hold
     #[derive(Debug, Clone)]
     pub struct ControlHold<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> ControlHold<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `POST` request to `/v1/control/hold`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url = format!("{}/v1/control/hold", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/v1/control/hold", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -1904,31 +1897,24 @@ pub mod builder {
     ///[`Client::control_resume`]: super::Client::control_resume
     #[derive(Debug, Clone)]
     pub struct ControlResume<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> ControlResume<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `POST` request to `/v1/control/resume`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url = format!("{}/v1/control/resume", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client.client.post(__progenitor_url).build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(__progenitor_response)),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let Self { _client } = self;
+            let _url = format!("{}/v1/control/resume", _client.baseurl,);
+            let _request = _client.client.post(_url).build()?;
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => Ok(ResponseValue::empty(_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -1938,14 +1924,14 @@ pub mod builder {
     ///[`Client::task_get`]: super::Client::task_get
     #[derive(Debug, Clone)]
     pub struct TaskGet<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         task: Result<String, String>,
     }
 
     impl<'a> TaskGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 task: Err("task was not initialized".to_string()),
             }
         }
@@ -1962,32 +1948,26 @@ pub mod builder {
 
         ///Sends a `GET` request to `/v1/task/{task}`
         pub async fn send(self) -> Result<ResponseValue<types::Task>, Error<()>> {
-            let Self {
-                __progenitor_client,
-                task,
-            } = self;
+            let Self { _client, task } = self;
             let task = task.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/task/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -1997,38 +1977,31 @@ pub mod builder {
     ///[`Client::tasks_get`]: super::Client::tasks_get
     #[derive(Debug, Clone)]
     pub struct TasksGet<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> TasksGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `GET` request to `/v1/tasks`
         pub async fn send(self) -> Result<ResponseValue<Vec<types::Task>>, Error<()>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url = format!("{}/v1/tasks", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/v1/tasks", _client.baseurl,);
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2038,14 +2011,14 @@ pub mod builder {
     ///[`Client::task_submit`]: super::Client::task_submit
     #[derive(Debug, Clone)]
     pub struct TaskSubmit<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::TaskSubmit, String>,
     }
 
     impl<'a> TaskSubmit<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::TaskSubmit::default()),
             }
         }
@@ -2071,31 +2044,25 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/tasks`
         pub async fn send(self) -> Result<ResponseValue<types::TaskSubmitResult>, Error<()>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::TaskSubmit>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/tasks", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/v1/tasks", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2105,7 +2072,7 @@ pub mod builder {
     ///[`Client::task_events_get`]: super::Client::task_events_get
     #[derive(Debug, Clone)]
     pub struct TaskEventsGet<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         task: Result<String, String>,
         minseq: Result<Option<u32>, String>,
     }
@@ -2113,7 +2080,7 @@ pub mod builder {
     impl<'a> TaskEventsGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 task: Err("task was not initialized".to_string()),
                 minseq: Ok(None),
             }
@@ -2143,38 +2110,35 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/tasks/{task}/events`
         pub async fn send(self) -> Result<ResponseValue<Vec<types::TaskEvent>>, Error<()>> {
             let Self {
-                __progenitor_client,
+                _client,
                 task,
                 minseq,
             } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let minseq = minseq.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/tasks/{}/events",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(1usize);
+            let mut _query = Vec::with_capacity(1usize);
             if let Some(v) = &minseq {
-                __progenitor_query.push(("minseq", v.to_string()));
+                _query.push(("minseq", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2184,14 +2148,14 @@ pub mod builder {
     ///[`Client::task_outputs_get`]: super::Client::task_outputs_get
     #[derive(Debug, Clone)]
     pub struct TaskOutputsGet<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         task: Result<String, String>,
     }
 
     impl<'a> TaskOutputsGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 task: Err("task was not initialized".to_string()),
             }
         }
@@ -2208,32 +2172,26 @@ pub mod builder {
 
         ///Sends a `GET` request to `/v1/tasks/{task}/outputs`
         pub async fn send(self) -> Result<ResponseValue<Vec<types::TaskOutput>>, Error<()>> {
-            let Self {
-                __progenitor_client,
-                task,
-            } = self;
+            let Self { _client, task } = self;
             let task = task.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/tasks/{}/outputs",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2243,7 +2201,7 @@ pub mod builder {
     ///[`Client::task_output_download`]: super::Client::task_output_download
     #[derive(Debug, Clone)]
     pub struct TaskOutputDownload<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         task: Result<String, String>,
         output: Result<String, String>,
     }
@@ -2251,7 +2209,7 @@ pub mod builder {
     impl<'a> TaskOutputDownload<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 task: Err("task was not initialized".to_string()),
                 output: Err("output was not initialized".to_string()),
             }
@@ -2280,27 +2238,24 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/tasks/{task}/outputs/{output}`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<()>> {
             let Self {
-                __progenitor_client,
+                _client,
                 task,
                 output,
             } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let output = output.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/tasks/{}/outputs/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&task.to_string()),
                 encode_path(&output.to_string()),
             );
-            let __progenitor_request = __progenitor_client.client.get(__progenitor_url).build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _request = _client.client.get(_url).build()?;
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2310,14 +2265,14 @@ pub mod builder {
     ///[`Client::user_create`]: super::Client::user_create
     #[derive(Debug, Clone)]
     pub struct UserCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::UserCreate, String>,
     }
 
     impl<'a> UserCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::UserCreate::default()),
             }
         }
@@ -2343,31 +2298,25 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/users`
         pub async fn send(self) -> Result<ResponseValue<types::UserCreateResult>, Error<()>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::UserCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/users", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/v1/users", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2377,38 +2326,31 @@ pub mod builder {
     ///[`Client::whoami`]: super::Client::whoami
     #[derive(Debug, Clone)]
     pub struct Whoami<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> Whoami<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `GET` request to `/v1/whoami`
         pub async fn send(self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url = format!("{}/v1/whoami", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/v1/whoami", _client.baseurl,);
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2418,14 +2360,14 @@ pub mod builder {
     ///[`Client::worker_bootstrap`]: super::Client::worker_bootstrap
     #[derive(Debug, Clone)]
     pub struct WorkerBootstrap<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::WorkerBootstrap, String>,
     }
 
     impl<'a> WorkerBootstrap<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::WorkerBootstrap::default()),
             }
         }
@@ -2451,31 +2393,25 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/worker/bootstrap`
         pub async fn send(self) -> Result<ResponseValue<types::WorkerBootstrapResult>, Error<()>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerBootstrap>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/worker/bootstrap", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/v1/worker/bootstrap", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2485,38 +2421,31 @@ pub mod builder {
     ///[`Client::worker_ping`]: super::Client::worker_ping
     #[derive(Debug, Clone)]
     pub struct WorkerPing<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> WorkerPing<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `GET` request to `/v1/worker/ping`
         pub async fn send(self) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url = format!("{}/v1/worker/ping", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/v1/worker/ping", _client.baseurl,);
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2526,7 +2455,7 @@ pub mod builder {
     ///[`Client::worker_task_append`]: super::Client::worker_task_append
     #[derive(Debug, Clone)]
     pub struct WorkerTaskAppend<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         task: Result<String, String>,
         body: Result<types::builder::WorkerAppendTask, String>,
     }
@@ -2534,7 +2463,7 @@ pub mod builder {
     impl<'a> WorkerTaskAppend<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 task: Err("task was not initialized".to_string()),
                 body: Ok(types::builder::WorkerAppendTask::default()),
             }
@@ -2574,7 +2503,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/worker/task/{task}/append`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self {
-                __progenitor_client,
+                _client,
                 task,
                 body,
             } = self;
@@ -2582,24 +2511,17 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerAppendTask>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/worker/task/{}/append",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let __progenitor_request = __progenitor_client
-                .client
-                .post(__progenitor_url)
-                .json(&body)
-                .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => Ok(ResponseValue::empty(__progenitor_response)),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _request = _client.client.post(_url).json(&body).build()?;
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => Ok(ResponseValue::empty(_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2609,7 +2531,7 @@ pub mod builder {
     ///[`Client::worker_task_upload_chunk`]: super::Client::worker_task_upload_chunk
     #[derive(Debug)]
     pub struct WorkerTaskUploadChunk<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         task: Result<String, String>,
         body: Result<reqwest::Body, String>,
     }
@@ -2617,7 +2539,7 @@ pub mod builder {
     impl<'a> WorkerTaskUploadChunk<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 task: Err("task was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
@@ -2646,20 +2568,20 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/worker/task/{task}/chunk`
         pub async fn send(self) -> Result<ResponseValue<types::UploadedChunk>, Error<()>> {
             let Self {
-                __progenitor_client,
+                _client,
                 task,
                 body,
             } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/worker/task/{}/chunk",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
@@ -2670,14 +2592,11 @@ pub mod builder {
                 )
                 .body(body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2687,7 +2606,7 @@ pub mod builder {
     ///[`Client::worker_task_complete`]: super::Client::worker_task_complete
     #[derive(Debug, Clone)]
     pub struct WorkerTaskComplete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         task: Result<String, String>,
         body: Result<types::builder::WorkerCompleteTask, String>,
     }
@@ -2695,7 +2614,7 @@ pub mod builder {
     impl<'a> WorkerTaskComplete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 task: Err("task was not initialized".to_string()),
                 body: Ok(types::builder::WorkerCompleteTask::default()),
             }
@@ -2735,7 +2654,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/worker/task/{task}/complete`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self {
-                __progenitor_client,
+                _client,
                 task,
                 body,
             } = self;
@@ -2743,24 +2662,17 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerCompleteTask>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/worker/task/{}/complete",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let __progenitor_request = __progenitor_client
-                .client
-                .post(__progenitor_url)
-                .json(&body)
-                .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(__progenitor_response)),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _request = _client.client.post(_url).json(&body).build()?;
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => Ok(ResponseValue::empty(_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2770,7 +2682,7 @@ pub mod builder {
     ///[`Client::worker_task_add_output`]: super::Client::worker_task_add_output
     #[derive(Debug, Clone)]
     pub struct WorkerTaskAddOutput<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         task: Result<String, String>,
         body: Result<types::builder::WorkerAddOutput, String>,
     }
@@ -2778,7 +2690,7 @@ pub mod builder {
     impl<'a> WorkerTaskAddOutput<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 task: Err("task was not initialized".to_string()),
                 body: Ok(types::builder::WorkerAddOutput::default()),
             }
@@ -2816,7 +2728,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/worker/task/{task}/output`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self {
-                __progenitor_client,
+                _client,
                 task,
                 body,
             } = self;
@@ -2824,24 +2736,17 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerAddOutput>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/worker/task/{}/output",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let __progenitor_request = __progenitor_client
-                .client
-                .post(__progenitor_url)
-                .json(&body)
-                .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => Ok(ResponseValue::empty(__progenitor_response)),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _request = _client.client.post(_url).json(&body).build()?;
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => Ok(ResponseValue::empty(_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2851,38 +2756,31 @@ pub mod builder {
     ///[`Client::workers_list`]: super::Client::workers_list
     #[derive(Debug, Clone)]
     pub struct WorkersList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> WorkersList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `GET` request to `/v1/workers`
         pub async fn send(self) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url = format!("{}/v1/workers", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/v1/workers", _client.baseurl,);
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2892,31 +2790,24 @@ pub mod builder {
     ///[`Client::workers_recycle`]: super::Client::workers_recycle
     #[derive(Debug, Clone)]
     pub struct WorkersRecycle<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> WorkersRecycle<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `POST` request to `/v1/workers/recycle`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url = format!("{}/v1/workers/recycle", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client.client.post(__progenitor_url).build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(__progenitor_response)),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let Self { _client } = self;
+            let _url = format!("{}/v1/workers/recycle", _client.baseurl,);
+            let _request = _client.client.post(_url).build()?;
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => Ok(ResponseValue::empty(_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/buildomat-builder-tagged.out
+++ b/progenitor-impl/tests/output/buildomat-builder-tagged.out
@@ -1863,31 +1863,31 @@ pub mod builder {
     ///[`Client::control_hold`]: super::Client::control_hold
     #[derive(Debug, Clone)]
     pub struct ControlHold<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> ControlHold<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `POST` request to `/v1/control/hold`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self { _client } = self;
-            let _url = format!("{}/v1/control/hold", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/v1/control/hold", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -1897,24 +1897,24 @@ pub mod builder {
     ///[`Client::control_resume`]: super::Client::control_resume
     #[derive(Debug, Clone)]
     pub struct ControlResume<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> ControlResume<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `POST` request to `/v1/control/resume`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self { _client } = self;
-            let _url = format!("{}/v1/control/resume", _client.baseurl,);
-            let _request = _client.client.post(_url).build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(_response)),
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let Self { client } = self;
+            let url = format!("{}/v1/control/resume", client.baseurl,);
+            let request = client.client.post(url).build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => Ok(ResponseValue::empty(response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -1924,14 +1924,14 @@ pub mod builder {
     ///[`Client::task_get`]: super::Client::task_get
     #[derive(Debug, Clone)]
     pub struct TaskGet<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         task: Result<String, String>,
     }
 
     impl<'a> TaskGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 task: Err("task was not initialized".to_string()),
             }
         }
@@ -1948,26 +1948,26 @@ pub mod builder {
 
         ///Sends a `GET` request to `/v1/task/{task}`
         pub async fn send(self) -> Result<ResponseValue<types::Task>, Error<()>> {
-            let Self { _client, task } = self;
+            let Self { client, task } = self;
             let task = task.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/task/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -1977,31 +1977,31 @@ pub mod builder {
     ///[`Client::tasks_get`]: super::Client::tasks_get
     #[derive(Debug, Clone)]
     pub struct TasksGet<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> TasksGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `GET` request to `/v1/tasks`
         pub async fn send(self) -> Result<ResponseValue<Vec<types::Task>>, Error<()>> {
-            let Self { _client } = self;
-            let _url = format!("{}/v1/tasks", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/v1/tasks", client.baseurl,);
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2011,14 +2011,14 @@ pub mod builder {
     ///[`Client::task_submit`]: super::Client::task_submit
     #[derive(Debug, Clone)]
     pub struct TaskSubmit<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::TaskSubmit, String>,
     }
 
     impl<'a> TaskSubmit<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::TaskSubmit::default()),
             }
         }
@@ -2044,25 +2044,25 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/tasks`
         pub async fn send(self) -> Result<ResponseValue<types::TaskSubmitResult>, Error<()>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::TaskSubmit>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/tasks", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/v1/tasks", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2072,7 +2072,7 @@ pub mod builder {
     ///[`Client::task_events_get`]: super::Client::task_events_get
     #[derive(Debug, Clone)]
     pub struct TaskEventsGet<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         task: Result<String, String>,
         minseq: Result<Option<u32>, String>,
     }
@@ -2080,7 +2080,7 @@ pub mod builder {
     impl<'a> TaskEventsGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 task: Err("task was not initialized".to_string()),
                 minseq: Ok(None),
             }
@@ -2110,35 +2110,35 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/tasks/{task}/events`
         pub async fn send(self) -> Result<ResponseValue<Vec<types::TaskEvent>>, Error<()>> {
             let Self {
-                _client,
+                client,
                 task,
                 minseq,
             } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let minseq = minseq.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/tasks/{}/events",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let mut _query = Vec::with_capacity(1usize);
+            let mut query = Vec::with_capacity(1usize);
             if let Some(v) = &minseq {
-                _query.push(("minseq", v.to_string()));
+                query.push(("minseq", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2148,14 +2148,14 @@ pub mod builder {
     ///[`Client::task_outputs_get`]: super::Client::task_outputs_get
     #[derive(Debug, Clone)]
     pub struct TaskOutputsGet<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         task: Result<String, String>,
     }
 
     impl<'a> TaskOutputsGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 task: Err("task was not initialized".to_string()),
             }
         }
@@ -2172,26 +2172,26 @@ pub mod builder {
 
         ///Sends a `GET` request to `/v1/tasks/{task}/outputs`
         pub async fn send(self) -> Result<ResponseValue<Vec<types::TaskOutput>>, Error<()>> {
-            let Self { _client, task } = self;
+            let Self { client, task } = self;
             let task = task.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/tasks/{}/outputs",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2201,7 +2201,7 @@ pub mod builder {
     ///[`Client::task_output_download`]: super::Client::task_output_download
     #[derive(Debug, Clone)]
     pub struct TaskOutputDownload<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         task: Result<String, String>,
         output: Result<String, String>,
     }
@@ -2209,7 +2209,7 @@ pub mod builder {
     impl<'a> TaskOutputDownload<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 task: Err("task was not initialized".to_string()),
                 output: Err("output was not initialized".to_string()),
             }
@@ -2238,24 +2238,24 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/tasks/{task}/outputs/{output}`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<()>> {
             let Self {
-                _client,
+                client,
                 task,
                 output,
             } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let output = output.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/tasks/{}/outputs/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&task.to_string()),
                 encode_path(&output.to_string()),
             );
-            let _request = _client.client.get(_url).build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(_response)),
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let request = client.client.get(url).build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2265,14 +2265,14 @@ pub mod builder {
     ///[`Client::user_create`]: super::Client::user_create
     #[derive(Debug, Clone)]
     pub struct UserCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::UserCreate, String>,
     }
 
     impl<'a> UserCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::UserCreate::default()),
             }
         }
@@ -2298,25 +2298,25 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/users`
         pub async fn send(self) -> Result<ResponseValue<types::UserCreateResult>, Error<()>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::UserCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/users", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/v1/users", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2326,31 +2326,31 @@ pub mod builder {
     ///[`Client::whoami`]: super::Client::whoami
     #[derive(Debug, Clone)]
     pub struct Whoami<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> Whoami<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `GET` request to `/v1/whoami`
         pub async fn send(self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
-            let Self { _client } = self;
-            let _url = format!("{}/v1/whoami", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/v1/whoami", client.baseurl,);
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2360,14 +2360,14 @@ pub mod builder {
     ///[`Client::worker_bootstrap`]: super::Client::worker_bootstrap
     #[derive(Debug, Clone)]
     pub struct WorkerBootstrap<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::WorkerBootstrap, String>,
     }
 
     impl<'a> WorkerBootstrap<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::WorkerBootstrap::default()),
             }
         }
@@ -2393,25 +2393,25 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/worker/bootstrap`
         pub async fn send(self) -> Result<ResponseValue<types::WorkerBootstrapResult>, Error<()>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerBootstrap>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/worker/bootstrap", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/v1/worker/bootstrap", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2421,31 +2421,31 @@ pub mod builder {
     ///[`Client::worker_ping`]: super::Client::worker_ping
     #[derive(Debug, Clone)]
     pub struct WorkerPing<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> WorkerPing<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `GET` request to `/v1/worker/ping`
         pub async fn send(self) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
-            let Self { _client } = self;
-            let _url = format!("{}/v1/worker/ping", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/v1/worker/ping", client.baseurl,);
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2455,7 +2455,7 @@ pub mod builder {
     ///[`Client::worker_task_append`]: super::Client::worker_task_append
     #[derive(Debug, Clone)]
     pub struct WorkerTaskAppend<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         task: Result<String, String>,
         body: Result<types::builder::WorkerAppendTask, String>,
     }
@@ -2463,7 +2463,7 @@ pub mod builder {
     impl<'a> WorkerTaskAppend<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 task: Err("task was not initialized".to_string()),
                 body: Ok(types::builder::WorkerAppendTask::default()),
             }
@@ -2502,26 +2502,22 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/append`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self {
-                _client,
-                task,
-                body,
-            } = self;
+            let Self { client, task, body } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerAppendTask>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/worker/task/{}/append",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let _request = _client.client.post(_url).json(&body).build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => Ok(ResponseValue::empty(_response)),
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let request = client.client.post(url).json(&body).build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => Ok(ResponseValue::empty(response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2531,7 +2527,7 @@ pub mod builder {
     ///[`Client::worker_task_upload_chunk`]: super::Client::worker_task_upload_chunk
     #[derive(Debug)]
     pub struct WorkerTaskUploadChunk<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         task: Result<String, String>,
         body: Result<reqwest::Body, String>,
     }
@@ -2539,7 +2535,7 @@ pub mod builder {
     impl<'a> WorkerTaskUploadChunk<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 task: Err("task was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
@@ -2567,21 +2563,17 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/chunk`
         pub async fn send(self) -> Result<ResponseValue<types::UploadedChunk>, Error<()>> {
-            let Self {
-                _client,
-                task,
-                body,
-            } = self;
+            let Self { client, task, body } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/worker/task/{}/chunk",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
@@ -2592,11 +2584,11 @@ pub mod builder {
                 )
                 .body(body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2606,7 +2598,7 @@ pub mod builder {
     ///[`Client::worker_task_complete`]: super::Client::worker_task_complete
     #[derive(Debug, Clone)]
     pub struct WorkerTaskComplete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         task: Result<String, String>,
         body: Result<types::builder::WorkerCompleteTask, String>,
     }
@@ -2614,7 +2606,7 @@ pub mod builder {
     impl<'a> WorkerTaskComplete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 task: Err("task was not initialized".to_string()),
                 body: Ok(types::builder::WorkerCompleteTask::default()),
             }
@@ -2653,26 +2645,22 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/complete`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self {
-                _client,
-                task,
-                body,
-            } = self;
+            let Self { client, task, body } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerCompleteTask>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/worker/task/{}/complete",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let _request = _client.client.post(_url).json(&body).build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(_response)),
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let request = client.client.post(url).json(&body).build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => Ok(ResponseValue::empty(response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2682,7 +2670,7 @@ pub mod builder {
     ///[`Client::worker_task_add_output`]: super::Client::worker_task_add_output
     #[derive(Debug, Clone)]
     pub struct WorkerTaskAddOutput<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         task: Result<String, String>,
         body: Result<types::builder::WorkerAddOutput, String>,
     }
@@ -2690,7 +2678,7 @@ pub mod builder {
     impl<'a> WorkerTaskAddOutput<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 task: Err("task was not initialized".to_string()),
                 body: Ok(types::builder::WorkerAddOutput::default()),
             }
@@ -2727,26 +2715,22 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/output`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self {
-                _client,
-                task,
-                body,
-            } = self;
+            let Self { client, task, body } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerAddOutput>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/worker/task/{}/output",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let _request = _client.client.post(_url).json(&body).build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => Ok(ResponseValue::empty(_response)),
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let request = client.client.post(url).json(&body).build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => Ok(ResponseValue::empty(response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2756,31 +2740,31 @@ pub mod builder {
     ///[`Client::workers_list`]: super::Client::workers_list
     #[derive(Debug, Clone)]
     pub struct WorkersList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> WorkersList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `GET` request to `/v1/workers`
         pub async fn send(self) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
-            let Self { _client } = self;
-            let _url = format!("{}/v1/workers", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/v1/workers", client.baseurl,);
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2790,24 +2774,24 @@ pub mod builder {
     ///[`Client::workers_recycle`]: super::Client::workers_recycle
     #[derive(Debug, Clone)]
     pub struct WorkersRecycle<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> WorkersRecycle<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `POST` request to `/v1/workers/recycle`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self { _client } = self;
-            let _url = format!("{}/v1/workers/recycle", _client.baseurl,);
-            let _request = _client.client.post(_url).build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(_response)),
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let Self { client } = self;
+            let url = format!("{}/v1/workers/recycle", client.baseurl,);
+            let request = client.client.post(url).build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => Ok(ResponseValue::empty(response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/buildomat-builder.out
+++ b/progenitor-impl/tests/output/buildomat-builder.out
@@ -1863,38 +1863,31 @@ pub mod builder {
     ///[`Client::control_hold`]: super::Client::control_hold
     #[derive(Debug, Clone)]
     pub struct ControlHold<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> ControlHold<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `POST` request to `/v1/control/hold`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url = format!("{}/v1/control/hold", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/v1/control/hold", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -1904,31 +1897,24 @@ pub mod builder {
     ///[`Client::control_resume`]: super::Client::control_resume
     #[derive(Debug, Clone)]
     pub struct ControlResume<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> ControlResume<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `POST` request to `/v1/control/resume`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url = format!("{}/v1/control/resume", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client.client.post(__progenitor_url).build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(__progenitor_response)),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let Self { _client } = self;
+            let _url = format!("{}/v1/control/resume", _client.baseurl,);
+            let _request = _client.client.post(_url).build()?;
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => Ok(ResponseValue::empty(_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -1938,14 +1924,14 @@ pub mod builder {
     ///[`Client::task_get`]: super::Client::task_get
     #[derive(Debug, Clone)]
     pub struct TaskGet<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         task: Result<String, String>,
     }
 
     impl<'a> TaskGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 task: Err("task was not initialized".to_string()),
             }
         }
@@ -1962,32 +1948,26 @@ pub mod builder {
 
         ///Sends a `GET` request to `/v1/task/{task}`
         pub async fn send(self) -> Result<ResponseValue<types::Task>, Error<()>> {
-            let Self {
-                __progenitor_client,
-                task,
-            } = self;
+            let Self { _client, task } = self;
             let task = task.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/task/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -1997,38 +1977,31 @@ pub mod builder {
     ///[`Client::tasks_get`]: super::Client::tasks_get
     #[derive(Debug, Clone)]
     pub struct TasksGet<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> TasksGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `GET` request to `/v1/tasks`
         pub async fn send(self) -> Result<ResponseValue<Vec<types::Task>>, Error<()>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url = format!("{}/v1/tasks", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/v1/tasks", _client.baseurl,);
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2038,14 +2011,14 @@ pub mod builder {
     ///[`Client::task_submit`]: super::Client::task_submit
     #[derive(Debug, Clone)]
     pub struct TaskSubmit<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::TaskSubmit, String>,
     }
 
     impl<'a> TaskSubmit<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::TaskSubmit::default()),
             }
         }
@@ -2071,31 +2044,25 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/tasks`
         pub async fn send(self) -> Result<ResponseValue<types::TaskSubmitResult>, Error<()>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::TaskSubmit>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/tasks", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/v1/tasks", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2105,7 +2072,7 @@ pub mod builder {
     ///[`Client::task_events_get`]: super::Client::task_events_get
     #[derive(Debug, Clone)]
     pub struct TaskEventsGet<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         task: Result<String, String>,
         minseq: Result<Option<u32>, String>,
     }
@@ -2113,7 +2080,7 @@ pub mod builder {
     impl<'a> TaskEventsGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 task: Err("task was not initialized".to_string()),
                 minseq: Ok(None),
             }
@@ -2143,38 +2110,35 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/tasks/{task}/events`
         pub async fn send(self) -> Result<ResponseValue<Vec<types::TaskEvent>>, Error<()>> {
             let Self {
-                __progenitor_client,
+                _client,
                 task,
                 minseq,
             } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let minseq = minseq.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/tasks/{}/events",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(1usize);
+            let mut _query = Vec::with_capacity(1usize);
             if let Some(v) = &minseq {
-                __progenitor_query.push(("minseq", v.to_string()));
+                _query.push(("minseq", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2184,14 +2148,14 @@ pub mod builder {
     ///[`Client::task_outputs_get`]: super::Client::task_outputs_get
     #[derive(Debug, Clone)]
     pub struct TaskOutputsGet<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         task: Result<String, String>,
     }
 
     impl<'a> TaskOutputsGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 task: Err("task was not initialized".to_string()),
             }
         }
@@ -2208,32 +2172,26 @@ pub mod builder {
 
         ///Sends a `GET` request to `/v1/tasks/{task}/outputs`
         pub async fn send(self) -> Result<ResponseValue<Vec<types::TaskOutput>>, Error<()>> {
-            let Self {
-                __progenitor_client,
-                task,
-            } = self;
+            let Self { _client, task } = self;
             let task = task.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/tasks/{}/outputs",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2243,7 +2201,7 @@ pub mod builder {
     ///[`Client::task_output_download`]: super::Client::task_output_download
     #[derive(Debug, Clone)]
     pub struct TaskOutputDownload<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         task: Result<String, String>,
         output: Result<String, String>,
     }
@@ -2251,7 +2209,7 @@ pub mod builder {
     impl<'a> TaskOutputDownload<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 task: Err("task was not initialized".to_string()),
                 output: Err("output was not initialized".to_string()),
             }
@@ -2280,27 +2238,24 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/tasks/{task}/outputs/{output}`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<()>> {
             let Self {
-                __progenitor_client,
+                _client,
                 task,
                 output,
             } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let output = output.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/tasks/{}/outputs/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&task.to_string()),
                 encode_path(&output.to_string()),
             );
-            let __progenitor_request = __progenitor_client.client.get(__progenitor_url).build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _request = _client.client.get(_url).build()?;
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2310,14 +2265,14 @@ pub mod builder {
     ///[`Client::user_create`]: super::Client::user_create
     #[derive(Debug, Clone)]
     pub struct UserCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::UserCreate, String>,
     }
 
     impl<'a> UserCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::UserCreate::default()),
             }
         }
@@ -2343,31 +2298,25 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/users`
         pub async fn send(self) -> Result<ResponseValue<types::UserCreateResult>, Error<()>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::UserCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/users", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/v1/users", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2377,38 +2326,31 @@ pub mod builder {
     ///[`Client::whoami`]: super::Client::whoami
     #[derive(Debug, Clone)]
     pub struct Whoami<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> Whoami<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `GET` request to `/v1/whoami`
         pub async fn send(self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url = format!("{}/v1/whoami", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/v1/whoami", _client.baseurl,);
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2418,14 +2360,14 @@ pub mod builder {
     ///[`Client::worker_bootstrap`]: super::Client::worker_bootstrap
     #[derive(Debug, Clone)]
     pub struct WorkerBootstrap<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::WorkerBootstrap, String>,
     }
 
     impl<'a> WorkerBootstrap<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::WorkerBootstrap::default()),
             }
         }
@@ -2451,31 +2393,25 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/worker/bootstrap`
         pub async fn send(self) -> Result<ResponseValue<types::WorkerBootstrapResult>, Error<()>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerBootstrap>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/worker/bootstrap", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/v1/worker/bootstrap", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2485,38 +2421,31 @@ pub mod builder {
     ///[`Client::worker_ping`]: super::Client::worker_ping
     #[derive(Debug, Clone)]
     pub struct WorkerPing<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> WorkerPing<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `GET` request to `/v1/worker/ping`
         pub async fn send(self) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url = format!("{}/v1/worker/ping", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/v1/worker/ping", _client.baseurl,);
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2526,7 +2455,7 @@ pub mod builder {
     ///[`Client::worker_task_append`]: super::Client::worker_task_append
     #[derive(Debug, Clone)]
     pub struct WorkerTaskAppend<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         task: Result<String, String>,
         body: Result<types::builder::WorkerAppendTask, String>,
     }
@@ -2534,7 +2463,7 @@ pub mod builder {
     impl<'a> WorkerTaskAppend<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 task: Err("task was not initialized".to_string()),
                 body: Ok(types::builder::WorkerAppendTask::default()),
             }
@@ -2574,7 +2503,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/worker/task/{task}/append`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self {
-                __progenitor_client,
+                _client,
                 task,
                 body,
             } = self;
@@ -2582,24 +2511,17 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerAppendTask>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/worker/task/{}/append",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let __progenitor_request = __progenitor_client
-                .client
-                .post(__progenitor_url)
-                .json(&body)
-                .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => Ok(ResponseValue::empty(__progenitor_response)),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _request = _client.client.post(_url).json(&body).build()?;
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => Ok(ResponseValue::empty(_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2609,7 +2531,7 @@ pub mod builder {
     ///[`Client::worker_task_upload_chunk`]: super::Client::worker_task_upload_chunk
     #[derive(Debug)]
     pub struct WorkerTaskUploadChunk<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         task: Result<String, String>,
         body: Result<reqwest::Body, String>,
     }
@@ -2617,7 +2539,7 @@ pub mod builder {
     impl<'a> WorkerTaskUploadChunk<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 task: Err("task was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
@@ -2646,20 +2568,20 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/worker/task/{task}/chunk`
         pub async fn send(self) -> Result<ResponseValue<types::UploadedChunk>, Error<()>> {
             let Self {
-                __progenitor_client,
+                _client,
                 task,
                 body,
             } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/worker/task/{}/chunk",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
@@ -2670,14 +2592,11 @@ pub mod builder {
                 )
                 .body(body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2687,7 +2606,7 @@ pub mod builder {
     ///[`Client::worker_task_complete`]: super::Client::worker_task_complete
     #[derive(Debug, Clone)]
     pub struct WorkerTaskComplete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         task: Result<String, String>,
         body: Result<types::builder::WorkerCompleteTask, String>,
     }
@@ -2695,7 +2614,7 @@ pub mod builder {
     impl<'a> WorkerTaskComplete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 task: Err("task was not initialized".to_string()),
                 body: Ok(types::builder::WorkerCompleteTask::default()),
             }
@@ -2735,7 +2654,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/worker/task/{task}/complete`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self {
-                __progenitor_client,
+                _client,
                 task,
                 body,
             } = self;
@@ -2743,24 +2662,17 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerCompleteTask>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/worker/task/{}/complete",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let __progenitor_request = __progenitor_client
-                .client
-                .post(__progenitor_url)
-                .json(&body)
-                .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(__progenitor_response)),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _request = _client.client.post(_url).json(&body).build()?;
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => Ok(ResponseValue::empty(_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2770,7 +2682,7 @@ pub mod builder {
     ///[`Client::worker_task_add_output`]: super::Client::worker_task_add_output
     #[derive(Debug, Clone)]
     pub struct WorkerTaskAddOutput<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         task: Result<String, String>,
         body: Result<types::builder::WorkerAddOutput, String>,
     }
@@ -2778,7 +2690,7 @@ pub mod builder {
     impl<'a> WorkerTaskAddOutput<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 task: Err("task was not initialized".to_string()),
                 body: Ok(types::builder::WorkerAddOutput::default()),
             }
@@ -2816,7 +2728,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/worker/task/{task}/output`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self {
-                __progenitor_client,
+                _client,
                 task,
                 body,
             } = self;
@@ -2824,24 +2736,17 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerAddOutput>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/worker/task/{}/output",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let __progenitor_request = __progenitor_client
-                .client
-                .post(__progenitor_url)
-                .json(&body)
-                .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => Ok(ResponseValue::empty(__progenitor_response)),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _request = _client.client.post(_url).json(&body).build()?;
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => Ok(ResponseValue::empty(_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2851,38 +2756,31 @@ pub mod builder {
     ///[`Client::workers_list`]: super::Client::workers_list
     #[derive(Debug, Clone)]
     pub struct WorkersList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> WorkersList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `GET` request to `/v1/workers`
         pub async fn send(self) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url = format!("{}/v1/workers", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/v1/workers", _client.baseurl,);
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2892,31 +2790,24 @@ pub mod builder {
     ///[`Client::workers_recycle`]: super::Client::workers_recycle
     #[derive(Debug, Clone)]
     pub struct WorkersRecycle<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> WorkersRecycle<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `POST` request to `/v1/workers/recycle`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url = format!("{}/v1/workers/recycle", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client.client.post(__progenitor_url).build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(__progenitor_response)),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let Self { _client } = self;
+            let _url = format!("{}/v1/workers/recycle", _client.baseurl,);
+            let _request = _client.client.post(_url).build()?;
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => Ok(ResponseValue::empty(_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/buildomat-builder.out
+++ b/progenitor-impl/tests/output/buildomat-builder.out
@@ -1863,31 +1863,31 @@ pub mod builder {
     ///[`Client::control_hold`]: super::Client::control_hold
     #[derive(Debug, Clone)]
     pub struct ControlHold<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> ControlHold<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `POST` request to `/v1/control/hold`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self { _client } = self;
-            let _url = format!("{}/v1/control/hold", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/v1/control/hold", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -1897,24 +1897,24 @@ pub mod builder {
     ///[`Client::control_resume`]: super::Client::control_resume
     #[derive(Debug, Clone)]
     pub struct ControlResume<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> ControlResume<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `POST` request to `/v1/control/resume`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self { _client } = self;
-            let _url = format!("{}/v1/control/resume", _client.baseurl,);
-            let _request = _client.client.post(_url).build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(_response)),
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let Self { client } = self;
+            let url = format!("{}/v1/control/resume", client.baseurl,);
+            let request = client.client.post(url).build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => Ok(ResponseValue::empty(response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -1924,14 +1924,14 @@ pub mod builder {
     ///[`Client::task_get`]: super::Client::task_get
     #[derive(Debug, Clone)]
     pub struct TaskGet<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         task: Result<String, String>,
     }
 
     impl<'a> TaskGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 task: Err("task was not initialized".to_string()),
             }
         }
@@ -1948,26 +1948,26 @@ pub mod builder {
 
         ///Sends a `GET` request to `/v1/task/{task}`
         pub async fn send(self) -> Result<ResponseValue<types::Task>, Error<()>> {
-            let Self { _client, task } = self;
+            let Self { client, task } = self;
             let task = task.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/task/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -1977,31 +1977,31 @@ pub mod builder {
     ///[`Client::tasks_get`]: super::Client::tasks_get
     #[derive(Debug, Clone)]
     pub struct TasksGet<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> TasksGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `GET` request to `/v1/tasks`
         pub async fn send(self) -> Result<ResponseValue<Vec<types::Task>>, Error<()>> {
-            let Self { _client } = self;
-            let _url = format!("{}/v1/tasks", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/v1/tasks", client.baseurl,);
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2011,14 +2011,14 @@ pub mod builder {
     ///[`Client::task_submit`]: super::Client::task_submit
     #[derive(Debug, Clone)]
     pub struct TaskSubmit<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::TaskSubmit, String>,
     }
 
     impl<'a> TaskSubmit<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::TaskSubmit::default()),
             }
         }
@@ -2044,25 +2044,25 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/tasks`
         pub async fn send(self) -> Result<ResponseValue<types::TaskSubmitResult>, Error<()>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::TaskSubmit>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/tasks", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/v1/tasks", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2072,7 +2072,7 @@ pub mod builder {
     ///[`Client::task_events_get`]: super::Client::task_events_get
     #[derive(Debug, Clone)]
     pub struct TaskEventsGet<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         task: Result<String, String>,
         minseq: Result<Option<u32>, String>,
     }
@@ -2080,7 +2080,7 @@ pub mod builder {
     impl<'a> TaskEventsGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 task: Err("task was not initialized".to_string()),
                 minseq: Ok(None),
             }
@@ -2110,35 +2110,35 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/tasks/{task}/events`
         pub async fn send(self) -> Result<ResponseValue<Vec<types::TaskEvent>>, Error<()>> {
             let Self {
-                _client,
+                client,
                 task,
                 minseq,
             } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let minseq = minseq.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/tasks/{}/events",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let mut _query = Vec::with_capacity(1usize);
+            let mut query = Vec::with_capacity(1usize);
             if let Some(v) = &minseq {
-                _query.push(("minseq", v.to_string()));
+                query.push(("minseq", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2148,14 +2148,14 @@ pub mod builder {
     ///[`Client::task_outputs_get`]: super::Client::task_outputs_get
     #[derive(Debug, Clone)]
     pub struct TaskOutputsGet<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         task: Result<String, String>,
     }
 
     impl<'a> TaskOutputsGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 task: Err("task was not initialized".to_string()),
             }
         }
@@ -2172,26 +2172,26 @@ pub mod builder {
 
         ///Sends a `GET` request to `/v1/tasks/{task}/outputs`
         pub async fn send(self) -> Result<ResponseValue<Vec<types::TaskOutput>>, Error<()>> {
-            let Self { _client, task } = self;
+            let Self { client, task } = self;
             let task = task.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/tasks/{}/outputs",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2201,7 +2201,7 @@ pub mod builder {
     ///[`Client::task_output_download`]: super::Client::task_output_download
     #[derive(Debug, Clone)]
     pub struct TaskOutputDownload<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         task: Result<String, String>,
         output: Result<String, String>,
     }
@@ -2209,7 +2209,7 @@ pub mod builder {
     impl<'a> TaskOutputDownload<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 task: Err("task was not initialized".to_string()),
                 output: Err("output was not initialized".to_string()),
             }
@@ -2238,24 +2238,24 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/tasks/{task}/outputs/{output}`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<()>> {
             let Self {
-                _client,
+                client,
                 task,
                 output,
             } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let output = output.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/tasks/{}/outputs/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&task.to_string()),
                 encode_path(&output.to_string()),
             );
-            let _request = _client.client.get(_url).build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(_response)),
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let request = client.client.get(url).build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2265,14 +2265,14 @@ pub mod builder {
     ///[`Client::user_create`]: super::Client::user_create
     #[derive(Debug, Clone)]
     pub struct UserCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::UserCreate, String>,
     }
 
     impl<'a> UserCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::UserCreate::default()),
             }
         }
@@ -2298,25 +2298,25 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/users`
         pub async fn send(self) -> Result<ResponseValue<types::UserCreateResult>, Error<()>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::UserCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/users", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/v1/users", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2326,31 +2326,31 @@ pub mod builder {
     ///[`Client::whoami`]: super::Client::whoami
     #[derive(Debug, Clone)]
     pub struct Whoami<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> Whoami<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `GET` request to `/v1/whoami`
         pub async fn send(self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
-            let Self { _client } = self;
-            let _url = format!("{}/v1/whoami", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/v1/whoami", client.baseurl,);
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2360,14 +2360,14 @@ pub mod builder {
     ///[`Client::worker_bootstrap`]: super::Client::worker_bootstrap
     #[derive(Debug, Clone)]
     pub struct WorkerBootstrap<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::WorkerBootstrap, String>,
     }
 
     impl<'a> WorkerBootstrap<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::WorkerBootstrap::default()),
             }
         }
@@ -2393,25 +2393,25 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/worker/bootstrap`
         pub async fn send(self) -> Result<ResponseValue<types::WorkerBootstrapResult>, Error<()>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerBootstrap>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/worker/bootstrap", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/v1/worker/bootstrap", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2421,31 +2421,31 @@ pub mod builder {
     ///[`Client::worker_ping`]: super::Client::worker_ping
     #[derive(Debug, Clone)]
     pub struct WorkerPing<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> WorkerPing<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `GET` request to `/v1/worker/ping`
         pub async fn send(self) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
-            let Self { _client } = self;
-            let _url = format!("{}/v1/worker/ping", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/v1/worker/ping", client.baseurl,);
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2455,7 +2455,7 @@ pub mod builder {
     ///[`Client::worker_task_append`]: super::Client::worker_task_append
     #[derive(Debug, Clone)]
     pub struct WorkerTaskAppend<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         task: Result<String, String>,
         body: Result<types::builder::WorkerAppendTask, String>,
     }
@@ -2463,7 +2463,7 @@ pub mod builder {
     impl<'a> WorkerTaskAppend<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 task: Err("task was not initialized".to_string()),
                 body: Ok(types::builder::WorkerAppendTask::default()),
             }
@@ -2502,26 +2502,22 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/append`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self {
-                _client,
-                task,
-                body,
-            } = self;
+            let Self { client, task, body } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerAppendTask>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/worker/task/{}/append",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let _request = _client.client.post(_url).json(&body).build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => Ok(ResponseValue::empty(_response)),
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let request = client.client.post(url).json(&body).build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => Ok(ResponseValue::empty(response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2531,7 +2527,7 @@ pub mod builder {
     ///[`Client::worker_task_upload_chunk`]: super::Client::worker_task_upload_chunk
     #[derive(Debug)]
     pub struct WorkerTaskUploadChunk<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         task: Result<String, String>,
         body: Result<reqwest::Body, String>,
     }
@@ -2539,7 +2535,7 @@ pub mod builder {
     impl<'a> WorkerTaskUploadChunk<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 task: Err("task was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
@@ -2567,21 +2563,17 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/chunk`
         pub async fn send(self) -> Result<ResponseValue<types::UploadedChunk>, Error<()>> {
-            let Self {
-                _client,
-                task,
-                body,
-            } = self;
+            let Self { client, task, body } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/worker/task/{}/chunk",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
@@ -2592,11 +2584,11 @@ pub mod builder {
                 )
                 .body(body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2606,7 +2598,7 @@ pub mod builder {
     ///[`Client::worker_task_complete`]: super::Client::worker_task_complete
     #[derive(Debug, Clone)]
     pub struct WorkerTaskComplete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         task: Result<String, String>,
         body: Result<types::builder::WorkerCompleteTask, String>,
     }
@@ -2614,7 +2606,7 @@ pub mod builder {
     impl<'a> WorkerTaskComplete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 task: Err("task was not initialized".to_string()),
                 body: Ok(types::builder::WorkerCompleteTask::default()),
             }
@@ -2653,26 +2645,22 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/complete`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self {
-                _client,
-                task,
-                body,
-            } = self;
+            let Self { client, task, body } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerCompleteTask>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/worker/task/{}/complete",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let _request = _client.client.post(_url).json(&body).build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(_response)),
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let request = client.client.post(url).json(&body).build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => Ok(ResponseValue::empty(response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2682,7 +2670,7 @@ pub mod builder {
     ///[`Client::worker_task_add_output`]: super::Client::worker_task_add_output
     #[derive(Debug, Clone)]
     pub struct WorkerTaskAddOutput<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         task: Result<String, String>,
         body: Result<types::builder::WorkerAddOutput, String>,
     }
@@ -2690,7 +2678,7 @@ pub mod builder {
     impl<'a> WorkerTaskAddOutput<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 task: Err("task was not initialized".to_string()),
                 body: Ok(types::builder::WorkerAddOutput::default()),
             }
@@ -2727,26 +2715,22 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/worker/task/{task}/output`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self {
-                _client,
-                task,
-                body,
-            } = self;
+            let Self { client, task, body } = self;
             let task = task.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(std::convert::TryInto::<types::WorkerAddOutput>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/worker/task/{}/output",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&task.to_string()),
             );
-            let _request = _client.client.post(_url).json(&body).build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => Ok(ResponseValue::empty(_response)),
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let request = client.client.post(url).json(&body).build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => Ok(ResponseValue::empty(response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2756,31 +2740,31 @@ pub mod builder {
     ///[`Client::workers_list`]: super::Client::workers_list
     #[derive(Debug, Clone)]
     pub struct WorkersList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> WorkersList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `GET` request to `/v1/workers`
         pub async fn send(self) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
-            let Self { _client } = self;
-            let _url = format!("{}/v1/workers", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/v1/workers", client.baseurl,);
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2790,24 +2774,24 @@ pub mod builder {
     ///[`Client::workers_recycle`]: super::Client::workers_recycle
     #[derive(Debug, Clone)]
     pub struct WorkersRecycle<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> WorkersRecycle<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `POST` request to `/v1/workers/recycle`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
-            let Self { _client } = self;
-            let _url = format!("{}/v1/workers/recycle", _client.baseurl,);
-            let _request = _client.client.post(_url).build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(_response)),
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let Self { client } = self;
+            let url = format!("{}/v1/workers/recycle", client.baseurl,);
+            let request = client.client.post(url).build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => Ok(ResponseValue::empty(response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/buildomat-positional.out
+++ b/progenitor-impl/tests/output/buildomat-positional.out
@@ -313,32 +313,32 @@ impl Client {
 impl Client {
     ///Sends a `POST` request to `/v1/control/hold`
     pub async fn control_hold<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
-        let _url = format!("{}/v1/control/hold", self.baseurl,);
-        let _request = self
+        let url = format!("{}/v1/control/hold", self.baseurl,);
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
-            _ => Err(Error::UnexpectedResponse(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
     ///Sends a `POST` request to `/v1/control/resume`
     pub async fn control_resume<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
-        let _url = format!("{}/v1/control/resume", self.baseurl,);
-        let _request = self.client.post(_url).build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => Ok(ResponseValue::empty(_response)),
-            _ => Err(Error::UnexpectedResponse(_response)),
+        let url = format!("{}/v1/control/resume", self.baseurl,);
+        let request = self.client.post(url).build()?;
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => Ok(ResponseValue::empty(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -347,43 +347,43 @@ impl Client {
         &'a self,
         task: &'a str,
     ) -> Result<ResponseValue<types::Task>, Error<()>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/task/{}",
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
-            _ => Err(Error::UnexpectedResponse(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
     ///Sends a `GET` request to `/v1/tasks`
     pub async fn tasks_get<'a>(&'a self) -> Result<ResponseValue<Vec<types::Task>>, Error<()>> {
-        let _url = format!("{}/v1/tasks", self.baseurl,);
-        let _request = self
+        let url = format!("{}/v1/tasks", self.baseurl,);
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
-            _ => Err(Error::UnexpectedResponse(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -392,21 +392,21 @@ impl Client {
         &'a self,
         body: &'a types::TaskSubmit,
     ) -> Result<ResponseValue<types::TaskSubmitResult>, Error<()>> {
-        let _url = format!("{}/v1/tasks", self.baseurl,);
-        let _request = self
+        let url = format!("{}/v1/tasks", self.baseurl,);
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
-            _ => Err(Error::UnexpectedResponse(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -416,30 +416,30 @@ impl Client {
         task: &'a str,
         minseq: Option<u32>,
     ) -> Result<ResponseValue<Vec<types::TaskEvent>>, Error<()>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/tasks/{}/events",
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let mut _query = Vec::with_capacity(1usize);
+        let mut query = Vec::with_capacity(1usize);
         if let Some(v) = &minseq {
-            _query.push(("minseq", v.to_string()));
+            query.push(("minseq", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
-            _ => Err(Error::UnexpectedResponse(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -448,24 +448,24 @@ impl Client {
         &'a self,
         task: &'a str,
     ) -> Result<ResponseValue<Vec<types::TaskOutput>>, Error<()>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/tasks/{}/outputs",
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
-            _ => Err(Error::UnexpectedResponse(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -475,18 +475,18 @@ impl Client {
         task: &'a str,
         output: &'a str,
     ) -> Result<ResponseValue<ByteStream>, Error<()>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/tasks/{}/outputs/{}",
             self.baseurl,
             encode_path(&task.to_string()),
             encode_path(&output.to_string()),
         );
-        let _request = self.client.get(_url).build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200..=299 => Ok(ResponseValue::stream(_response)),
-            _ => Err(Error::UnexpectedResponse(_response)),
+        let request = self.client.get(url).build()?;
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200..=299 => Ok(ResponseValue::stream(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -495,40 +495,40 @@ impl Client {
         &'a self,
         body: &'a types::UserCreate,
     ) -> Result<ResponseValue<types::UserCreateResult>, Error<()>> {
-        let _url = format!("{}/v1/users", self.baseurl,);
-        let _request = self
+        let url = format!("{}/v1/users", self.baseurl,);
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
-            _ => Err(Error::UnexpectedResponse(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
     ///Sends a `GET` request to `/v1/whoami`
     pub async fn whoami<'a>(&'a self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
-        let _url = format!("{}/v1/whoami", self.baseurl,);
-        let _request = self
+        let url = format!("{}/v1/whoami", self.baseurl,);
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
-            _ => Err(Error::UnexpectedResponse(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -537,21 +537,21 @@ impl Client {
         &'a self,
         body: &'a types::WorkerBootstrap,
     ) -> Result<ResponseValue<types::WorkerBootstrapResult>, Error<()>> {
-        let _url = format!("{}/v1/worker/bootstrap", self.baseurl,);
-        let _request = self
+        let url = format!("{}/v1/worker/bootstrap", self.baseurl,);
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
-            _ => Err(Error::UnexpectedResponse(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -559,20 +559,20 @@ impl Client {
     pub async fn worker_ping<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
-        let _url = format!("{}/v1/worker/ping", self.baseurl,);
-        let _request = self
+        let url = format!("{}/v1/worker/ping", self.baseurl,);
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
-            _ => Err(Error::UnexpectedResponse(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -582,17 +582,17 @@ impl Client {
         task: &'a str,
         body: &'a types::WorkerAppendTask,
     ) -> Result<ResponseValue<()>, Error<()>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/worker/task/{}/append",
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let _request = self.client.post(_url).json(&body).build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => Ok(ResponseValue::empty(_response)),
-            _ => Err(Error::UnexpectedResponse(_response)),
+        let request = self.client.post(url).json(&body).build()?;
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => Ok(ResponseValue::empty(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -602,14 +602,14 @@ impl Client {
         task: &'a str,
         body: B,
     ) -> Result<ResponseValue<types::UploadedChunk>, Error<()>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/worker/task/{}/chunk",
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
@@ -620,11 +620,11 @@ impl Client {
             )
             .body(body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
-            _ => Err(Error::UnexpectedResponse(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -634,17 +634,17 @@ impl Client {
         task: &'a str,
         body: &'a types::WorkerCompleteTask,
     ) -> Result<ResponseValue<()>, Error<()>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/worker/task/{}/complete",
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let _request = self.client.post(_url).json(&body).build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => Ok(ResponseValue::empty(_response)),
-            _ => Err(Error::UnexpectedResponse(_response)),
+        let request = self.client.post(url).json(&body).build()?;
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => Ok(ResponseValue::empty(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -654,17 +654,17 @@ impl Client {
         task: &'a str,
         body: &'a types::WorkerAddOutput,
     ) -> Result<ResponseValue<()>, Error<()>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/worker/task/{}/output",
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let _request = self.client.post(_url).json(&body).build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => Ok(ResponseValue::empty(_response)),
-            _ => Err(Error::UnexpectedResponse(_response)),
+        let request = self.client.post(url).json(&body).build()?;
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => Ok(ResponseValue::empty(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -672,32 +672,32 @@ impl Client {
     pub async fn workers_list<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
-        let _url = format!("{}/v1/workers", self.baseurl,);
-        let _request = self
+        let url = format!("{}/v1/workers", self.baseurl,);
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
-            _ => Err(Error::UnexpectedResponse(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
     ///Sends a `POST` request to `/v1/workers/recycle`
     pub async fn workers_recycle<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
-        let _url = format!("{}/v1/workers/recycle", self.baseurl,);
-        let _request = self.client.post(_url).build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => Ok(ResponseValue::empty(_response)),
-            _ => Err(Error::UnexpectedResponse(_response)),
+        let url = format!("{}/v1/workers/recycle", self.baseurl,);
+        let request = self.client.post(url).build()?;
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => Ok(ResponseValue::empty(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 }

--- a/progenitor-impl/tests/output/buildomat-positional.out
+++ b/progenitor-impl/tests/output/buildomat-positional.out
@@ -313,32 +313,32 @@ impl Client {
 impl Client {
     ///Sends a `POST` request to `/v1/control/hold`
     pub async fn control_hold<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
-        let __progenitor_url = format!("{}/v1/control/hold", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/v1/control/hold", self.baseurl,);
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
     ///Sends a `POST` request to `/v1/control/resume`
     pub async fn control_resume<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
-        let __progenitor_url = format!("{}/v1/control/resume", self.baseurl,);
-        let __progenitor_request = self.client.post(__progenitor_url).build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => Ok(ResponseValue::empty(__progenitor_response)),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+        let _url = format!("{}/v1/control/resume", self.baseurl,);
+        let _request = self.client.post(_url).build()?;
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => Ok(ResponseValue::empty(_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -347,43 +347,43 @@ impl Client {
         &'a self,
         task: &'a str,
     ) -> Result<ResponseValue<types::Task>, Error<()>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/task/{}",
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
     ///Sends a `GET` request to `/v1/tasks`
     pub async fn tasks_get<'a>(&'a self) -> Result<ResponseValue<Vec<types::Task>>, Error<()>> {
-        let __progenitor_url = format!("{}/v1/tasks", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/v1/tasks", self.baseurl,);
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -392,21 +392,21 @@ impl Client {
         &'a self,
         body: &'a types::TaskSubmit,
     ) -> Result<ResponseValue<types::TaskSubmitResult>, Error<()>> {
-        let __progenitor_url = format!("{}/v1/tasks", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/v1/tasks", self.baseurl,);
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -416,30 +416,30 @@ impl Client {
         task: &'a str,
         minseq: Option<u32>,
     ) -> Result<ResponseValue<Vec<types::TaskEvent>>, Error<()>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/tasks/{}/events",
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(1usize);
+        let mut _query = Vec::with_capacity(1usize);
         if let Some(v) = &minseq {
-            __progenitor_query.push(("minseq", v.to_string()));
+            _query.push(("minseq", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -448,24 +448,24 @@ impl Client {
         &'a self,
         task: &'a str,
     ) -> Result<ResponseValue<Vec<types::TaskOutput>>, Error<()>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/tasks/{}/outputs",
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -475,18 +475,18 @@ impl Client {
         task: &'a str,
         output: &'a str,
     ) -> Result<ResponseValue<ByteStream>, Error<()>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/tasks/{}/outputs/{}",
             self.baseurl,
             encode_path(&task.to_string()),
             encode_path(&output.to_string()),
         );
-        let __progenitor_request = self.client.get(__progenitor_url).build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+        let _request = self.client.get(_url).build()?;
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200..=299 => Ok(ResponseValue::stream(_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -495,40 +495,40 @@ impl Client {
         &'a self,
         body: &'a types::UserCreate,
     ) -> Result<ResponseValue<types::UserCreateResult>, Error<()>> {
-        let __progenitor_url = format!("{}/v1/users", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/v1/users", self.baseurl,);
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
     ///Sends a `GET` request to `/v1/whoami`
     pub async fn whoami<'a>(&'a self) -> Result<ResponseValue<types::WhoamiResult>, Error<()>> {
-        let __progenitor_url = format!("{}/v1/whoami", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/v1/whoami", self.baseurl,);
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -537,21 +537,21 @@ impl Client {
         &'a self,
         body: &'a types::WorkerBootstrap,
     ) -> Result<ResponseValue<types::WorkerBootstrapResult>, Error<()>> {
-        let __progenitor_url = format!("{}/v1/worker/bootstrap", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/v1/worker/bootstrap", self.baseurl,);
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -559,20 +559,20 @@ impl Client {
     pub async fn worker_ping<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::WorkerPingResult>, Error<()>> {
-        let __progenitor_url = format!("{}/v1/worker/ping", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/v1/worker/ping", self.baseurl,);
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -582,17 +582,17 @@ impl Client {
         task: &'a str,
         body: &'a types::WorkerAppendTask,
     ) -> Result<ResponseValue<()>, Error<()>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/worker/task/{}/append",
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let __progenitor_request = self.client.post(__progenitor_url).json(&body).build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => Ok(ResponseValue::empty(__progenitor_response)),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+        let _request = self.client.post(_url).json(&body).build()?;
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => Ok(ResponseValue::empty(_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -602,14 +602,14 @@ impl Client {
         task: &'a str,
         body: B,
     ) -> Result<ResponseValue<types::UploadedChunk>, Error<()>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/worker/task/{}/chunk",
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
@@ -620,11 +620,11 @@ impl Client {
             )
             .body(body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -634,17 +634,17 @@ impl Client {
         task: &'a str,
         body: &'a types::WorkerCompleteTask,
     ) -> Result<ResponseValue<()>, Error<()>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/worker/task/{}/complete",
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let __progenitor_request = self.client.post(__progenitor_url).json(&body).build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => Ok(ResponseValue::empty(__progenitor_response)),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+        let _request = self.client.post(_url).json(&body).build()?;
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => Ok(ResponseValue::empty(_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -654,17 +654,17 @@ impl Client {
         task: &'a str,
         body: &'a types::WorkerAddOutput,
     ) -> Result<ResponseValue<()>, Error<()>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/worker/task/{}/output",
             self.baseurl,
             encode_path(&task.to_string()),
         );
-        let __progenitor_request = self.client.post(__progenitor_url).json(&body).build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => Ok(ResponseValue::empty(__progenitor_response)),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+        let _request = self.client.post(_url).json(&body).build()?;
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => Ok(ResponseValue::empty(_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -672,32 +672,32 @@ impl Client {
     pub async fn workers_list<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::WorkersResult>, Error<()>> {
-        let __progenitor_url = format!("{}/v1/workers", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/v1/workers", self.baseurl,);
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
     ///Sends a `POST` request to `/v1/workers/recycle`
     pub async fn workers_recycle<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {
-        let __progenitor_url = format!("{}/v1/workers/recycle", self.baseurl,);
-        let __progenitor_request = self.client.post(__progenitor_url).build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => Ok(ResponseValue::empty(__progenitor_response)),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+        let _url = format!("{}/v1/workers/recycle", self.baseurl,);
+        let _request = self.client.post(_url).build()?;
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => Ok(ResponseValue::empty(_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 }

--- a/progenitor-impl/tests/output/keeper-builder-tagged.out
+++ b/progenitor-impl/tests/output/keeper-builder-tagged.out
@@ -1065,7 +1065,7 @@ pub mod builder {
     ///[`Client::enrol`]: super::Client::enrol
     #[derive(Debug, Clone)]
     pub struct Enrol<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         authorization: Result<String, String>,
         body: Result<types::builder::EnrolBody, String>,
     }
@@ -1073,7 +1073,7 @@ pub mod builder {
     impl<'a> Enrol<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(types::builder::EnrolBody::default()),
             }
@@ -1111,7 +1111,7 @@ pub mod builder {
         ///Sends a `POST` request to `/enrol`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self {
-                __progenitor_client,
+                _client,
                 authorization,
                 body,
             } = self;
@@ -1119,23 +1119,20 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::EnrolBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/enrol", __progenitor_client.baseurl,);
+            let _url = format!("{}/enrol", _client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => Ok(ResponseValue::empty(__progenitor_response)),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => Ok(ResponseValue::empty(_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -1145,14 +1142,14 @@ pub mod builder {
     ///[`Client::global_jobs`]: super::Client::global_jobs
     #[derive(Debug, Clone)]
     pub struct GlobalJobs<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         authorization: Result<String, String>,
     }
 
     impl<'a> GlobalJobs<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 authorization: Err("authorization was not initialized".to_string()),
             }
         }
@@ -1170,30 +1167,27 @@ pub mod builder {
         ///Sends a `GET` request to `/global/jobs`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalJobsResult>, Error<()>> {
             let Self {
-                __progenitor_client,
+                _client,
                 authorization,
             } = self;
             let authorization = authorization.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/global/jobs", __progenitor_client.baseurl,);
+            let _url = format!("{}/global/jobs", _client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .headers(header_map)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -1203,14 +1197,14 @@ pub mod builder {
     ///[`Client::ping`]: super::Client::ping
     #[derive(Debug, Clone)]
     pub struct Ping<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         authorization: Result<String, String>,
     }
 
     impl<'a> Ping<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 authorization: Err("authorization was not initialized".to_string()),
             }
         }
@@ -1228,30 +1222,27 @@ pub mod builder {
         ///Sends a `GET` request to `/ping`
         pub async fn send(self) -> Result<ResponseValue<types::PingResult>, Error<()>> {
             let Self {
-                __progenitor_client,
+                _client,
                 authorization,
             } = self;
             let authorization = authorization.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/ping", __progenitor_client.baseurl,);
+            let _url = format!("{}/ping", _client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .headers(header_map)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -1261,7 +1252,7 @@ pub mod builder {
     ///[`Client::report_finish`]: super::Client::report_finish
     #[derive(Debug, Clone)]
     pub struct ReportFinish<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         authorization: Result<String, String>,
         body: Result<types::builder::ReportFinishBody, String>,
     }
@@ -1269,7 +1260,7 @@ pub mod builder {
     impl<'a> ReportFinish<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(types::builder::ReportFinishBody::default()),
             }
@@ -1309,7 +1300,7 @@ pub mod builder {
         ///Sends a `POST` request to `/report/finish`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self {
-                __progenitor_client,
+                _client,
                 authorization,
                 body,
             } = self;
@@ -1317,12 +1308,12 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ReportFinishBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/report/finish", __progenitor_client.baseurl,);
+            let _url = format!("{}/report/finish", _client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
@@ -1330,14 +1321,11 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -1347,7 +1335,7 @@ pub mod builder {
     ///[`Client::report_output`]: super::Client::report_output
     #[derive(Debug, Clone)]
     pub struct ReportOutput<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         authorization: Result<String, String>,
         body: Result<types::builder::ReportOutputBody, String>,
     }
@@ -1355,7 +1343,7 @@ pub mod builder {
     impl<'a> ReportOutput<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(types::builder::ReportOutputBody::default()),
             }
@@ -1395,7 +1383,7 @@ pub mod builder {
         ///Sends a `POST` request to `/report/output`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self {
-                __progenitor_client,
+                _client,
                 authorization,
                 body,
             } = self;
@@ -1403,12 +1391,12 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ReportOutputBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/report/output", __progenitor_client.baseurl,);
+            let _url = format!("{}/report/output", _client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
@@ -1416,14 +1404,11 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -1433,7 +1418,7 @@ pub mod builder {
     ///[`Client::report_start`]: super::Client::report_start
     #[derive(Debug, Clone)]
     pub struct ReportStart<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         authorization: Result<String, String>,
         body: Result<types::builder::ReportStartBody, String>,
     }
@@ -1441,7 +1426,7 @@ pub mod builder {
     impl<'a> ReportStart<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(types::builder::ReportStartBody::default()),
             }
@@ -1479,7 +1464,7 @@ pub mod builder {
         ///Sends a `POST` request to `/report/start`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self {
-                __progenitor_client,
+                _client,
                 authorization,
                 body,
             } = self;
@@ -1487,12 +1472,12 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ReportStartBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/report/start", __progenitor_client.baseurl,);
+            let _url = format!("{}/report/start", _client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
@@ -1500,14 +1485,11 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/keeper-builder-tagged.out
+++ b/progenitor-impl/tests/output/keeper-builder-tagged.out
@@ -1065,7 +1065,7 @@ pub mod builder {
     ///[`Client::enrol`]: super::Client::enrol
     #[derive(Debug, Clone)]
     pub struct Enrol<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         authorization: Result<String, String>,
         body: Result<types::builder::EnrolBody, String>,
     }
@@ -1073,7 +1073,7 @@ pub mod builder {
     impl<'a> Enrol<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(types::builder::EnrolBody::default()),
             }
@@ -1111,7 +1111,7 @@ pub mod builder {
         ///Sends a `POST` request to `/enrol`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self {
-                _client,
+                client,
                 authorization,
                 body,
             } = self;
@@ -1119,20 +1119,20 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::EnrolBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/enrol", _client.baseurl,);
+            let url = format!("{}/enrol", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => Ok(ResponseValue::empty(_response)),
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => Ok(ResponseValue::empty(response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -1142,14 +1142,14 @@ pub mod builder {
     ///[`Client::global_jobs`]: super::Client::global_jobs
     #[derive(Debug, Clone)]
     pub struct GlobalJobs<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         authorization: Result<String, String>,
     }
 
     impl<'a> GlobalJobs<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 authorization: Err("authorization was not initialized".to_string()),
             }
         }
@@ -1167,27 +1167,27 @@ pub mod builder {
         ///Sends a `GET` request to `/global/jobs`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalJobsResult>, Error<()>> {
             let Self {
-                _client,
+                client,
                 authorization,
             } = self;
             let authorization = authorization.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/global/jobs", _client.baseurl,);
+            let url = format!("{}/global/jobs", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .headers(header_map)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -1197,14 +1197,14 @@ pub mod builder {
     ///[`Client::ping`]: super::Client::ping
     #[derive(Debug, Clone)]
     pub struct Ping<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         authorization: Result<String, String>,
     }
 
     impl<'a> Ping<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 authorization: Err("authorization was not initialized".to_string()),
             }
         }
@@ -1222,27 +1222,27 @@ pub mod builder {
         ///Sends a `GET` request to `/ping`
         pub async fn send(self) -> Result<ResponseValue<types::PingResult>, Error<()>> {
             let Self {
-                _client,
+                client,
                 authorization,
             } = self;
             let authorization = authorization.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/ping", _client.baseurl,);
+            let url = format!("{}/ping", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .headers(header_map)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -1252,7 +1252,7 @@ pub mod builder {
     ///[`Client::report_finish`]: super::Client::report_finish
     #[derive(Debug, Clone)]
     pub struct ReportFinish<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         authorization: Result<String, String>,
         body: Result<types::builder::ReportFinishBody, String>,
     }
@@ -1260,7 +1260,7 @@ pub mod builder {
     impl<'a> ReportFinish<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(types::builder::ReportFinishBody::default()),
             }
@@ -1300,7 +1300,7 @@ pub mod builder {
         ///Sends a `POST` request to `/report/finish`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self {
-                _client,
+                client,
                 authorization,
                 body,
             } = self;
@@ -1308,12 +1308,12 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ReportFinishBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/report/finish", _client.baseurl,);
+            let url = format!("{}/report/finish", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
@@ -1321,11 +1321,11 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -1335,7 +1335,7 @@ pub mod builder {
     ///[`Client::report_output`]: super::Client::report_output
     #[derive(Debug, Clone)]
     pub struct ReportOutput<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         authorization: Result<String, String>,
         body: Result<types::builder::ReportOutputBody, String>,
     }
@@ -1343,7 +1343,7 @@ pub mod builder {
     impl<'a> ReportOutput<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(types::builder::ReportOutputBody::default()),
             }
@@ -1383,7 +1383,7 @@ pub mod builder {
         ///Sends a `POST` request to `/report/output`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self {
-                _client,
+                client,
                 authorization,
                 body,
             } = self;
@@ -1391,12 +1391,12 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ReportOutputBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/report/output", _client.baseurl,);
+            let url = format!("{}/report/output", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
@@ -1404,11 +1404,11 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -1418,7 +1418,7 @@ pub mod builder {
     ///[`Client::report_start`]: super::Client::report_start
     #[derive(Debug, Clone)]
     pub struct ReportStart<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         authorization: Result<String, String>,
         body: Result<types::builder::ReportStartBody, String>,
     }
@@ -1426,7 +1426,7 @@ pub mod builder {
     impl<'a> ReportStart<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(types::builder::ReportStartBody::default()),
             }
@@ -1464,7 +1464,7 @@ pub mod builder {
         ///Sends a `POST` request to `/report/start`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self {
-                _client,
+                client,
                 authorization,
                 body,
             } = self;
@@ -1472,12 +1472,12 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ReportStartBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/report/start", _client.baseurl,);
+            let url = format!("{}/report/start", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
@@ -1485,11 +1485,11 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/keeper-builder.out
+++ b/progenitor-impl/tests/output/keeper-builder.out
@@ -1065,7 +1065,7 @@ pub mod builder {
     ///[`Client::enrol`]: super::Client::enrol
     #[derive(Debug, Clone)]
     pub struct Enrol<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         authorization: Result<String, String>,
         body: Result<types::builder::EnrolBody, String>,
     }
@@ -1073,7 +1073,7 @@ pub mod builder {
     impl<'a> Enrol<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(types::builder::EnrolBody::default()),
             }
@@ -1111,7 +1111,7 @@ pub mod builder {
         ///Sends a `POST` request to `/enrol`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self {
-                __progenitor_client,
+                _client,
                 authorization,
                 body,
             } = self;
@@ -1119,23 +1119,20 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::EnrolBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/enrol", __progenitor_client.baseurl,);
+            let _url = format!("{}/enrol", _client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => Ok(ResponseValue::empty(__progenitor_response)),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => Ok(ResponseValue::empty(_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -1145,14 +1142,14 @@ pub mod builder {
     ///[`Client::global_jobs`]: super::Client::global_jobs
     #[derive(Debug, Clone)]
     pub struct GlobalJobs<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         authorization: Result<String, String>,
     }
 
     impl<'a> GlobalJobs<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 authorization: Err("authorization was not initialized".to_string()),
             }
         }
@@ -1170,30 +1167,27 @@ pub mod builder {
         ///Sends a `GET` request to `/global/jobs`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalJobsResult>, Error<()>> {
             let Self {
-                __progenitor_client,
+                _client,
                 authorization,
             } = self;
             let authorization = authorization.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/global/jobs", __progenitor_client.baseurl,);
+            let _url = format!("{}/global/jobs", _client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .headers(header_map)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -1203,14 +1197,14 @@ pub mod builder {
     ///[`Client::ping`]: super::Client::ping
     #[derive(Debug, Clone)]
     pub struct Ping<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         authorization: Result<String, String>,
     }
 
     impl<'a> Ping<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 authorization: Err("authorization was not initialized".to_string()),
             }
         }
@@ -1228,30 +1222,27 @@ pub mod builder {
         ///Sends a `GET` request to `/ping`
         pub async fn send(self) -> Result<ResponseValue<types::PingResult>, Error<()>> {
             let Self {
-                __progenitor_client,
+                _client,
                 authorization,
             } = self;
             let authorization = authorization.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/ping", __progenitor_client.baseurl,);
+            let _url = format!("{}/ping", _client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .headers(header_map)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -1261,7 +1252,7 @@ pub mod builder {
     ///[`Client::report_finish`]: super::Client::report_finish
     #[derive(Debug, Clone)]
     pub struct ReportFinish<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         authorization: Result<String, String>,
         body: Result<types::builder::ReportFinishBody, String>,
     }
@@ -1269,7 +1260,7 @@ pub mod builder {
     impl<'a> ReportFinish<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(types::builder::ReportFinishBody::default()),
             }
@@ -1309,7 +1300,7 @@ pub mod builder {
         ///Sends a `POST` request to `/report/finish`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self {
-                __progenitor_client,
+                _client,
                 authorization,
                 body,
             } = self;
@@ -1317,12 +1308,12 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ReportFinishBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/report/finish", __progenitor_client.baseurl,);
+            let _url = format!("{}/report/finish", _client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
@@ -1330,14 +1321,11 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -1347,7 +1335,7 @@ pub mod builder {
     ///[`Client::report_output`]: super::Client::report_output
     #[derive(Debug, Clone)]
     pub struct ReportOutput<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         authorization: Result<String, String>,
         body: Result<types::builder::ReportOutputBody, String>,
     }
@@ -1355,7 +1343,7 @@ pub mod builder {
     impl<'a> ReportOutput<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(types::builder::ReportOutputBody::default()),
             }
@@ -1395,7 +1383,7 @@ pub mod builder {
         ///Sends a `POST` request to `/report/output`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self {
-                __progenitor_client,
+                _client,
                 authorization,
                 body,
             } = self;
@@ -1403,12 +1391,12 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ReportOutputBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/report/output", __progenitor_client.baseurl,);
+            let _url = format!("{}/report/output", _client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
@@ -1416,14 +1404,11 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -1433,7 +1418,7 @@ pub mod builder {
     ///[`Client::report_start`]: super::Client::report_start
     #[derive(Debug, Clone)]
     pub struct ReportStart<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         authorization: Result<String, String>,
         body: Result<types::builder::ReportStartBody, String>,
     }
@@ -1441,7 +1426,7 @@ pub mod builder {
     impl<'a> ReportStart<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(types::builder::ReportStartBody::default()),
             }
@@ -1479,7 +1464,7 @@ pub mod builder {
         ///Sends a `POST` request to `/report/start`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self {
-                __progenitor_client,
+                _client,
                 authorization,
                 body,
             } = self;
@@ -1487,12 +1472,12 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ReportStartBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/report/start", __progenitor_client.baseurl,);
+            let _url = format!("{}/report/start", _client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
@@ -1500,14 +1485,11 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/keeper-builder.out
+++ b/progenitor-impl/tests/output/keeper-builder.out
@@ -1065,7 +1065,7 @@ pub mod builder {
     ///[`Client::enrol`]: super::Client::enrol
     #[derive(Debug, Clone)]
     pub struct Enrol<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         authorization: Result<String, String>,
         body: Result<types::builder::EnrolBody, String>,
     }
@@ -1073,7 +1073,7 @@ pub mod builder {
     impl<'a> Enrol<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(types::builder::EnrolBody::default()),
             }
@@ -1111,7 +1111,7 @@ pub mod builder {
         ///Sends a `POST` request to `/enrol`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self {
-                _client,
+                client,
                 authorization,
                 body,
             } = self;
@@ -1119,20 +1119,20 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::EnrolBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/enrol", _client.baseurl,);
+            let url = format!("{}/enrol", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => Ok(ResponseValue::empty(_response)),
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => Ok(ResponseValue::empty(response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -1142,14 +1142,14 @@ pub mod builder {
     ///[`Client::global_jobs`]: super::Client::global_jobs
     #[derive(Debug, Clone)]
     pub struct GlobalJobs<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         authorization: Result<String, String>,
     }
 
     impl<'a> GlobalJobs<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 authorization: Err("authorization was not initialized".to_string()),
             }
         }
@@ -1167,27 +1167,27 @@ pub mod builder {
         ///Sends a `GET` request to `/global/jobs`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalJobsResult>, Error<()>> {
             let Self {
-                _client,
+                client,
                 authorization,
             } = self;
             let authorization = authorization.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/global/jobs", _client.baseurl,);
+            let url = format!("{}/global/jobs", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .headers(header_map)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -1197,14 +1197,14 @@ pub mod builder {
     ///[`Client::ping`]: super::Client::ping
     #[derive(Debug, Clone)]
     pub struct Ping<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         authorization: Result<String, String>,
     }
 
     impl<'a> Ping<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 authorization: Err("authorization was not initialized".to_string()),
             }
         }
@@ -1222,27 +1222,27 @@ pub mod builder {
         ///Sends a `GET` request to `/ping`
         pub async fn send(self) -> Result<ResponseValue<types::PingResult>, Error<()>> {
             let Self {
-                _client,
+                client,
                 authorization,
             } = self;
             let authorization = authorization.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/ping", _client.baseurl,);
+            let url = format!("{}/ping", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .headers(header_map)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -1252,7 +1252,7 @@ pub mod builder {
     ///[`Client::report_finish`]: super::Client::report_finish
     #[derive(Debug, Clone)]
     pub struct ReportFinish<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         authorization: Result<String, String>,
         body: Result<types::builder::ReportFinishBody, String>,
     }
@@ -1260,7 +1260,7 @@ pub mod builder {
     impl<'a> ReportFinish<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(types::builder::ReportFinishBody::default()),
             }
@@ -1300,7 +1300,7 @@ pub mod builder {
         ///Sends a `POST` request to `/report/finish`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self {
-                _client,
+                client,
                 authorization,
                 body,
             } = self;
@@ -1308,12 +1308,12 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ReportFinishBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/report/finish", _client.baseurl,);
+            let url = format!("{}/report/finish", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
@@ -1321,11 +1321,11 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -1335,7 +1335,7 @@ pub mod builder {
     ///[`Client::report_output`]: super::Client::report_output
     #[derive(Debug, Clone)]
     pub struct ReportOutput<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         authorization: Result<String, String>,
         body: Result<types::builder::ReportOutputBody, String>,
     }
@@ -1343,7 +1343,7 @@ pub mod builder {
     impl<'a> ReportOutput<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(types::builder::ReportOutputBody::default()),
             }
@@ -1383,7 +1383,7 @@ pub mod builder {
         ///Sends a `POST` request to `/report/output`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self {
-                _client,
+                client,
                 authorization,
                 body,
             } = self;
@@ -1391,12 +1391,12 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ReportOutputBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/report/output", _client.baseurl,);
+            let url = format!("{}/report/output", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
@@ -1404,11 +1404,11 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -1418,7 +1418,7 @@ pub mod builder {
     ///[`Client::report_start`]: super::Client::report_start
     #[derive(Debug, Clone)]
     pub struct ReportStart<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         authorization: Result<String, String>,
         body: Result<types::builder::ReportStartBody, String>,
     }
@@ -1426,7 +1426,7 @@ pub mod builder {
     impl<'a> ReportStart<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 authorization: Err("authorization was not initialized".to_string()),
                 body: Ok(types::builder::ReportStartBody::default()),
             }
@@ -1464,7 +1464,7 @@ pub mod builder {
         ///Sends a `POST` request to `/report/start`
         pub async fn send(self) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
             let Self {
-                _client,
+                client,
                 authorization,
                 body,
             } = self;
@@ -1472,12 +1472,12 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ReportStartBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/report/start", _client.baseurl,);
+            let url = format!("{}/report/start", client.baseurl,);
             let mut header_map = HeaderMap::with_capacity(1usize);
             header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
@@ -1485,11 +1485,11 @@ pub mod builder {
                 .json(&body)
                 .headers(header_map)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/keeper-positional.out
+++ b/progenitor-impl/tests/output/keeper-positional.out
@@ -210,20 +210,20 @@ impl Client {
         authorization: &'a str,
         body: &'a types::EnrolBody,
     ) -> Result<ResponseValue<()>, Error<()>> {
-        let __progenitor_url = format!("{}/enrol", self.baseurl,);
+        let _url = format!("{}/enrol", self.baseurl,);
         let mut header_map = HeaderMap::with_capacity(1usize);
         header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .json(&body)
             .headers(header_map)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => Ok(ResponseValue::empty(__progenitor_response)),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => Ok(ResponseValue::empty(_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -235,23 +235,23 @@ impl Client {
         &'a self,
         authorization: &'a str,
     ) -> Result<ResponseValue<types::GlobalJobsResult>, Error<()>> {
-        let __progenitor_url = format!("{}/global/jobs", self.baseurl,);
+        let _url = format!("{}/global/jobs", self.baseurl,);
         let mut header_map = HeaderMap::with_capacity(1usize);
         header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .headers(header_map)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -263,23 +263,23 @@ impl Client {
         &'a self,
         authorization: &'a str,
     ) -> Result<ResponseValue<types::PingResult>, Error<()>> {
-        let __progenitor_url = format!("{}/ping", self.baseurl,);
+        let _url = format!("{}/ping", self.baseurl,);
         let mut header_map = HeaderMap::with_capacity(1usize);
         header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .headers(header_map)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -293,12 +293,12 @@ impl Client {
         authorization: &'a str,
         body: &'a types::ReportFinishBody,
     ) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
-        let __progenitor_url = format!("{}/report/finish", self.baseurl,);
+        let _url = format!("{}/report/finish", self.baseurl,);
         let mut header_map = HeaderMap::with_capacity(1usize);
         header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
@@ -306,11 +306,11 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -324,12 +324,12 @@ impl Client {
         authorization: &'a str,
         body: &'a types::ReportOutputBody,
     ) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
-        let __progenitor_url = format!("{}/report/output", self.baseurl,);
+        let _url = format!("{}/report/output", self.baseurl,);
         let mut header_map = HeaderMap::with_capacity(1usize);
         header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
@@ -337,11 +337,11 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -355,12 +355,12 @@ impl Client {
         authorization: &'a str,
         body: &'a types::ReportStartBody,
     ) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
-        let __progenitor_url = format!("{}/report/start", self.baseurl,);
+        let _url = format!("{}/report/start", self.baseurl,);
         let mut header_map = HeaderMap::with_capacity(1usize);
         header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
@@ -368,11 +368,11 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 }

--- a/progenitor-impl/tests/output/keeper-positional.out
+++ b/progenitor-impl/tests/output/keeper-positional.out
@@ -210,20 +210,20 @@ impl Client {
         authorization: &'a str,
         body: &'a types::EnrolBody,
     ) -> Result<ResponseValue<()>, Error<()>> {
-        let _url = format!("{}/enrol", self.baseurl,);
+        let url = format!("{}/enrol", self.baseurl,);
         let mut header_map = HeaderMap::with_capacity(1usize);
         header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .json(&body)
             .headers(header_map)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => Ok(ResponseValue::empty(_response)),
-            _ => Err(Error::UnexpectedResponse(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => Ok(ResponseValue::empty(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -235,23 +235,23 @@ impl Client {
         &'a self,
         authorization: &'a str,
     ) -> Result<ResponseValue<types::GlobalJobsResult>, Error<()>> {
-        let _url = format!("{}/global/jobs", self.baseurl,);
+        let url = format!("{}/global/jobs", self.baseurl,);
         let mut header_map = HeaderMap::with_capacity(1usize);
         header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .headers(header_map)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
-            _ => Err(Error::UnexpectedResponse(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -263,23 +263,23 @@ impl Client {
         &'a self,
         authorization: &'a str,
     ) -> Result<ResponseValue<types::PingResult>, Error<()>> {
-        let _url = format!("{}/ping", self.baseurl,);
+        let url = format!("{}/ping", self.baseurl,);
         let mut header_map = HeaderMap::with_capacity(1usize);
         header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .headers(header_map)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
-            _ => Err(Error::UnexpectedResponse(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -293,12 +293,12 @@ impl Client {
         authorization: &'a str,
         body: &'a types::ReportFinishBody,
     ) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
-        let _url = format!("{}/report/finish", self.baseurl,);
+        let url = format!("{}/report/finish", self.baseurl,);
         let mut header_map = HeaderMap::with_capacity(1usize);
         header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
@@ -306,11 +306,11 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
-            _ => Err(Error::UnexpectedResponse(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -324,12 +324,12 @@ impl Client {
         authorization: &'a str,
         body: &'a types::ReportOutputBody,
     ) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
-        let _url = format!("{}/report/output", self.baseurl,);
+        let url = format!("{}/report/output", self.baseurl,);
         let mut header_map = HeaderMap::with_capacity(1usize);
         header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
@@ -337,11 +337,11 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
-            _ => Err(Error::UnexpectedResponse(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -355,12 +355,12 @@ impl Client {
         authorization: &'a str,
         body: &'a types::ReportStartBody,
     ) -> Result<ResponseValue<types::ReportResult>, Error<()>> {
-        let _url = format!("{}/report/start", self.baseurl,);
+        let url = format!("{}/report/start", self.baseurl,);
         let mut header_map = HeaderMap::with_capacity(1usize);
         header_map.append("Authorization", HeaderValue::try_from(authorization)?);
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
@@ -368,11 +368,11 @@ impl Client {
             .json(&body)
             .headers(header_map)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
-            _ => Err(Error::UnexpectedResponse(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 }

--- a/progenitor-impl/tests/output/nexus-builder-tagged.out
+++ b/progenitor-impl/tests/output/nexus-builder-tagged.out
@@ -21032,14 +21032,14 @@ pub mod builder {
     ///[`ClientDisksExt::disk_view_by_id`]: super::ClientDisksExt::disk_view_by_id
     #[derive(Debug, Clone)]
     pub struct DiskViewById<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> DiskViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21056,32 +21056,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/disks/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/by-id/disks/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -21091,14 +21091,14 @@ pub mod builder {
     ///[`ClientImagesExt::image_view_by_id`]: super::ClientImagesExt::image_view_by_id
     #[derive(Debug, Clone)]
     pub struct ImageViewById<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> ImageViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21115,32 +21115,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/images/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/by-id/images/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -21150,14 +21150,14 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_view_by_id`]: super::ClientInstancesExt::instance_view_by_id
     #[derive(Debug, Clone)]
     pub struct InstanceViewById<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> InstanceViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21174,32 +21174,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/instances/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/by-id/instances/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -21210,14 +21210,14 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_network_interface_view_by_id`]: super::ClientInstancesExt::instance_network_interface_view_by_id
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceViewById<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> InstanceNetworkInterfaceViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21236,32 +21236,32 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/by-id/network-interfaces/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -21271,14 +21271,14 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_view_by_id`]: super::ClientOrganizationsExt::organization_view_by_id
     #[derive(Debug, Clone)]
     pub struct OrganizationViewById<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> OrganizationViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21295,32 +21295,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/organizations/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/by-id/organizations/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -21330,14 +21330,14 @@ pub mod builder {
     ///[`ClientProjectsExt::project_view_by_id`]: super::ClientProjectsExt::project_view_by_id
     #[derive(Debug, Clone)]
     pub struct ProjectViewById<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> ProjectViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21354,32 +21354,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/projects/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/by-id/projects/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -21389,14 +21389,14 @@ pub mod builder {
     ///[`ClientSnapshotsExt::snapshot_view_by_id`]: super::ClientSnapshotsExt::snapshot_view_by_id
     #[derive(Debug, Clone)]
     pub struct SnapshotViewById<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SnapshotViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21413,32 +21413,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/snapshots/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/by-id/snapshots/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -21448,14 +21448,14 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_route_view_by_id`]: super::ClientVpcsExt::vpc_router_route_view_by_id
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteViewById<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcRouterRouteViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21472,32 +21472,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/vpc-router-routes/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/by-id/vpc-router-routes/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -21507,14 +21507,14 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_view_by_id`]: super::ClientVpcsExt::vpc_router_view_by_id
     #[derive(Debug, Clone)]
     pub struct VpcRouterViewById<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcRouterViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21531,32 +21531,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/vpc-routers/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/by-id/vpc-routers/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -21566,14 +21566,14 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_subnet_view_by_id`]: super::ClientVpcsExt::vpc_subnet_view_by_id
     #[derive(Debug, Clone)]
     pub struct VpcSubnetViewById<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcSubnetViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21590,32 +21590,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/vpc-subnets/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/by-id/vpc-subnets/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -21625,14 +21625,14 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_view_by_id`]: super::ClientVpcsExt::vpc_view_by_id
     #[derive(Debug, Clone)]
     pub struct VpcViewById<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21649,32 +21649,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/vpcs/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/by-id/vpcs/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -21684,14 +21684,14 @@ pub mod builder {
     ///[`ClientHiddenExt::device_auth_request`]: super::ClientHiddenExt::device_auth_request
     #[derive(Debug, Clone)]
     pub struct DeviceAuthRequest<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::DeviceAuthRequest, String>,
     }
 
     impl<'a> DeviceAuthRequest<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::DeviceAuthRequest::default()),
             }
         }
@@ -21719,17 +21719,17 @@ pub mod builder {
 
         ///Sends a `POST` request to `/device/auth`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::DeviceAuthRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/device/auth", _client.baseurl,);
-            let _request = _client.client.post(_url).form_urlencoded(&body)?.build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(_response)),
-                _ => Err(Error::ErrorResponse(ResponseValue::stream(_response))),
+            let url = format!("{}/device/auth", client.baseurl,);
+            let request = client.client.post(url).form_urlencoded(&body)?.build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(response)),
+                _ => Err(Error::ErrorResponse(ResponseValue::stream(response))),
             }
         }
     }
@@ -21739,14 +21739,14 @@ pub mod builder {
     ///[`ClientHiddenExt::device_auth_confirm`]: super::ClientHiddenExt::device_auth_confirm
     #[derive(Debug, Clone)]
     pub struct DeviceAuthConfirm<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::DeviceAuthVerify, String>,
     }
 
     impl<'a> DeviceAuthConfirm<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::DeviceAuthVerify::default()),
             }
         }
@@ -21774,31 +21774,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/device/confirm`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::DeviceAuthVerify>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/device/confirm", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/device/confirm", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -21808,14 +21808,14 @@ pub mod builder {
     ///[`ClientHiddenExt::device_access_token`]: super::ClientHiddenExt::device_access_token
     #[derive(Debug, Clone)]
     pub struct DeviceAccessToken<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::DeviceAccessTokenRequest, String>,
     }
 
     impl<'a> DeviceAccessToken<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::DeviceAccessTokenRequest::default()),
             }
         }
@@ -21842,17 +21842,17 @@ pub mod builder {
 
         ///Sends a `POST` request to `/device/token`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::DeviceAccessTokenRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/device/token", _client.baseurl,);
-            let _request = _client.client.post(_url).form_urlencoded(&body)?.build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(_response)),
-                _ => Err(Error::ErrorResponse(ResponseValue::stream(_response))),
+            let url = format!("{}/device/token", client.baseurl,);
+            let request = client.client.post(url).form_urlencoded(&body)?.build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(response)),
+                _ => Err(Error::ErrorResponse(ResponseValue::stream(response))),
             }
         }
     }
@@ -21862,7 +21862,7 @@ pub mod builder {
     ///[`ClientSilosExt::group_list`]: super::ClientSilosExt::group_list
     #[derive(Debug, Clone)]
     pub struct GroupList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -21871,7 +21871,7 @@ pub mod builder {
     impl<'a> GroupList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -21915,7 +21915,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -21923,37 +21923,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/groups", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/groups", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -22019,14 +22019,14 @@ pub mod builder {
     ///[`ClientHiddenExt::login_spoof`]: super::ClientHiddenExt::login_spoof
     #[derive(Debug, Clone)]
     pub struct LoginSpoof<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::SpoofLoginBody, String>,
     }
 
     impl<'a> LoginSpoof<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::SpoofLoginBody::default()),
             }
         }
@@ -22052,31 +22052,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/login`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SpoofLoginBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/login", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/login", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -22086,7 +22086,7 @@ pub mod builder {
     ///[`ClientLoginExt::login_local`]: super::ClientLoginExt::login_local
     #[derive(Debug, Clone)]
     pub struct LoginLocal<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         body: Result<types::builder::UsernamePasswordCredentials, String>,
     }
@@ -22094,7 +22094,7 @@ pub mod builder {
     impl<'a> LoginLocal<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(types::builder::UsernamePasswordCredentials::default()),
             }
@@ -22133,7 +22133,7 @@ pub mod builder {
         ///Sends a `POST` request to `/login/{silo_name}/local`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 silo_name,
                 body,
             } = self;
@@ -22141,23 +22141,23 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::UsernamePasswordCredentials>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/login/{}/local",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let _request = _client.client.post(_url).json(&body).build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(_response)),
+            let request = client.client.post(url).json(&body).build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -22167,7 +22167,7 @@ pub mod builder {
     ///[`ClientLoginExt::login_saml_begin`]: super::ClientLoginExt::login_saml_begin
     #[derive(Debug, Clone)]
     pub struct LoginSamlBegin<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         provider_name: Result<types::Name, String>,
     }
@@ -22175,7 +22175,7 @@ pub mod builder {
     impl<'a> LoginSamlBegin<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 provider_name: Err("provider_name was not initialized".to_string()),
             }
@@ -22204,30 +22204,30 @@ pub mod builder {
         ///Sends a `GET` request to `/login/{silo_name}/saml/{provider_name}`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 silo_name,
                 provider_name,
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let provider_name = provider_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/login/{}/saml/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let _request = _client.client.get(_url).build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(_response)),
+            let request = client.client.get(url).build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -22237,7 +22237,7 @@ pub mod builder {
     ///[`ClientLoginExt::login_saml`]: super::ClientLoginExt::login_saml
     #[derive(Debug)]
     pub struct LoginSaml<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         provider_name: Result<types::Name, String>,
         body: Result<reqwest::Body, String>,
@@ -22246,7 +22246,7 @@ pub mod builder {
     impl<'a> LoginSaml<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 provider_name: Err("provider_name was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
@@ -22286,7 +22286,7 @@ pub mod builder {
         ///Sends a `POST` request to `/login/{silo_name}/saml/{provider_name}`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 silo_name,
                 provider_name,
                 body,
@@ -22294,32 +22294,32 @@ pub mod builder {
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let provider_name = provider_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/login/{}/saml/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::CONTENT_TYPE,
                     reqwest::header::HeaderValue::from_static("application/octet-stream"),
                 )
                 .body(body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -22329,37 +22329,37 @@ pub mod builder {
     ///[`ClientHiddenExt::logout`]: super::ClientHiddenExt::logout
     #[derive(Debug, Clone)]
     pub struct Logout<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> Logout<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `POST` request to `/logout`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { _client } = self;
-            let _url = format!("{}/logout", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/logout", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -22369,7 +22369,7 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_list`]: super::ClientOrganizationsExt::organization_list
     #[derive(Debug, Clone)]
     pub struct OrganizationList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameOrIdSortMode>, String>,
@@ -22378,7 +22378,7 @@ pub mod builder {
     impl<'a> OrganizationList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -22422,7 +22422,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -22430,37 +22430,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/organizations", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/organizations", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -22526,14 +22526,14 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_create`]: super::ClientOrganizationsExt::organization_create
     #[derive(Debug, Clone)]
     pub struct OrganizationCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::OrganizationCreate, String>,
     }
 
     impl<'a> OrganizationCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::OrganizationCreate::default()),
             }
         }
@@ -22561,31 +22561,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/organizations`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/organizations", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/organizations", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -22595,14 +22595,14 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_view`]: super::ClientOrganizationsExt::organization_view
     #[derive(Debug, Clone)]
     pub struct OrganizationView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
     }
 
     impl<'a> OrganizationView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
@@ -22620,34 +22620,34 @@ pub mod builder {
         ///Sends a `GET` request to `/organizations/{organization_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -22657,7 +22657,7 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_update`]: super::ClientOrganizationsExt::organization_update
     #[derive(Debug, Clone)]
     pub struct OrganizationUpdate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         body: Result<types::builder::OrganizationUpdate, String>,
     }
@@ -22665,7 +22665,7 @@ pub mod builder {
     impl<'a> OrganizationUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 body: Ok(types::builder::OrganizationUpdate::default()),
             }
@@ -22705,7 +22705,7 @@ pub mod builder {
         ///Sends a `PUT` request to `/organizations/{organization_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 body,
             } = self;
@@ -22713,31 +22713,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -22747,14 +22747,14 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_delete`]: super::ClientOrganizationsExt::organization_delete
     #[derive(Debug, Clone)]
     pub struct OrganizationDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
     }
 
     impl<'a> OrganizationDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
@@ -22772,34 +22772,34 @@ pub mod builder {
         ///Sends a `DELETE` request to `/organizations/{organization_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -22809,14 +22809,14 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_policy_view`]: super::ClientOrganizationsExt::organization_policy_view
     #[derive(Debug, Clone)]
     pub struct OrganizationPolicyView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
     }
 
     impl<'a> OrganizationPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
@@ -22836,34 +22836,34 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/policy",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -22873,7 +22873,7 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_policy_update`]: super::ClientOrganizationsExt::organization_policy_update
     #[derive(Debug, Clone)]
     pub struct OrganizationPolicyUpdate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         body: Result<types::builder::OrganizationRolePolicy, String>,
     }
@@ -22881,7 +22881,7 @@ pub mod builder {
     impl<'a> OrganizationPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 body: Ok(types::builder::OrganizationRolePolicy::default()),
             }
@@ -22923,7 +22923,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 body,
             } = self;
@@ -22931,31 +22931,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/policy",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -22965,7 +22965,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_list`]: super::ClientProjectsExt::project_list
     #[derive(Debug, Clone)]
     pub struct ProjectList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -22975,7 +22975,7 @@ pub mod builder {
     impl<'a> ProjectList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -23031,7 +23031,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 limit,
                 page_token,
@@ -23041,41 +23041,41 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -23142,7 +23142,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_create`]: super::ClientProjectsExt::project_create
     #[derive(Debug, Clone)]
     pub struct ProjectCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         body: Result<types::builder::ProjectCreate, String>,
     }
@@ -23150,7 +23150,7 @@ pub mod builder {
     impl<'a> ProjectCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 body: Ok(types::builder::ProjectCreate::default()),
             }
@@ -23189,7 +23189,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 body,
             } = self;
@@ -23197,31 +23197,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -23231,7 +23231,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_view`]: super::ClientProjectsExt::project_view
     #[derive(Debug, Clone)]
     pub struct ProjectView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
     }
@@ -23239,7 +23239,7 @@ pub mod builder {
     impl<'a> ProjectView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
             }
@@ -23269,37 +23269,37 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -23309,7 +23309,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_update`]: super::ClientProjectsExt::project_update
     #[derive(Debug, Clone)]
     pub struct ProjectUpdate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::ProjectUpdate, String>,
@@ -23318,7 +23318,7 @@ pub mod builder {
     impl<'a> ProjectUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::ProjectUpdate::default()),
@@ -23368,7 +23368,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 body,
@@ -23378,32 +23378,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -23413,7 +23413,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_delete`]: super::ClientProjectsExt::project_delete
     #[derive(Debug, Clone)]
     pub struct ProjectDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
     }
@@ -23421,7 +23421,7 @@ pub mod builder {
     impl<'a> ProjectDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
             }
@@ -23451,37 +23451,37 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -23491,7 +23491,7 @@ pub mod builder {
     ///[`ClientDisksExt::disk_list`]: super::ClientDisksExt::disk_list
     #[derive(Debug, Clone)]
     pub struct DiskList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -23502,7 +23502,7 @@ pub mod builder {
     impl<'a> DiskList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -23569,7 +23569,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 limit,
@@ -23581,42 +23581,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/disks",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -23683,7 +23683,7 @@ pub mod builder {
     ///[`ClientDisksExt::disk_create`]: super::ClientDisksExt::disk_create
     #[derive(Debug, Clone)]
     pub struct DiskCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::DiskCreate, String>,
@@ -23692,7 +23692,7 @@ pub mod builder {
     impl<'a> DiskCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::DiskCreate::default()),
@@ -23742,7 +23742,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}/disks`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 body,
@@ -23752,32 +23752,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/disks",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -23787,7 +23787,7 @@ pub mod builder {
     ///[`ClientDisksExt::disk_view`]: super::ClientDisksExt::disk_view
     #[derive(Debug, Clone)]
     pub struct DiskView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         disk_name: Result<types::Name, String>,
@@ -23796,7 +23796,7 @@ pub mod builder {
     impl<'a> DiskView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 disk_name: Err("disk_name was not initialized".to_string()),
@@ -23838,7 +23838,7 @@ pub mod builder {
         /// {disk_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 disk_name,
@@ -23846,32 +23846,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let disk_name = disk_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/disks/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -23881,7 +23881,7 @@ pub mod builder {
     ///[`ClientDisksExt::disk_delete`]: super::ClientDisksExt::disk_delete
     #[derive(Debug, Clone)]
     pub struct DiskDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         disk_name: Result<types::Name, String>,
@@ -23890,7 +23890,7 @@ pub mod builder {
     impl<'a> DiskDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 disk_name: Err("disk_name was not initialized".to_string()),
@@ -23932,7 +23932,7 @@ pub mod builder {
         /// {disk_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 disk_name,
@@ -23940,32 +23940,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let disk_name = disk_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/disks/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -23975,7 +23975,7 @@ pub mod builder {
     ///[`ClientDisksExt::disk_metrics_list`]: super::ClientDisksExt::disk_metrics_list
     #[derive(Debug, Clone)]
     pub struct DiskMetricsList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         disk_name: Result<types::Name, String>,
@@ -23989,7 +23989,7 @@ pub mod builder {
     impl<'a> DiskMetricsList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 disk_name: Err("disk_name was not initialized".to_string()),
@@ -24092,7 +24092,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::MeasurementResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 disk_name,
@@ -24110,47 +24110,47 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let start_time = start_time.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/disks/{}/metrics/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
                 encode_path(&metric_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(4usize);
+            let mut query = Vec::with_capacity(4usize);
             if let Some(v) = &end_time {
-                _query.push(("end_time", v.to_string()));
+                query.push(("end_time", v.to_string()));
             }
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &start_time {
-                _query.push(("start_time", v.to_string()));
+                query.push(("start_time", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -24219,7 +24219,7 @@ pub mod builder {
     ///[`ClientImagesExt::image_list`]: super::ClientImagesExt::image_list
     #[derive(Debug, Clone)]
     pub struct ImageList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -24230,7 +24230,7 @@ pub mod builder {
     impl<'a> ImageList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -24297,7 +24297,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ImageResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 limit,
@@ -24309,42 +24309,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/images",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -24411,7 +24411,7 @@ pub mod builder {
     ///[`ClientImagesExt::image_create`]: super::ClientImagesExt::image_create
     #[derive(Debug, Clone)]
     pub struct ImageCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::ImageCreate, String>,
@@ -24420,7 +24420,7 @@ pub mod builder {
     impl<'a> ImageCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::ImageCreate::default()),
@@ -24470,7 +24470,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}/images`
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 body,
@@ -24480,32 +24480,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ImageCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/images",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -24515,7 +24515,7 @@ pub mod builder {
     ///[`ClientImagesExt::image_view`]: super::ClientImagesExt::image_view
     #[derive(Debug, Clone)]
     pub struct ImageView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         image_name: Result<types::Name, String>,
@@ -24524,7 +24524,7 @@ pub mod builder {
     impl<'a> ImageView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 image_name: Err("image_name was not initialized".to_string()),
@@ -24566,7 +24566,7 @@ pub mod builder {
         /// {image_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 image_name,
@@ -24574,32 +24574,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/images/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -24609,7 +24609,7 @@ pub mod builder {
     ///[`ClientImagesExt::image_delete`]: super::ClientImagesExt::image_delete
     #[derive(Debug, Clone)]
     pub struct ImageDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         image_name: Result<types::Name, String>,
@@ -24618,7 +24618,7 @@ pub mod builder {
     impl<'a> ImageDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 image_name: Err("image_name was not initialized".to_string()),
@@ -24660,7 +24660,7 @@ pub mod builder {
         /// {image_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 image_name,
@@ -24668,32 +24668,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/images/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -24703,7 +24703,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_list`]: super::ClientInstancesExt::instance_list
     #[derive(Debug, Clone)]
     pub struct InstanceList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -24714,7 +24714,7 @@ pub mod builder {
     impl<'a> InstanceList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -24782,7 +24782,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 limit,
@@ -24794,42 +24794,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -24897,7 +24897,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_create`]: super::ClientInstancesExt::instance_create
     #[derive(Debug, Clone)]
     pub struct InstanceCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::InstanceCreate, String>,
@@ -24906,7 +24906,7 @@ pub mod builder {
     impl<'a> InstanceCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::InstanceCreate::default()),
@@ -24957,7 +24957,7 @@ pub mod builder {
         /// instances`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 body,
@@ -24967,32 +24967,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -25002,7 +25002,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_view`]: super::ClientInstancesExt::instance_view
     #[derive(Debug, Clone)]
     pub struct InstanceView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25011,7 +25011,7 @@ pub mod builder {
     impl<'a> InstanceView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25053,7 +25053,7 @@ pub mod builder {
         /// instances/{instance_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25061,32 +25061,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -25096,7 +25096,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_delete`]: super::ClientInstancesExt::instance_delete
     #[derive(Debug, Clone)]
     pub struct InstanceDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25105,7 +25105,7 @@ pub mod builder {
     impl<'a> InstanceDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25147,7 +25147,7 @@ pub mod builder {
         /// instances/{instance_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25155,32 +25155,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -25190,7 +25190,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_disk_list`]: super::ClientInstancesExt::instance_disk_list
     #[derive(Debug, Clone)]
     pub struct InstanceDiskList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25202,7 +25202,7 @@ pub mod builder {
     impl<'a> InstanceDiskList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25281,7 +25281,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25295,43 +25295,43 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -25399,7 +25399,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_disk_attach`]: super::ClientInstancesExt::instance_disk_attach
     #[derive(Debug, Clone)]
     pub struct InstanceDiskAttach<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25409,7 +25409,7 @@ pub mod builder {
     impl<'a> InstanceDiskAttach<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25471,7 +25471,7 @@ pub mod builder {
         /// instances/{instance_name}/disks/attach`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25483,33 +25483,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskIdentifier>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks/attach",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                202u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                202u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -25519,7 +25519,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_disk_detach`]: super::ClientInstancesExt::instance_disk_detach
     #[derive(Debug, Clone)]
     pub struct InstanceDiskDetach<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25529,7 +25529,7 @@ pub mod builder {
     impl<'a> InstanceDiskDetach<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25591,7 +25591,7 @@ pub mod builder {
         /// instances/{instance_name}/disks/detach`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25603,33 +25603,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskIdentifier>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks/detach",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                202u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                202u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -25639,7 +25639,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_external_ip_list`]: super::ClientInstancesExt::instance_external_ip_list
     #[derive(Debug, Clone)]
     pub struct InstanceExternalIpList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25648,7 +25648,7 @@ pub mod builder {
     impl<'a> InstanceExternalIpList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25692,7 +25692,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ExternalIpResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25700,32 +25700,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/external-ips",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -25735,7 +25735,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_migrate`]: super::ClientInstancesExt::instance_migrate
     #[derive(Debug, Clone)]
     pub struct InstanceMigrate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25745,7 +25745,7 @@ pub mod builder {
     impl<'a> InstanceMigrate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25807,7 +25807,7 @@ pub mod builder {
         /// instances/{instance_name}/migrate`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25819,33 +25819,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceMigrate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/migrate",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -25855,7 +25855,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_network_interface_list`]: super::ClientInstancesExt::instance_network_interface_list
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25867,7 +25867,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25947,7 +25947,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::NetworkInterfaceResultsPage>, Error<types::Error>>
         {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25961,43 +25961,43 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -26065,7 +26065,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_network_interface_create`]: super::ClientInstancesExt::instance_network_interface_create
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26075,7 +26075,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26141,7 +26141,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26153,33 +26153,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::NetworkInterfaceCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -26189,7 +26189,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_network_interface_view`]: super::ClientInstancesExt::instance_network_interface_view
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26199,7 +26199,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26254,7 +26254,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26264,33 +26264,33 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let interface_name = interface_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -26300,7 +26300,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_network_interface_update`]: super::ClientInstancesExt::instance_network_interface_update
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceUpdate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26311,7 +26311,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26388,7 +26388,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26402,34 +26402,34 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::NetworkInterfaceUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -26439,7 +26439,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_network_interface_delete`]: super::ClientInstancesExt::instance_network_interface_delete
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26449,7 +26449,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26502,7 +26502,7 @@ pub mod builder {
         /// instances/{instance_name}/network-interfaces/{interface_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26512,33 +26512,33 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let interface_name = interface_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -26548,7 +26548,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_reboot`]: super::ClientInstancesExt::instance_reboot
     #[derive(Debug, Clone)]
     pub struct InstanceReboot<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26557,7 +26557,7 @@ pub mod builder {
     impl<'a> InstanceReboot<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26599,7 +26599,7 @@ pub mod builder {
         /// instances/{instance_name}/reboot`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26607,32 +26607,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/reboot",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                202u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                202u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -26642,7 +26642,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_serial_console`]: super::ClientInstancesExt::instance_serial_console
     #[derive(Debug, Clone)]
     pub struct InstanceSerialConsole<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26654,7 +26654,7 @@ pub mod builder {
     impl<'a> InstanceSerialConsole<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26734,7 +26734,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceSerialConsoleData>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26748,43 +26748,43 @@ pub mod builder {
             let from_start = from_start.map_err(Error::InvalidRequest)?;
             let max_bytes = max_bytes.map_err(Error::InvalidRequest)?;
             let most_recent = most_recent.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/serial-console",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &from_start {
-                _query.push(("from_start", v.to_string()));
+                query.push(("from_start", v.to_string()));
             }
             if let Some(v) = &max_bytes {
-                _query.push(("max_bytes", v.to_string()));
+                query.push(("max_bytes", v.to_string()));
             }
             if let Some(v) = &most_recent {
-                _query.push(("most_recent", v.to_string()));
+                query.push(("most_recent", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -26794,7 +26794,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_serial_console_stream`]: super::ClientInstancesExt::instance_serial_console_stream
     #[derive(Debug, Clone)]
     pub struct InstanceSerialConsoleStream<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26803,7 +26803,7 @@ pub mod builder {
     impl<'a> InstanceSerialConsoleStream<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26847,7 +26847,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26855,16 +26855,16 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/serial-console/stream",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(reqwest::header::CONNECTION, "Upgrade")
                 .header(reqwest::header::UPGRADE, "websocket")
                 .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -26876,12 +26876,12 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                101u16 => ResponseValue::upgrade(_response).await,
-                200..=299 => ResponseValue::upgrade(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                101u16 => ResponseValue::upgrade(response).await,
+                200..=299 => ResponseValue::upgrade(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -26891,7 +26891,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_start`]: super::ClientInstancesExt::instance_start
     #[derive(Debug, Clone)]
     pub struct InstanceStart<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26900,7 +26900,7 @@ pub mod builder {
     impl<'a> InstanceStart<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26942,7 +26942,7 @@ pub mod builder {
         /// instances/{instance_name}/start`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26950,32 +26950,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/start",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                202u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                202u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -26985,7 +26985,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_stop`]: super::ClientInstancesExt::instance_stop
     #[derive(Debug, Clone)]
     pub struct InstanceStop<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26994,7 +26994,7 @@ pub mod builder {
     impl<'a> InstanceStop<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -27036,7 +27036,7 @@ pub mod builder {
         /// instances/{instance_name}/stop`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -27044,32 +27044,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/stop",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                202u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                202u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -27079,7 +27079,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_policy_view`]: super::ClientProjectsExt::project_policy_view
     #[derive(Debug, Clone)]
     pub struct ProjectPolicyView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
     }
@@ -27087,7 +27087,7 @@ pub mod builder {
     impl<'a> ProjectPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
             }
@@ -27119,37 +27119,37 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/policy",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -27159,7 +27159,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_policy_update`]: super::ClientProjectsExt::project_policy_update
     #[derive(Debug, Clone)]
     pub struct ProjectPolicyUpdate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::ProjectRolePolicy, String>,
@@ -27168,7 +27168,7 @@ pub mod builder {
     impl<'a> ProjectPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::ProjectRolePolicy::default()),
@@ -27222,7 +27222,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 body,
@@ -27232,32 +27232,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/policy",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -27267,7 +27267,7 @@ pub mod builder {
     ///[`ClientSnapshotsExt::snapshot_list`]: super::ClientSnapshotsExt::snapshot_list
     #[derive(Debug, Clone)]
     pub struct SnapshotList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -27278,7 +27278,7 @@ pub mod builder {
     impl<'a> SnapshotList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -27346,7 +27346,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SnapshotResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 limit,
@@ -27358,42 +27358,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/snapshots",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -27461,7 +27461,7 @@ pub mod builder {
     ///[`ClientSnapshotsExt::snapshot_create`]: super::ClientSnapshotsExt::snapshot_create
     #[derive(Debug, Clone)]
     pub struct SnapshotCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::SnapshotCreate, String>,
@@ -27470,7 +27470,7 @@ pub mod builder {
     impl<'a> SnapshotCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::SnapshotCreate::default()),
@@ -27521,7 +27521,7 @@ pub mod builder {
         /// snapshots`
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 body,
@@ -27531,32 +27531,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::SnapshotCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/snapshots",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -27566,7 +27566,7 @@ pub mod builder {
     ///[`ClientSnapshotsExt::snapshot_view`]: super::ClientSnapshotsExt::snapshot_view
     #[derive(Debug, Clone)]
     pub struct SnapshotView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         snapshot_name: Result<types::Name, String>,
@@ -27575,7 +27575,7 @@ pub mod builder {
     impl<'a> SnapshotView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 snapshot_name: Err("snapshot_name was not initialized".to_string()),
@@ -27617,7 +27617,7 @@ pub mod builder {
         /// snapshots/{snapshot_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 snapshot_name,
@@ -27625,32 +27625,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let snapshot_name = snapshot_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/snapshots/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -27660,7 +27660,7 @@ pub mod builder {
     ///[`ClientSnapshotsExt::snapshot_delete`]: super::ClientSnapshotsExt::snapshot_delete
     #[derive(Debug, Clone)]
     pub struct SnapshotDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         snapshot_name: Result<types::Name, String>,
@@ -27669,7 +27669,7 @@ pub mod builder {
     impl<'a> SnapshotDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 snapshot_name: Err("snapshot_name was not initialized".to_string()),
@@ -27711,7 +27711,7 @@ pub mod builder {
         /// snapshots/{snapshot_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 snapshot_name,
@@ -27719,32 +27719,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let snapshot_name = snapshot_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/snapshots/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -27754,7 +27754,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_list`]: super::ClientVpcsExt::vpc_list
     #[derive(Debug, Clone)]
     pub struct VpcList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -27765,7 +27765,7 @@ pub mod builder {
     impl<'a> VpcList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -27832,7 +27832,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 limit,
@@ -27844,42 +27844,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -27946,7 +27946,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_create`]: super::ClientVpcsExt::vpc_create
     #[derive(Debug, Clone)]
     pub struct VpcCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::VpcCreate, String>,
@@ -27955,7 +27955,7 @@ pub mod builder {
     impl<'a> VpcCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::VpcCreate::default()),
@@ -28005,7 +28005,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs`
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 body,
@@ -28015,32 +28015,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -28050,7 +28050,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_view`]: super::ClientVpcsExt::vpc_view
     #[derive(Debug, Clone)]
     pub struct VpcView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28059,7 +28059,7 @@ pub mod builder {
     impl<'a> VpcView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28101,7 +28101,7 @@ pub mod builder {
         /// {vpc_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28109,32 +28109,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -28144,7 +28144,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_update`]: super::ClientVpcsExt::vpc_update
     #[derive(Debug, Clone)]
     pub struct VpcUpdate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28154,7 +28154,7 @@ pub mod builder {
     impl<'a> VpcUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28216,7 +28216,7 @@ pub mod builder {
         /// {vpc_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28228,33 +28228,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -28264,7 +28264,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_delete`]: super::ClientVpcsExt::vpc_delete
     #[derive(Debug, Clone)]
     pub struct VpcDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28273,7 +28273,7 @@ pub mod builder {
     impl<'a> VpcDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28315,7 +28315,7 @@ pub mod builder {
         /// {vpc_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28323,32 +28323,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -28358,7 +28358,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_firewall_rules_view`]: super::ClientVpcsExt::vpc_firewall_rules_view
     #[derive(Debug, Clone)]
     pub struct VpcFirewallRulesView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28367,7 +28367,7 @@ pub mod builder {
     impl<'a> VpcFirewallRulesView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28411,7 +28411,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcFirewallRules>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28419,32 +28419,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -28454,7 +28454,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_firewall_rules_update`]: super::ClientVpcsExt::vpc_firewall_rules_update
     #[derive(Debug, Clone)]
     pub struct VpcFirewallRulesUpdate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28464,7 +28464,7 @@ pub mod builder {
     impl<'a> VpcFirewallRulesUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28529,7 +28529,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcFirewallRules>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28541,33 +28541,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcFirewallRuleUpdateParams>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -28577,7 +28577,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_list`]: super::ClientVpcsExt::vpc_router_list
     #[derive(Debug, Clone)]
     pub struct VpcRouterList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28589,7 +28589,7 @@ pub mod builder {
     impl<'a> VpcRouterList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28668,7 +28668,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcRouterResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28682,43 +28682,43 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -28786,7 +28786,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_create`]: super::ClientVpcsExt::vpc_router_create
     #[derive(Debug, Clone)]
     pub struct VpcRouterCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28796,7 +28796,7 @@ pub mod builder {
     impl<'a> VpcRouterCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28858,7 +28858,7 @@ pub mod builder {
         /// {vpc_name}/routers`
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28870,33 +28870,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcRouterCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -28906,7 +28906,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_view`]: super::ClientVpcsExt::vpc_router_view
     #[derive(Debug, Clone)]
     pub struct VpcRouterView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28916,7 +28916,7 @@ pub mod builder {
     impl<'a> VpcRouterView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28969,7 +28969,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28979,33 +28979,33 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -29015,7 +29015,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_update`]: super::ClientVpcsExt::vpc_router_update
     #[derive(Debug, Clone)]
     pub struct VpcRouterUpdate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29026,7 +29026,7 @@ pub mod builder {
     impl<'a> VpcRouterUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29099,7 +29099,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29113,34 +29113,34 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcRouterUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -29150,7 +29150,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_delete`]: super::ClientVpcsExt::vpc_router_delete
     #[derive(Debug, Clone)]
     pub struct VpcRouterDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29160,7 +29160,7 @@ pub mod builder {
     impl<'a> VpcRouterDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29213,7 +29213,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29223,33 +29223,33 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -29259,7 +29259,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_route_list`]: super::ClientVpcsExt::vpc_router_route_list
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29272,7 +29272,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29362,7 +29362,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::RouterRouteResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29378,44 +29378,44 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -29483,7 +29483,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_route_create`]: super::ClientVpcsExt::vpc_router_route_create
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29494,7 +29494,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29569,7 +29569,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}/routes`
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29583,34 +29583,34 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::RouterRouteCreateParams>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -29620,7 +29620,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_route_view`]: super::ClientVpcsExt::vpc_router_route_view
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29631,7 +29631,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29695,7 +29695,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}/routes/{route_name}`
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29707,34 +29707,34 @@ pub mod builder {
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
             let route_name = route_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -29744,7 +29744,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_route_update`]: super::ClientVpcsExt::vpc_router_route_update
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteUpdate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29756,7 +29756,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29842,7 +29842,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}/routes/{route_name}`
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29858,35 +29858,35 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::RouterRouteUpdateParams>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -29896,7 +29896,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_route_delete`]: super::ClientVpcsExt::vpc_router_route_delete
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29907,7 +29907,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29971,7 +29971,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}/routes/{route_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29983,34 +29983,34 @@ pub mod builder {
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
             let route_name = route_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -30020,7 +30020,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_subnet_list`]: super::ClientVpcsExt::vpc_subnet_list
     #[derive(Debug, Clone)]
     pub struct VpcSubnetList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30032,7 +30032,7 @@ pub mod builder {
     impl<'a> VpcSubnetList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30111,7 +30111,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcSubnetResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30125,43 +30125,43 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -30229,7 +30229,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_subnet_create`]: super::ClientVpcsExt::vpc_subnet_create
     #[derive(Debug, Clone)]
     pub struct VpcSubnetCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30239,7 +30239,7 @@ pub mod builder {
     impl<'a> VpcSubnetCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30301,7 +30301,7 @@ pub mod builder {
         /// {vpc_name}/subnets`
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30313,33 +30313,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcSubnetCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -30349,7 +30349,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_subnet_view`]: super::ClientVpcsExt::vpc_subnet_view
     #[derive(Debug, Clone)]
     pub struct VpcSubnetView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30359,7 +30359,7 @@ pub mod builder {
     impl<'a> VpcSubnetView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30412,7 +30412,7 @@ pub mod builder {
         /// {vpc_name}/subnets/{subnet_name}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30422,33 +30422,33 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -30458,7 +30458,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_subnet_update`]: super::ClientVpcsExt::vpc_subnet_update
     #[derive(Debug, Clone)]
     pub struct VpcSubnetUpdate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30469,7 +30469,7 @@ pub mod builder {
     impl<'a> VpcSubnetUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30542,7 +30542,7 @@ pub mod builder {
         /// {vpc_name}/subnets/{subnet_name}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30556,34 +30556,34 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcSubnetUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -30593,7 +30593,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_subnet_delete`]: super::ClientVpcsExt::vpc_subnet_delete
     #[derive(Debug, Clone)]
     pub struct VpcSubnetDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30603,7 +30603,7 @@ pub mod builder {
     impl<'a> VpcSubnetDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30656,7 +30656,7 @@ pub mod builder {
         /// {vpc_name}/subnets/{subnet_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30666,33 +30666,33 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -30702,7 +30702,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_subnet_list_network_interfaces`]: super::ClientVpcsExt::vpc_subnet_list_network_interfaces
     #[derive(Debug, Clone)]
     pub struct VpcSubnetListNetworkInterfaces<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30715,7 +30715,7 @@ pub mod builder {
     impl<'a> VpcSubnetListNetworkInterfaces<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30806,7 +30806,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::NetworkInterfaceResultsPage>, Error<types::Error>>
         {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30822,44 +30822,44 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}/network-interfaces",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -30927,39 +30927,39 @@ pub mod builder {
     ///[`ClientSilosExt::policy_view`]: super::ClientSilosExt::policy_view
     #[derive(Debug, Clone)]
     pub struct PolicyView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> PolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `GET` request to `/policy`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-            let Self { _client } = self;
-            let _url = format!("{}/policy", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/policy", client.baseurl,);
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -30969,14 +30969,14 @@ pub mod builder {
     ///[`ClientSilosExt::policy_update`]: super::ClientSilosExt::policy_update
     #[derive(Debug, Clone)]
     pub struct PolicyUpdate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::SiloRolePolicy, String>,
     }
 
     impl<'a> PolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::SiloRolePolicy::default()),
             }
         }
@@ -31004,31 +31004,31 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SiloRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/policy", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/policy", client.baseurl,);
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -31038,7 +31038,7 @@ pub mod builder {
     ///[`ClientRolesExt::role_list`]: super::ClientRolesExt::role_list
     #[derive(Debug, Clone)]
     pub struct RoleList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
     }
@@ -31046,7 +31046,7 @@ pub mod builder {
     impl<'a> RoleList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
             }
@@ -31078,40 +31078,40 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::RoleResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/roles", _client.baseurl,);
-            let mut _query = Vec::with_capacity(2usize);
+            let url = format!("{}/roles", client.baseurl,);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -31176,14 +31176,14 @@ pub mod builder {
     ///[`ClientRolesExt::role_view`]: super::ClientRolesExt::role_view
     #[derive(Debug, Clone)]
     pub struct RoleView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         role_name: Result<String, String>,
     }
 
     impl<'a> RoleView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 role_name: Err("role_name was not initialized".to_string()),
             }
         }
@@ -31200,32 +31200,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/roles/{role_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Role>, Error<types::Error>> {
-            let Self { _client, role_name } = self;
+            let Self { client, role_name } = self;
             let role_name = role_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/roles/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&role_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -31235,37 +31235,37 @@ pub mod builder {
     ///[`ClientHiddenExt::session_me`]: super::ClientHiddenExt::session_me
     #[derive(Debug, Clone)]
     pub struct SessionMe<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> SessionMe<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `GET` request to `/session/me`
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
-            let Self { _client } = self;
-            let _url = format!("{}/session/me", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/session/me", client.baseurl,);
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -31275,7 +31275,7 @@ pub mod builder {
     ///[`ClientHiddenExt::session_me_groups`]: super::ClientHiddenExt::session_me_groups
     #[derive(Debug, Clone)]
     pub struct SessionMeGroups<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -31284,7 +31284,7 @@ pub mod builder {
     impl<'a> SessionMeGroups<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -31328,7 +31328,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -31336,37 +31336,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/session/me/groups", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/session/me/groups", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -31432,7 +31432,7 @@ pub mod builder {
     ///[`ClientSessionExt::session_sshkey_list`]: super::ClientSessionExt::session_sshkey_list
     #[derive(Debug, Clone)]
     pub struct SessionSshkeyList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameSortMode>, String>,
@@ -31441,7 +31441,7 @@ pub mod builder {
     impl<'a> SessionSshkeyList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -31485,7 +31485,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SshKeyResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -31493,37 +31493,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/session/me/sshkeys", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/session/me/sshkeys", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -31589,14 +31589,14 @@ pub mod builder {
     ///[`ClientSessionExt::session_sshkey_create`]: super::ClientSessionExt::session_sshkey_create
     #[derive(Debug, Clone)]
     pub struct SessionSshkeyCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::SshKeyCreate, String>,
     }
 
     impl<'a> SessionSshkeyCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::SshKeyCreate::default()),
             }
         }
@@ -31622,31 +31622,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/session/me/sshkeys`
         pub async fn send(self) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SshKeyCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/session/me/sshkeys", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/session/me/sshkeys", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -31656,14 +31656,14 @@ pub mod builder {
     ///[`ClientSessionExt::session_sshkey_view`]: super::ClientSessionExt::session_sshkey_view
     #[derive(Debug, Clone)]
     pub struct SessionSshkeyView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         ssh_key_name: Result<types::Name, String>,
     }
 
     impl<'a> SessionSshkeyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 ssh_key_name: Err("ssh_key_name was not initialized".to_string()),
             }
         }
@@ -31681,34 +31681,34 @@ pub mod builder {
         ///Sends a `GET` request to `/session/me/sshkeys/{ssh_key_name}`
         pub async fn send(self) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 ssh_key_name,
             } = self;
             let ssh_key_name = ssh_key_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/session/me/sshkeys/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -31718,14 +31718,14 @@ pub mod builder {
     ///[`ClientSessionExt::session_sshkey_delete`]: super::ClientSessionExt::session_sshkey_delete
     #[derive(Debug, Clone)]
     pub struct SessionSshkeyDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         ssh_key_name: Result<types::Name, String>,
     }
 
     impl<'a> SessionSshkeyDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 ssh_key_name: Err("ssh_key_name was not initialized".to_string()),
             }
         }
@@ -31743,34 +31743,34 @@ pub mod builder {
         ///Sends a `DELETE` request to `/session/me/sshkeys/{ssh_key_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 ssh_key_name,
             } = self;
             let ssh_key_name = ssh_key_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/session/me/sshkeys/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -31780,14 +31780,14 @@ pub mod builder {
     ///[`ClientSystemExt::system_image_view_by_id`]: super::ClientSystemExt::system_image_view_by_id
     #[derive(Debug, Clone)]
     pub struct SystemImageViewById<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SystemImageViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -31804,32 +31804,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/by-id/images/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/by-id/images/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -31839,14 +31839,14 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_view_by_id`]: super::ClientSystemExt::ip_pool_view_by_id
     #[derive(Debug, Clone)]
     pub struct IpPoolViewById<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> IpPoolViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -31863,32 +31863,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/by-id/ip-pools/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/by-id/ip-pools/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -31898,14 +31898,14 @@ pub mod builder {
     ///[`ClientSystemExt::silo_view_by_id`]: super::ClientSystemExt::silo_view_by_id
     #[derive(Debug, Clone)]
     pub struct SiloViewById<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SiloViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -31922,32 +31922,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/by-id/silos/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/by-id/silos/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -31957,7 +31957,7 @@ pub mod builder {
     ///[`ClientSystemExt::certificate_list`]: super::ClientSystemExt::certificate_list
     #[derive(Debug, Clone)]
     pub struct CertificateList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameSortMode>, String>,
@@ -31966,7 +31966,7 @@ pub mod builder {
     impl<'a> CertificateList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -32010,7 +32010,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::CertificateResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -32018,37 +32018,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/certificates", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/system/certificates", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -32114,14 +32114,14 @@ pub mod builder {
     ///[`ClientSystemExt::certificate_create`]: super::ClientSystemExt::certificate_create
     #[derive(Debug, Clone)]
     pub struct CertificateCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::CertificateCreate, String>,
     }
 
     impl<'a> CertificateCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::CertificateCreate::default()),
             }
         }
@@ -32149,31 +32149,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/certificates`
         pub async fn send(self) -> Result<ResponseValue<types::Certificate>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::CertificateCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/certificates", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/system/certificates", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -32183,14 +32183,14 @@ pub mod builder {
     ///[`ClientSystemExt::certificate_view`]: super::ClientSystemExt::certificate_view
     #[derive(Debug, Clone)]
     pub struct CertificateView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         certificate: Result<types::NameOrId, String>,
     }
 
     impl<'a> CertificateView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 certificate: Err("certificate was not initialized".to_string()),
             }
         }
@@ -32208,34 +32208,34 @@ pub mod builder {
         ///Sends a `GET` request to `/system/certificates/{certificate}`
         pub async fn send(self) -> Result<ResponseValue<types::Certificate>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 certificate,
             } = self;
             let certificate = certificate.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/certificates/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&certificate.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -32245,14 +32245,14 @@ pub mod builder {
     ///[`ClientSystemExt::certificate_delete`]: super::ClientSystemExt::certificate_delete
     #[derive(Debug, Clone)]
     pub struct CertificateDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         certificate: Result<types::NameOrId, String>,
     }
 
     impl<'a> CertificateDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 certificate: Err("certificate was not initialized".to_string()),
             }
         }
@@ -32270,34 +32270,34 @@ pub mod builder {
         ///Sends a `DELETE` request to `/system/certificates/{certificate}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 certificate,
             } = self;
             let certificate = certificate.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/certificates/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&certificate.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -32307,7 +32307,7 @@ pub mod builder {
     ///[`ClientSystemExt::physical_disk_list`]: super::ClientSystemExt::physical_disk_list
     #[derive(Debug, Clone)]
     pub struct PhysicalDiskList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -32316,7 +32316,7 @@ pub mod builder {
     impl<'a> PhysicalDiskList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -32360,7 +32360,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::PhysicalDiskResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -32368,37 +32368,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/hardware/disks", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/system/hardware/disks", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -32464,7 +32464,7 @@ pub mod builder {
     ///[`ClientSystemExt::rack_list`]: super::ClientSystemExt::rack_list
     #[derive(Debug, Clone)]
     pub struct RackList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -32473,7 +32473,7 @@ pub mod builder {
     impl<'a> RackList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -32517,7 +32517,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::RackResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -32525,37 +32525,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/hardware/racks", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/system/hardware/racks", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -32621,14 +32621,14 @@ pub mod builder {
     ///[`ClientSystemExt::rack_view`]: super::ClientSystemExt::rack_view
     #[derive(Debug, Clone)]
     pub struct RackView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         rack_id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> RackView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 rack_id: Err("rack_id was not initialized".to_string()),
             }
         }
@@ -32645,32 +32645,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/hardware/racks/{rack_id}`
         pub async fn send(self) -> Result<ResponseValue<types::Rack>, Error<types::Error>> {
-            let Self { _client, rack_id } = self;
+            let Self { client, rack_id } = self;
             let rack_id = rack_id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/hardware/racks/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&rack_id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -32680,7 +32680,7 @@ pub mod builder {
     ///[`ClientSystemExt::sled_list`]: super::ClientSystemExt::sled_list
     #[derive(Debug, Clone)]
     pub struct SledList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -32689,7 +32689,7 @@ pub mod builder {
     impl<'a> SledList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -32733,7 +32733,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SledResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -32741,37 +32741,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/hardware/sleds", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/system/hardware/sleds", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -32837,14 +32837,14 @@ pub mod builder {
     ///[`ClientSystemExt::sled_view`]: super::ClientSystemExt::sled_view
     #[derive(Debug, Clone)]
     pub struct SledView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         sled_id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SledView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 sled_id: Err("sled_id was not initialized".to_string()),
             }
         }
@@ -32861,32 +32861,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/hardware/sleds/{sled_id}`
         pub async fn send(self) -> Result<ResponseValue<types::Sled>, Error<types::Error>> {
-            let Self { _client, sled_id } = self;
+            let Self { client, sled_id } = self;
             let sled_id = sled_id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/hardware/sleds/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&sled_id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -32896,7 +32896,7 @@ pub mod builder {
     ///[`ClientSystemExt::sled_physical_disk_list`]: super::ClientSystemExt::sled_physical_disk_list
     #[derive(Debug, Clone)]
     pub struct SledPhysicalDiskList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         sled_id: Result<uuid::Uuid, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -32906,7 +32906,7 @@ pub mod builder {
     impl<'a> SledPhysicalDiskList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 sled_id: Err("sled_id was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -32961,7 +32961,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::PhysicalDiskResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 sled_id,
                 limit,
                 page_token,
@@ -32971,41 +32971,41 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/hardware/sleds/{}/disks",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&sled_id.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -33071,7 +33071,7 @@ pub mod builder {
     ///[`ClientSystemExt::system_image_list`]: super::ClientSystemExt::system_image_list
     #[derive(Debug, Clone)]
     pub struct SystemImageList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameSortMode>, String>,
@@ -33080,7 +33080,7 @@ pub mod builder {
     impl<'a> SystemImageList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -33124,7 +33124,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::GlobalImageResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -33132,37 +33132,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/images", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/system/images", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -33228,14 +33228,14 @@ pub mod builder {
     ///[`ClientSystemExt::system_image_create`]: super::ClientSystemExt::system_image_create
     #[derive(Debug, Clone)]
     pub struct SystemImageCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::GlobalImageCreate, String>,
     }
 
     impl<'a> SystemImageCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::GlobalImageCreate::default()),
             }
         }
@@ -33263,31 +33263,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/images`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::GlobalImageCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/images", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/system/images", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -33297,14 +33297,14 @@ pub mod builder {
     ///[`ClientSystemExt::system_image_view`]: super::ClientSystemExt::system_image_view
     #[derive(Debug, Clone)]
     pub struct SystemImageView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         image_name: Result<types::Name, String>,
     }
 
     impl<'a> SystemImageView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 image_name: Err("image_name was not initialized".to_string()),
             }
         }
@@ -33321,35 +33321,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/images/{image_name}`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-            let Self {
-                _client,
-                image_name,
-            } = self;
+            let Self { client, image_name } = self;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/images/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&image_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -33359,14 +33356,14 @@ pub mod builder {
     ///[`ClientSystemExt::system_image_delete`]: super::ClientSystemExt::system_image_delete
     #[derive(Debug, Clone)]
     pub struct SystemImageDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         image_name: Result<types::Name, String>,
     }
 
     impl<'a> SystemImageDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 image_name: Err("image_name was not initialized".to_string()),
             }
         }
@@ -33383,35 +33380,32 @@ pub mod builder {
 
         ///Sends a `DELETE` request to `/system/images/{image_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self {
-                _client,
-                image_name,
-            } = self;
+            let Self { client, image_name } = self;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/images/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&image_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -33421,7 +33415,7 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_list`]: super::ClientSystemExt::ip_pool_list
     #[derive(Debug, Clone)]
     pub struct IpPoolList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameOrIdSortMode>, String>,
@@ -33430,7 +33424,7 @@ pub mod builder {
     impl<'a> IpPoolList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -33474,7 +33468,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::IpPoolResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -33482,37 +33476,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/ip-pools", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/system/ip-pools", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -33578,14 +33572,14 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_create`]: super::ClientSystemExt::ip_pool_create
     #[derive(Debug, Clone)]
     pub struct IpPoolCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::IpPoolCreate, String>,
     }
 
     impl<'a> IpPoolCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::IpPoolCreate::default()),
             }
         }
@@ -33611,31 +33605,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/ip-pools`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::IpPoolCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/ip-pools", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/system/ip-pools", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -33645,14 +33639,14 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_view`]: super::ClientSystemExt::ip_pool_view
     #[derive(Debug, Clone)]
     pub struct IpPoolView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         pool_name: Result<types::Name, String>,
     }
 
     impl<'a> IpPoolView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
             }
         }
@@ -33669,32 +33663,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/ip-pools/{pool_name}`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-            let Self { _client, pool_name } = self;
+            let Self { client, pool_name } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/ip-pools/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -33704,7 +33698,7 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_update`]: super::ClientSystemExt::ip_pool_update
     #[derive(Debug, Clone)]
     pub struct IpPoolUpdate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         pool_name: Result<types::Name, String>,
         body: Result<types::builder::IpPoolUpdate, String>,
     }
@@ -33712,7 +33706,7 @@ pub mod builder {
     impl<'a> IpPoolUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 body: Ok(types::builder::IpPoolUpdate::default()),
             }
@@ -33750,7 +33744,7 @@ pub mod builder {
         ///Sends a `PUT` request to `/system/ip-pools/{pool_name}`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 pool_name,
                 body,
             } = self;
@@ -33758,31 +33752,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::IpPoolUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/ip-pools/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -33792,14 +33786,14 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_delete`]: super::ClientSystemExt::ip_pool_delete
     #[derive(Debug, Clone)]
     pub struct IpPoolDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         pool_name: Result<types::Name, String>,
     }
 
     impl<'a> IpPoolDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
             }
         }
@@ -33816,32 +33810,32 @@ pub mod builder {
 
         ///Sends a `DELETE` request to `/system/ip-pools/{pool_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { _client, pool_name } = self;
+            let Self { client, pool_name } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/ip-pools/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -33851,7 +33845,7 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_range_list`]: super::ClientSystemExt::ip_pool_range_list
     #[derive(Debug, Clone)]
     pub struct IpPoolRangeList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         pool_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -33860,7 +33854,7 @@ pub mod builder {
     impl<'a> IpPoolRangeList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -33903,7 +33897,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 pool_name,
                 limit,
                 page_token,
@@ -33911,38 +33905,38 @@ pub mod builder {
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/ip-pools/{}/ranges",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(2usize);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -34007,7 +34001,7 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_range_add`]: super::ClientSystemExt::ip_pool_range_add
     #[derive(Debug, Clone)]
     pub struct IpPoolRangeAdd<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         pool_name: Result<types::Name, String>,
         body: Result<types::IpRange, String>,
     }
@@ -34015,7 +34009,7 @@ pub mod builder {
     impl<'a> IpPoolRangeAdd<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
@@ -34044,37 +34038,37 @@ pub mod builder {
         ///Sends a `POST` request to `/system/ip-pools/{pool_name}/ranges/add`
         pub async fn send(self) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 pool_name,
                 body,
             } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/ip-pools/{}/ranges/add",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -34084,7 +34078,7 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_range_remove`]: super::ClientSystemExt::ip_pool_range_remove
     #[derive(Debug, Clone)]
     pub struct IpPoolRangeRemove<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         pool_name: Result<types::Name, String>,
         body: Result<types::IpRange, String>,
     }
@@ -34092,7 +34086,7 @@ pub mod builder {
     impl<'a> IpPoolRangeRemove<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
@@ -34122,37 +34116,37 @@ pub mod builder {
         /// `/system/ip-pools/{pool_name}/ranges/remove`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 pool_name,
                 body,
             } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/ip-pools/{}/ranges/remove",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -34162,37 +34156,37 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_service_view`]: super::ClientSystemExt::ip_pool_service_view
     #[derive(Debug, Clone)]
     pub struct IpPoolServiceView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> IpPoolServiceView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `GET` request to `/system/ip-pools-service`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-            let Self { _client } = self;
-            let _url = format!("{}/system/ip-pools-service", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/system/ip-pools-service", client.baseurl,);
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -34202,7 +34196,7 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_service_range_list`]: super::ClientSystemExt::ip_pool_service_range_list
     #[derive(Debug, Clone)]
     pub struct IpPoolServiceRangeList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
     }
@@ -34210,7 +34204,7 @@ pub mod builder {
     impl<'a> IpPoolServiceRangeList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
             }
@@ -34242,40 +34236,40 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/ip-pools-service/ranges", _client.baseurl,);
-            let mut _query = Vec::with_capacity(2usize);
+            let url = format!("{}/system/ip-pools-service/ranges", client.baseurl,);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -34340,14 +34334,14 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_service_range_add`]: super::ClientSystemExt::ip_pool_service_range_add
     #[derive(Debug, Clone)]
     pub struct IpPoolServiceRangeAdd<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::IpRange, String>,
     }
 
     impl<'a> IpPoolServiceRangeAdd<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -34364,29 +34358,29 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/ip-pools-service/ranges/add`
         pub async fn send(self) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/ip-pools-service/ranges/add", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/system/ip-pools-service/ranges/add", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -34396,14 +34390,14 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_service_range_remove`]: super::ClientSystemExt::ip_pool_service_range_remove
     #[derive(Debug, Clone)]
     pub struct IpPoolServiceRangeRemove<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::IpRange, String>,
     }
 
     impl<'a> IpPoolServiceRangeRemove<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -34420,29 +34414,29 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/ip-pools-service/ranges/remove`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/ip-pools-service/ranges/remove", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/system/ip-pools-service/ranges/remove", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -34452,7 +34446,7 @@ pub mod builder {
     ///[`ClientSystemExt::system_metric`]: super::ClientSystemExt::system_metric
     #[derive(Debug, Clone)]
     pub struct SystemMetric<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         metric_name: Result<types::SystemMetricName, String>,
         end_time: Result<Option<chrono::DateTime<chrono::offset::Utc>>, String>,
         id: Result<uuid::Uuid, String>,
@@ -34464,7 +34458,7 @@ pub mod builder {
     impl<'a> SystemMetric<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 metric_name: Err("metric_name was not initialized".to_string()),
                 end_time: Ok(None),
                 id: Err("id was not initialized".to_string()),
@@ -34543,7 +34537,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::MeasurementResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 metric_name,
                 end_time,
                 id,
@@ -34557,45 +34551,45 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let start_time = start_time.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/metrics/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&metric_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(5usize);
+            let mut query = Vec::with_capacity(5usize);
             if let Some(v) = &end_time {
-                _query.push(("end_time", v.to_string()));
+                query.push(("end_time", v.to_string()));
             }
-            _query.push(("id", id.to_string()));
+            query.push(("id", id.to_string()));
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &start_time {
-                _query.push(("start_time", v.to_string()));
+                query.push(("start_time", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -34605,39 +34599,39 @@ pub mod builder {
     ///[`ClientPolicyExt::system_policy_view`]: super::ClientPolicyExt::system_policy_view
     #[derive(Debug, Clone)]
     pub struct SystemPolicyView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> SystemPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `GET` request to `/system/policy`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
-            let Self { _client } = self;
-            let _url = format!("{}/system/policy", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/system/policy", client.baseurl,);
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -34647,14 +34641,14 @@ pub mod builder {
     ///[`ClientPolicyExt::system_policy_update`]: super::ClientPolicyExt::system_policy_update
     #[derive(Debug, Clone)]
     pub struct SystemPolicyUpdate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::FleetRolePolicy, String>,
     }
 
     impl<'a> SystemPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::FleetRolePolicy::default()),
             }
         }
@@ -34682,31 +34676,31 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::FleetRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/policy", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/system/policy", client.baseurl,);
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -34716,7 +34710,7 @@ pub mod builder {
     ///[`ClientSystemExt::saga_list`]: super::ClientSystemExt::saga_list
     #[derive(Debug, Clone)]
     pub struct SagaList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -34725,7 +34719,7 @@ pub mod builder {
     impl<'a> SagaList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -34769,7 +34763,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SagaResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -34777,37 +34771,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/sagas", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/system/sagas", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -34873,14 +34867,14 @@ pub mod builder {
     ///[`ClientSystemExt::saga_view`]: super::ClientSystemExt::saga_view
     #[derive(Debug, Clone)]
     pub struct SagaView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         saga_id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SagaView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 saga_id: Err("saga_id was not initialized".to_string()),
             }
         }
@@ -34897,32 +34891,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/sagas/{saga_id}`
         pub async fn send(self) -> Result<ResponseValue<types::Saga>, Error<types::Error>> {
-            let Self { _client, saga_id } = self;
+            let Self { client, saga_id } = self;
             let saga_id = saga_id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/sagas/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&saga_id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -34932,7 +34926,7 @@ pub mod builder {
     ///[`ClientSystemExt::silo_list`]: super::ClientSystemExt::silo_list
     #[derive(Debug, Clone)]
     pub struct SiloList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameOrIdSortMode>, String>,
@@ -34941,7 +34935,7 @@ pub mod builder {
     impl<'a> SiloList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -34985,7 +34979,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SiloResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -34993,37 +34987,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/silos", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/system/silos", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -35089,14 +35083,14 @@ pub mod builder {
     ///[`ClientSystemExt::silo_create`]: super::ClientSystemExt::silo_create
     #[derive(Debug, Clone)]
     pub struct SiloCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::SiloCreate, String>,
     }
 
     impl<'a> SiloCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::SiloCreate::default()),
             }
         }
@@ -35122,31 +35116,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/silos`
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SiloCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/silos", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/system/silos", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -35156,14 +35150,14 @@ pub mod builder {
     ///[`ClientSystemExt::silo_view`]: super::ClientSystemExt::silo_view
     #[derive(Debug, Clone)]
     pub struct SiloView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
     }
 
     impl<'a> SiloView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
@@ -35180,32 +35174,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/silos/{silo_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-            let Self { _client, silo_name } = self;
+            let Self { client, silo_name } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/silos/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -35215,14 +35209,14 @@ pub mod builder {
     ///[`ClientSystemExt::silo_delete`]: super::ClientSystemExt::silo_delete
     #[derive(Debug, Clone)]
     pub struct SiloDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
     }
 
     impl<'a> SiloDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
@@ -35239,32 +35233,32 @@ pub mod builder {
 
         ///Sends a `DELETE` request to `/system/silos/{silo_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { _client, silo_name } = self;
+            let Self { client, silo_name } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/silos/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -35274,7 +35268,7 @@ pub mod builder {
     ///[`ClientSystemExt::silo_identity_provider_list`]: super::ClientSystemExt::silo_identity_provider_list
     #[derive(Debug, Clone)]
     pub struct SiloIdentityProviderList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -35284,7 +35278,7 @@ pub mod builder {
     impl<'a> SiloIdentityProviderList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -35341,7 +35335,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::IdentityProviderResultsPage>, Error<types::Error>>
         {
             let Self {
-                _client,
+                client,
                 silo_name,
                 limit,
                 page_token,
@@ -35351,41 +35345,41 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/silos/{}/identity-providers",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -35452,7 +35446,7 @@ pub mod builder {
     ///[`ClientSystemExt::local_idp_user_create`]: super::ClientSystemExt::local_idp_user_create
     #[derive(Debug, Clone)]
     pub struct LocalIdpUserCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         body: Result<types::builder::UserCreate, String>,
     }
@@ -35460,7 +35454,7 @@ pub mod builder {
     impl<'a> LocalIdpUserCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(types::builder::UserCreate::default()),
             }
@@ -35499,7 +35493,7 @@ pub mod builder {
         /// `/system/silos/{silo_name}/identity-providers/local/users`
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 silo_name,
                 body,
             } = self;
@@ -35507,31 +35501,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::UserCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/silos/{}/identity-providers/local/users",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -35541,7 +35535,7 @@ pub mod builder {
     ///[`ClientSystemExt::local_idp_user_delete`]: super::ClientSystemExt::local_idp_user_delete
     #[derive(Debug, Clone)]
     pub struct LocalIdpUserDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         user_id: Result<uuid::Uuid, String>,
     }
@@ -35549,7 +35543,7 @@ pub mod builder {
     impl<'a> LocalIdpUserDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 user_id: Err("user_id was not initialized".to_string()),
             }
@@ -35579,37 +35573,37 @@ pub mod builder {
         /// `/system/silos/{silo_name}/identity-providers/local/users/{user_id}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 silo_name,
                 user_id,
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let user_id = user_id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/silos/{}/identity-providers/local/users/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -35619,7 +35613,7 @@ pub mod builder {
     ///[`ClientSystemExt::local_idp_user_set_password`]: super::ClientSystemExt::local_idp_user_set_password
     #[derive(Debug, Clone)]
     pub struct LocalIdpUserSetPassword<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         user_id: Result<uuid::Uuid, String>,
         body: Result<types::UserPassword, String>,
@@ -35628,7 +35622,7 @@ pub mod builder {
     impl<'a> LocalIdpUserSetPassword<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 user_id: Err("user_id was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
@@ -35670,7 +35664,7 @@ pub mod builder {
         /// set-password`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 silo_name,
                 user_id,
                 body,
@@ -35678,32 +35672,32 @@ pub mod builder {
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let user_id = user_id.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/silos/{}/identity-providers/local/users/{}/set-password",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -35713,7 +35707,7 @@ pub mod builder {
     ///[`ClientSystemExt::saml_identity_provider_create`]: super::ClientSystemExt::saml_identity_provider_create
     #[derive(Debug, Clone)]
     pub struct SamlIdentityProviderCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         body: Result<types::builder::SamlIdentityProviderCreate, String>,
     }
@@ -35721,7 +35715,7 @@ pub mod builder {
     impl<'a> SamlIdentityProviderCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(types::builder::SamlIdentityProviderCreate::default()),
             }
@@ -35763,7 +35757,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SamlIdentityProvider>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 silo_name,
                 body,
             } = self;
@@ -35771,31 +35765,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::SamlIdentityProviderCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/silos/{}/identity-providers/saml",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -35805,7 +35799,7 @@ pub mod builder {
     ///[`ClientSystemExt::saml_identity_provider_view`]: super::ClientSystemExt::saml_identity_provider_view
     #[derive(Debug, Clone)]
     pub struct SamlIdentityProviderView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         provider_name: Result<types::Name, String>,
     }
@@ -35813,7 +35807,7 @@ pub mod builder {
     impl<'a> SamlIdentityProviderView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 provider_name: Err("provider_name was not initialized".to_string()),
             }
@@ -35845,37 +35839,37 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SamlIdentityProvider>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 silo_name,
                 provider_name,
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let provider_name = provider_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/silos/{}/identity-providers/saml/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -35885,14 +35879,14 @@ pub mod builder {
     ///[`ClientSystemExt::silo_policy_view`]: super::ClientSystemExt::silo_policy_view
     #[derive(Debug, Clone)]
     pub struct SiloPolicyView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
     }
 
     impl<'a> SiloPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
@@ -35911,32 +35905,32 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-            let Self { _client, silo_name } = self;
+            let Self { client, silo_name } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/silos/{}/policy",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -35946,7 +35940,7 @@ pub mod builder {
     ///[`ClientSystemExt::silo_policy_update`]: super::ClientSystemExt::silo_policy_update
     #[derive(Debug, Clone)]
     pub struct SiloPolicyUpdate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         body: Result<types::builder::SiloRolePolicy, String>,
     }
@@ -35954,7 +35948,7 @@ pub mod builder {
     impl<'a> SiloPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(types::builder::SiloRolePolicy::default()),
             }
@@ -35994,7 +35988,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 silo_name,
                 body,
             } = self;
@@ -36002,31 +35996,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::SiloRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/silos/{}/policy",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -36036,7 +36030,7 @@ pub mod builder {
     ///[`ClientSystemExt::silo_users_list`]: super::ClientSystemExt::silo_users_list
     #[derive(Debug, Clone)]
     pub struct SiloUsersList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -36046,7 +36040,7 @@ pub mod builder {
     impl<'a> SiloUsersList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -36101,7 +36095,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 silo_name,
                 limit,
                 page_token,
@@ -36111,41 +36105,41 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/silos/{}/users/all",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -36211,7 +36205,7 @@ pub mod builder {
     ///[`ClientSystemExt::silo_user_view`]: super::ClientSystemExt::silo_user_view
     #[derive(Debug, Clone)]
     pub struct SiloUserView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         user_id: Result<uuid::Uuid, String>,
     }
@@ -36219,7 +36213,7 @@ pub mod builder {
     impl<'a> SiloUserView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 user_id: Err("user_id was not initialized".to_string()),
             }
@@ -36249,37 +36243,37 @@ pub mod builder {
         /// `/system/silos/{silo_name}/users/id/{user_id}`
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 silo_name,
                 user_id,
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let user_id = user_id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/silos/{}/users/id/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -36289,7 +36283,7 @@ pub mod builder {
     ///[`ClientSystemExt::system_user_list`]: super::ClientSystemExt::system_user_list
     #[derive(Debug, Clone)]
     pub struct SystemUserList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameSortMode>, String>,
@@ -36298,7 +36292,7 @@ pub mod builder {
     impl<'a> SystemUserList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -36342,7 +36336,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::UserBuiltinResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -36350,37 +36344,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/user", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/system/user", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -36446,14 +36440,14 @@ pub mod builder {
     ///[`ClientSystemExt::system_user_view`]: super::ClientSystemExt::system_user_view
     #[derive(Debug, Clone)]
     pub struct SystemUserView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         user_name: Result<types::Name, String>,
     }
 
     impl<'a> SystemUserView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 user_name: Err("user_name was not initialized".to_string()),
             }
         }
@@ -36470,32 +36464,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/user/{user_name}`
         pub async fn send(self) -> Result<ResponseValue<types::UserBuiltin>, Error<types::Error>> {
-            let Self { _client, user_name } = self;
+            let Self { client, user_name } = self;
             let user_name = user_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/user/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&user_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -36505,7 +36499,7 @@ pub mod builder {
     ///[`ClientMetricsExt::timeseries_schema_get`]: super::ClientMetricsExt::timeseries_schema_get
     #[derive(Debug, Clone)]
     pub struct TimeseriesSchemaGet<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
     }
@@ -36513,7 +36507,7 @@ pub mod builder {
     impl<'a> TimeseriesSchemaGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
             }
@@ -36546,40 +36540,40 @@ pub mod builder {
         ) -> Result<ResponseValue<types::TimeseriesSchemaResultsPage>, Error<types::Error>>
         {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/timeseries/schema", _client.baseurl,);
-            let mut _query = Vec::with_capacity(2usize);
+            let url = format!("{}/timeseries/schema", client.baseurl,);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -36644,7 +36638,7 @@ pub mod builder {
     ///[`ClientSilosExt::user_list`]: super::ClientSilosExt::user_list
     #[derive(Debug, Clone)]
     pub struct UserList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -36653,7 +36647,7 @@ pub mod builder {
     impl<'a> UserList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -36697,7 +36691,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -36705,37 +36699,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/users", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/users", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -36801,7 +36795,7 @@ pub mod builder {
     ///[`ClientDisksExt::disk_list_v1`]: super::ClientDisksExt::disk_list_v1
     #[derive(Debug, Clone)]
     pub struct DiskListV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         organization: Result<Option<types::NameOrId>, String>,
         page_token: Result<Option<String>, String>,
@@ -36812,7 +36806,7 @@ pub mod builder {
     impl<'a> DiskListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 organization: Ok(None),
                 page_token: Ok(None),
@@ -36880,7 +36874,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 organization,
                 page_token,
@@ -36892,43 +36886,43 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/disks", _client.baseurl,);
-            let mut _query = Vec::with_capacity(5usize);
+            let url = format!("{}/v1/disks", client.baseurl,);
+            let mut query = Vec::with_capacity(5usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -36996,7 +36990,7 @@ pub mod builder {
     ///[`ClientDisksExt::disk_create_v1`]: super::ClientDisksExt::disk_create_v1
     #[derive(Debug, Clone)]
     pub struct DiskCreateV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<types::NameOrId, String>,
         body: Result<types::builder::DiskCreate, String>,
@@ -37005,7 +36999,7 @@ pub mod builder {
     impl<'a> DiskCreateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization: Ok(None),
                 project: Err("project was not initialized".to_string()),
                 body: Ok(types::builder::DiskCreate::default()),
@@ -37055,7 +37049,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/disks`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization,
                 project,
                 body,
@@ -37065,33 +37059,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/disks", _client.baseurl,);
-            let mut _query = Vec::with_capacity(2usize);
+            let url = format!("{}/v1/disks", client.baseurl,);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
-            _query.push(("project", project.to_string()));
-            let _request = _client
+            query.push(("project", project.to_string()));
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -37101,7 +37095,7 @@ pub mod builder {
     ///[`ClientDisksExt::disk_view_v1`]: super::ClientDisksExt::disk_view_v1
     #[derive(Debug, Clone)]
     pub struct DiskViewV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         disk: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -37110,7 +37104,7 @@ pub mod builder {
     impl<'a> DiskViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 disk: Err("disk was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -37152,7 +37146,7 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/disks/{disk}`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 disk,
                 organization,
                 project,
@@ -37160,38 +37154,38 @@ pub mod builder {
             let disk = disk.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/disks/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&disk.to_string()),
             );
-            let mut _query = Vec::with_capacity(2usize);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -37201,7 +37195,7 @@ pub mod builder {
     ///[`ClientDisksExt::disk_delete_v1`]: super::ClientDisksExt::disk_delete_v1
     #[derive(Debug, Clone)]
     pub struct DiskDeleteV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         disk: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -37210,7 +37204,7 @@ pub mod builder {
     impl<'a> DiskDeleteV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 disk: Err("disk was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -37252,7 +37246,7 @@ pub mod builder {
         ///Sends a `DELETE` request to `/v1/disks/{disk}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 disk,
                 organization,
                 project,
@@ -37260,38 +37254,38 @@ pub mod builder {
             let disk = disk.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/disks/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&disk.to_string()),
             );
-            let mut _query = Vec::with_capacity(2usize);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -37301,7 +37295,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_list_v1`]: super::ClientInstancesExt::instance_list_v1
     #[derive(Debug, Clone)]
     pub struct InstanceListV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         organization: Result<Option<types::NameOrId>, String>,
         page_token: Result<Option<String>, String>,
@@ -37312,7 +37306,7 @@ pub mod builder {
     impl<'a> InstanceListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 organization: Ok(None),
                 page_token: Ok(None),
@@ -37380,7 +37374,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 organization,
                 page_token,
@@ -37392,43 +37386,43 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/instances", _client.baseurl,);
-            let mut _query = Vec::with_capacity(5usize);
+            let url = format!("{}/v1/instances", client.baseurl,);
+            let mut query = Vec::with_capacity(5usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -37496,7 +37490,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_create_v1`]: super::ClientInstancesExt::instance_create_v1
     #[derive(Debug, Clone)]
     pub struct InstanceCreateV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<types::NameOrId, String>,
         body: Result<types::builder::InstanceCreate, String>,
@@ -37505,7 +37499,7 @@ pub mod builder {
     impl<'a> InstanceCreateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization: Ok(None),
                 project: Err("project was not initialized".to_string()),
                 body: Ok(types::builder::InstanceCreate::default()),
@@ -37555,7 +37549,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization,
                 project,
                 body,
@@ -37565,33 +37559,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/instances", _client.baseurl,);
-            let mut _query = Vec::with_capacity(2usize);
+            let url = format!("{}/v1/instances", client.baseurl,);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
-            _query.push(("project", project.to_string()));
-            let _request = _client
+            query.push(("project", project.to_string()));
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -37601,7 +37595,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_view_v1`]: super::ClientInstancesExt::instance_view_v1
     #[derive(Debug, Clone)]
     pub struct InstanceViewV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -37610,7 +37604,7 @@ pub mod builder {
     impl<'a> InstanceViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -37652,7 +37646,7 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/instances/{instance}`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 instance,
                 organization,
                 project,
@@ -37660,38 +37654,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/instances/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut _query = Vec::with_capacity(2usize);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -37701,7 +37695,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_delete_v1`]: super::ClientInstancesExt::instance_delete_v1
     #[derive(Debug, Clone)]
     pub struct InstanceDeleteV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -37710,7 +37704,7 @@ pub mod builder {
     impl<'a> InstanceDeleteV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -37752,7 +37746,7 @@ pub mod builder {
         ///Sends a `DELETE` request to `/v1/instances/{instance}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 instance,
                 organization,
                 project,
@@ -37760,38 +37754,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/instances/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut _query = Vec::with_capacity(2usize);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -37801,7 +37795,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_disk_list_v1`]: super::ClientInstancesExt::instance_disk_list_v1
     #[derive(Debug, Clone)]
     pub struct InstanceDiskListV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         organization: Result<Option<types::NameOrId>, String>,
@@ -37813,7 +37807,7 @@ pub mod builder {
     impl<'a> InstanceDiskListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 instance: Err("instance was not initialized".to_string()),
                 limit: Ok(None),
                 organization: Ok(None),
@@ -37892,7 +37886,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 instance,
                 limit,
                 organization,
@@ -37906,47 +37900,47 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/instances/{}/disks",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut _query = Vec::with_capacity(5usize);
+            let mut query = Vec::with_capacity(5usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -38014,7 +38008,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_disk_attach_v1`]: super::ClientInstancesExt::instance_disk_attach_v1
     #[derive(Debug, Clone)]
     pub struct InstanceDiskAttachV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38024,7 +38018,7 @@ pub mod builder {
     impl<'a> InstanceDiskAttachV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38086,7 +38080,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/disks/attach`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 instance,
                 organization,
                 project,
@@ -38098,39 +38092,39 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskPath>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/instances/{}/disks/attach",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut _query = Vec::with_capacity(2usize);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                202u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                202u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -38140,7 +38134,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_disk_detach_v1`]: super::ClientInstancesExt::instance_disk_detach_v1
     #[derive(Debug, Clone)]
     pub struct InstanceDiskDetachV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38150,7 +38144,7 @@ pub mod builder {
     impl<'a> InstanceDiskDetachV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38212,7 +38206,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/disks/detach`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 instance,
                 organization,
                 project,
@@ -38224,39 +38218,39 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskPath>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/instances/{}/disks/detach",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut _query = Vec::with_capacity(2usize);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                202u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                202u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -38266,7 +38260,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_migrate_v1`]: super::ClientInstancesExt::instance_migrate_v1
     #[derive(Debug, Clone)]
     pub struct InstanceMigrateV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38276,7 +38270,7 @@ pub mod builder {
     impl<'a> InstanceMigrateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38338,7 +38332,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/migrate`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 instance,
                 organization,
                 project,
@@ -38350,39 +38344,39 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceMigrate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/instances/{}/migrate",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut _query = Vec::with_capacity(2usize);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -38392,7 +38386,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_reboot_v1`]: super::ClientInstancesExt::instance_reboot_v1
     #[derive(Debug, Clone)]
     pub struct InstanceRebootV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38401,7 +38395,7 @@ pub mod builder {
     impl<'a> InstanceRebootV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38443,7 +38437,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/reboot`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 instance,
                 organization,
                 project,
@@ -38451,38 +38445,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/instances/{}/reboot",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut _query = Vec::with_capacity(2usize);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                202u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                202u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -38492,7 +38486,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_serial_console_v1`]: super::ClientInstancesExt::instance_serial_console_v1
     #[derive(Debug, Clone)]
     pub struct InstanceSerialConsoleV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         from_start: Result<Option<u64>, String>,
         max_bytes: Result<Option<u64>, String>,
@@ -38504,7 +38498,7 @@ pub mod builder {
     impl<'a> InstanceSerialConsoleV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 instance: Err("instance was not initialized".to_string()),
                 from_start: Ok(None),
                 max_bytes: Ok(None),
@@ -38584,7 +38578,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceSerialConsoleData>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 instance,
                 from_start,
                 max_bytes,
@@ -38598,47 +38592,47 @@ pub mod builder {
             let most_recent = most_recent.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/instances/{}/serial-console",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut _query = Vec::with_capacity(5usize);
+            let mut query = Vec::with_capacity(5usize);
             if let Some(v) = &from_start {
-                _query.push(("from_start", v.to_string()));
+                query.push(("from_start", v.to_string()));
             }
             if let Some(v) = &max_bytes {
-                _query.push(("max_bytes", v.to_string()));
+                query.push(("max_bytes", v.to_string()));
             }
             if let Some(v) = &most_recent {
-                _query.push(("most_recent", v.to_string()));
+                query.push(("most_recent", v.to_string()));
             }
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -38648,7 +38642,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_serial_console_stream_v1`]: super::ClientInstancesExt::instance_serial_console_stream_v1
     #[derive(Debug, Clone)]
     pub struct InstanceSerialConsoleStreamV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38657,7 +38651,7 @@ pub mod builder {
     impl<'a> InstanceSerialConsoleStreamV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38702,7 +38696,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
             let Self {
-                _client,
+                client,
                 instance,
                 organization,
                 project,
@@ -38710,22 +38704,22 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/instances/{}/serial-console/stream",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut _query = Vec::with_capacity(2usize);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
-                .query(&_query)
+                .get(url)
+                .query(&query)
                 .header(reqwest::header::CONNECTION, "Upgrade")
                 .header(reqwest::header::UPGRADE, "websocket")
                 .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -38737,12 +38731,12 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                101u16 => ResponseValue::upgrade(_response).await,
-                200..=299 => ResponseValue::upgrade(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                101u16 => ResponseValue::upgrade(response).await,
+                200..=299 => ResponseValue::upgrade(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -38752,7 +38746,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_start_v1`]: super::ClientInstancesExt::instance_start_v1
     #[derive(Debug, Clone)]
     pub struct InstanceStartV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38761,7 +38755,7 @@ pub mod builder {
     impl<'a> InstanceStartV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38803,7 +38797,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/start`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 instance,
                 organization,
                 project,
@@ -38811,38 +38805,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/instances/{}/start",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut _query = Vec::with_capacity(2usize);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                202u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                202u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -38852,7 +38846,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_stop_v1`]: super::ClientInstancesExt::instance_stop_v1
     #[derive(Debug, Clone)]
     pub struct InstanceStopV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38861,7 +38855,7 @@ pub mod builder {
     impl<'a> InstanceStopV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38903,7 +38897,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/stop`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 instance,
                 organization,
                 project,
@@ -38911,38 +38905,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/instances/{}/stop",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut _query = Vec::with_capacity(2usize);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                202u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                202u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -38952,7 +38946,7 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_list_v1`]: super::ClientOrganizationsExt::organization_list_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationListV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameOrIdSortMode>, String>,
@@ -38961,7 +38955,7 @@ pub mod builder {
     impl<'a> OrganizationListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -39005,7 +38999,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -39013,37 +39007,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/organizations", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/v1/organizations", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -39109,14 +39103,14 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_create_v1`]: super::ClientOrganizationsExt::organization_create_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationCreateV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::OrganizationCreate, String>,
     }
 
     impl<'a> OrganizationCreateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::OrganizationCreate::default()),
             }
         }
@@ -39144,31 +39138,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/organizations`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/organizations", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/v1/organizations", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -39178,14 +39172,14 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_view_v1`]: super::ClientOrganizationsExt::organization_view_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationViewV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
     }
 
     impl<'a> OrganizationViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization: Err("organization was not initialized".to_string()),
             }
         }
@@ -39203,34 +39197,34 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/organizations/{organization}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization,
             } = self;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/organizations/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -39240,7 +39234,7 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_update_v1`]: super::ClientOrganizationsExt::organization_update_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationUpdateV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
         body: Result<types::builder::OrganizationUpdate, String>,
     }
@@ -39248,7 +39242,7 @@ pub mod builder {
     impl<'a> OrganizationUpdateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization: Err("organization was not initialized".to_string()),
                 body: Ok(types::builder::OrganizationUpdate::default()),
             }
@@ -39288,7 +39282,7 @@ pub mod builder {
         ///Sends a `PUT` request to `/v1/organizations/{organization}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization,
                 body,
             } = self;
@@ -39296,31 +39290,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/organizations/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -39330,14 +39324,14 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_delete_v1`]: super::ClientOrganizationsExt::organization_delete_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationDeleteV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
     }
 
     impl<'a> OrganizationDeleteV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization: Err("organization was not initialized".to_string()),
             }
         }
@@ -39355,34 +39349,34 @@ pub mod builder {
         ///Sends a `DELETE` request to `/v1/organizations/{organization}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization,
             } = self;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/organizations/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -39392,14 +39386,14 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_policy_view_v1`]: super::ClientOrganizationsExt::organization_policy_view_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationPolicyViewV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
     }
 
     impl<'a> OrganizationPolicyViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization: Err("organization was not initialized".to_string()),
             }
         }
@@ -39419,34 +39413,34 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization,
             } = self;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/organizations/{}/policy",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -39456,7 +39450,7 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_policy_update_v1`]: super::ClientOrganizationsExt::organization_policy_update_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationPolicyUpdateV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
         body: Result<types::builder::OrganizationRolePolicy, String>,
     }
@@ -39464,7 +39458,7 @@ pub mod builder {
     impl<'a> OrganizationPolicyUpdateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization: Err("organization was not initialized".to_string()),
                 body: Ok(types::builder::OrganizationRolePolicy::default()),
             }
@@ -39506,7 +39500,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization,
                 body,
             } = self;
@@ -39514,31 +39508,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/organizations/{}/policy",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -39548,7 +39542,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_list_v1`]: super::ClientProjectsExt::project_list_v1
     #[derive(Debug, Clone)]
     pub struct ProjectListV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         organization: Result<Option<types::NameOrId>, String>,
         page_token: Result<Option<String>, String>,
@@ -39558,7 +39552,7 @@ pub mod builder {
     impl<'a> ProjectListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 organization: Ok(None),
                 page_token: Ok(None),
@@ -39614,7 +39608,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 organization,
                 page_token,
@@ -39624,40 +39618,40 @@ pub mod builder {
             let organization = organization.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/projects", _client.baseurl,);
-            let mut _query = Vec::with_capacity(4usize);
+            let url = format!("{}/v1/projects", client.baseurl,);
+            let mut query = Vec::with_capacity(4usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -39724,7 +39718,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_create_v1`]: super::ClientProjectsExt::project_create_v1
     #[derive(Debug, Clone)]
     pub struct ProjectCreateV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
         body: Result<types::builder::ProjectCreate, String>,
     }
@@ -39732,7 +39726,7 @@ pub mod builder {
     impl<'a> ProjectCreateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization: Err("organization was not initialized".to_string()),
                 body: Ok(types::builder::ProjectCreate::default()),
             }
@@ -39770,7 +39764,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/projects`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization,
                 body,
             } = self;
@@ -39778,30 +39772,30 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/projects", _client.baseurl,);
-            let mut _query = Vec::with_capacity(1usize);
-            _query.push(("organization", organization.to_string()));
-            let _request = _client
+            let url = format!("{}/v1/projects", client.baseurl,);
+            let mut query = Vec::with_capacity(1usize);
+            query.push(("organization", organization.to_string()));
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -39811,7 +39805,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_view_v1`]: super::ClientProjectsExt::project_view_v1
     #[derive(Debug, Clone)]
     pub struct ProjectViewV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
     }
@@ -39819,7 +39813,7 @@ pub mod builder {
     impl<'a> ProjectViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
             }
@@ -39849,41 +39843,41 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/projects/{project}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 project,
                 organization,
             } = self;
             let project = project.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/projects/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut _query = Vec::with_capacity(1usize);
+            let mut query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -39893,7 +39887,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_update_v1`]: super::ClientProjectsExt::project_update_v1
     #[derive(Debug, Clone)]
     pub struct ProjectUpdateV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         body: Result<types::builder::ProjectUpdate, String>,
@@ -39902,7 +39896,7 @@ pub mod builder {
     impl<'a> ProjectUpdateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
                 body: Ok(types::builder::ProjectUpdate::default()),
@@ -39952,7 +39946,7 @@ pub mod builder {
         ///Sends a `PUT` request to `/v1/projects/{project}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 project,
                 organization,
                 body,
@@ -39962,36 +39956,36 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/projects/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut _query = Vec::with_capacity(1usize);
+            let mut query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -40001,7 +39995,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_delete_v1`]: super::ClientProjectsExt::project_delete_v1
     #[derive(Debug, Clone)]
     pub struct ProjectDeleteV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
     }
@@ -40009,7 +40003,7 @@ pub mod builder {
     impl<'a> ProjectDeleteV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
             }
@@ -40039,41 +40033,41 @@ pub mod builder {
         ///Sends a `DELETE` request to `/v1/projects/{project}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 project,
                 organization,
             } = self;
             let project = project.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/projects/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut _query = Vec::with_capacity(1usize);
+            let mut query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -40083,7 +40077,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_policy_view_v1`]: super::ClientProjectsExt::project_policy_view_v1
     #[derive(Debug, Clone)]
     pub struct ProjectPolicyViewV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
     }
@@ -40091,7 +40085,7 @@ pub mod builder {
     impl<'a> ProjectPolicyViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
             }
@@ -40123,41 +40117,41 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 project,
                 organization,
             } = self;
             let project = project.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/projects/{}/policy",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut _query = Vec::with_capacity(1usize);
+            let mut query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -40167,7 +40161,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_policy_update_v1`]: super::ClientProjectsExt::project_policy_update_v1
     #[derive(Debug, Clone)]
     pub struct ProjectPolicyUpdateV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         body: Result<types::builder::ProjectRolePolicy, String>,
@@ -40176,7 +40170,7 @@ pub mod builder {
     impl<'a> ProjectPolicyUpdateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
                 body: Ok(types::builder::ProjectRolePolicy::default()),
@@ -40230,7 +40224,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 project,
                 organization,
                 body,
@@ -40240,36 +40234,36 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/projects/{}/policy",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut _query = Vec::with_capacity(1usize);
+            let mut query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -40279,7 +40273,7 @@ pub mod builder {
     ///[`ClientSystemExt::system_component_version_list`]: super::ClientSystemExt::system_component_version_list
     #[derive(Debug, Clone)]
     pub struct SystemComponentVersionList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -40288,7 +40282,7 @@ pub mod builder {
     impl<'a> SystemComponentVersionList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -40333,7 +40327,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::UpdateableComponentResultsPage>, Error<types::Error>>
         {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -40341,37 +40335,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/system/update/components", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/v1/system/update/components", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -40438,7 +40432,7 @@ pub mod builder {
     ///[`ClientSystemExt::update_deployments_list`]: super::ClientSystemExt::update_deployments_list
     #[derive(Debug, Clone)]
     pub struct UpdateDeploymentsList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -40447,7 +40441,7 @@ pub mod builder {
     impl<'a> UpdateDeploymentsList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -40492,7 +40486,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::UpdateDeploymentResultsPage>, Error<types::Error>>
         {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -40500,37 +40494,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/system/update/deployments", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/v1/system/update/deployments", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -40596,14 +40590,14 @@ pub mod builder {
     ///[`ClientSystemExt::update_deployment_view`]: super::ClientSystemExt::update_deployment_view
     #[derive(Debug, Clone)]
     pub struct UpdateDeploymentView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> UpdateDeploymentView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -40622,32 +40616,32 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/system/update/deployments/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -40657,37 +40651,37 @@ pub mod builder {
     ///[`ClientSystemExt::system_update_refresh`]: super::ClientSystemExt::system_update_refresh
     #[derive(Debug, Clone)]
     pub struct SystemUpdateRefresh<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> SystemUpdateRefresh<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `POST` request to `/v1/system/update/refresh`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { _client } = self;
-            let _url = format!("{}/v1/system/update/refresh", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/v1/system/update/refresh", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -40697,14 +40691,14 @@ pub mod builder {
     ///[`ClientSystemExt::system_update_start`]: super::ClientSystemExt::system_update_start
     #[derive(Debug, Clone)]
     pub struct SystemUpdateStart<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::SystemUpdateStart, String>,
     }
 
     impl<'a> SystemUpdateStart<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::SystemUpdateStart::default()),
             }
         }
@@ -40734,31 +40728,31 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SystemUpdateStart>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/system/update/start", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/v1/system/update/start", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                202u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                202u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -40768,37 +40762,37 @@ pub mod builder {
     ///[`ClientSystemExt::system_update_stop`]: super::ClientSystemExt::system_update_stop
     #[derive(Debug, Clone)]
     pub struct SystemUpdateStop<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> SystemUpdateStop<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `POST` request to `/v1/system/update/stop`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { _client } = self;
-            let _url = format!("{}/v1/system/update/stop", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/v1/system/update/stop", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -40808,7 +40802,7 @@ pub mod builder {
     ///[`ClientSystemExt::system_update_list`]: super::ClientSystemExt::system_update_list
     #[derive(Debug, Clone)]
     pub struct SystemUpdateList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -40817,7 +40811,7 @@ pub mod builder {
     impl<'a> SystemUpdateList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -40861,7 +40855,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SystemUpdateResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -40869,37 +40863,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/system/update/updates", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/v1/system/update/updates", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -40965,14 +40959,14 @@ pub mod builder {
     ///[`ClientSystemExt::system_update_view`]: super::ClientSystemExt::system_update_view
     #[derive(Debug, Clone)]
     pub struct SystemUpdateView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         version: Result<types::SemverVersion, String>,
     }
 
     impl<'a> SystemUpdateView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 version: Err("version was not initialized".to_string()),
             }
         }
@@ -40989,32 +40983,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/v1/system/update/updates/{version}`
         pub async fn send(self) -> Result<ResponseValue<types::SystemUpdate>, Error<types::Error>> {
-            let Self { _client, version } = self;
+            let Self { client, version } = self;
             let version = version.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/system/update/updates/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&version.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -41024,14 +41018,14 @@ pub mod builder {
     ///[`ClientSystemExt::system_update_components_list`]: super::ClientSystemExt::system_update_components_list
     #[derive(Debug, Clone)]
     pub struct SystemUpdateComponentsList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         version: Result<types::SemverVersion, String>,
     }
 
     impl<'a> SystemUpdateComponentsList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 version: Err("version was not initialized".to_string()),
             }
         }
@@ -41051,32 +41045,32 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::ComponentUpdateResultsPage>, Error<types::Error>> {
-            let Self { _client, version } = self;
+            let Self { client, version } = self;
             let version = version.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/system/update/updates/{}/components",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&version.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -41086,39 +41080,39 @@ pub mod builder {
     ///[`ClientSystemExt::system_version`]: super::ClientSystemExt::system_version
     #[derive(Debug, Clone)]
     pub struct SystemVersion<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> SystemVersion<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `GET` request to `/v1/system/update/version`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SystemVersion>, Error<types::Error>> {
-            let Self { _client } = self;
-            let _url = format!("{}/v1/system/update/version", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/v1/system/update/version", client.baseurl,);
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/nexus-builder-tagged.out
+++ b/progenitor-impl/tests/output/nexus-builder-tagged.out
@@ -21032,14 +21032,14 @@ pub mod builder {
     ///[`ClientDisksExt::disk_view_by_id`]: super::ClientDisksExt::disk_view_by_id
     #[derive(Debug, Clone)]
     pub struct DiskViewById<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> DiskViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21056,38 +21056,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/disks/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/by-id/disks/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -21097,14 +21091,14 @@ pub mod builder {
     ///[`ClientImagesExt::image_view_by_id`]: super::ClientImagesExt::image_view_by_id
     #[derive(Debug, Clone)]
     pub struct ImageViewById<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> ImageViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21121,38 +21115,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/images/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/by-id/images/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -21162,14 +21150,14 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_view_by_id`]: super::ClientInstancesExt::instance_view_by_id
     #[derive(Debug, Clone)]
     pub struct InstanceViewById<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> InstanceViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21186,38 +21174,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/instances/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/by-id/instances/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -21228,14 +21210,14 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_network_interface_view_by_id`]: super::ClientInstancesExt::instance_network_interface_view_by_id
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceViewById<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> InstanceNetworkInterfaceViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21254,38 +21236,32 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/by-id/network-interfaces/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -21295,14 +21271,14 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_view_by_id`]: super::ClientOrganizationsExt::organization_view_by_id
     #[derive(Debug, Clone)]
     pub struct OrganizationViewById<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> OrganizationViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21319,38 +21295,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/organizations/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/by-id/organizations/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -21360,14 +21330,14 @@ pub mod builder {
     ///[`ClientProjectsExt::project_view_by_id`]: super::ClientProjectsExt::project_view_by_id
     #[derive(Debug, Clone)]
     pub struct ProjectViewById<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> ProjectViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21384,38 +21354,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/projects/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/by-id/projects/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -21425,14 +21389,14 @@ pub mod builder {
     ///[`ClientSnapshotsExt::snapshot_view_by_id`]: super::ClientSnapshotsExt::snapshot_view_by_id
     #[derive(Debug, Clone)]
     pub struct SnapshotViewById<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SnapshotViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21449,38 +21413,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/snapshots/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/by-id/snapshots/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -21490,14 +21448,14 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_route_view_by_id`]: super::ClientVpcsExt::vpc_router_route_view_by_id
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteViewById<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcRouterRouteViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21514,38 +21472,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/vpc-router-routes/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/by-id/vpc-router-routes/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -21555,14 +21507,14 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_view_by_id`]: super::ClientVpcsExt::vpc_router_view_by_id
     #[derive(Debug, Clone)]
     pub struct VpcRouterViewById<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcRouterViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21579,38 +21531,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/vpc-routers/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/by-id/vpc-routers/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -21620,14 +21566,14 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_subnet_view_by_id`]: super::ClientVpcsExt::vpc_subnet_view_by_id
     #[derive(Debug, Clone)]
     pub struct VpcSubnetViewById<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcSubnetViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21644,38 +21590,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/vpc-subnets/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/by-id/vpc-subnets/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -21685,14 +21625,14 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_view_by_id`]: super::ClientVpcsExt::vpc_view_by_id
     #[derive(Debug, Clone)]
     pub struct VpcViewById<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21709,38 +21649,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/vpcs/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/by-id/vpcs/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -21750,14 +21684,14 @@ pub mod builder {
     ///[`ClientHiddenExt::device_auth_request`]: super::ClientHiddenExt::device_auth_request
     #[derive(Debug, Clone)]
     pub struct DeviceAuthRequest<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::DeviceAuthRequest, String>,
     }
 
     impl<'a> DeviceAuthRequest<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::DeviceAuthRequest::default()),
             }
         }
@@ -21785,29 +21719,17 @@ pub mod builder {
 
         ///Sends a `POST` request to `/device/auth`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::DeviceAuthRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/device/auth", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
-                .client
-                .post(__progenitor_url)
-                .form_urlencoded(&body)?
-                .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
-                _ => Err(Error::ErrorResponse(ResponseValue::stream(
-                    __progenitor_response,
-                ))),
+            let _url = format!("{}/device/auth", _client.baseurl,);
+            let _request = _client.client.post(_url).form_urlencoded(&body)?.build()?;
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(_response)),
+                _ => Err(Error::ErrorResponse(ResponseValue::stream(_response))),
             }
         }
     }
@@ -21817,14 +21739,14 @@ pub mod builder {
     ///[`ClientHiddenExt::device_auth_confirm`]: super::ClientHiddenExt::device_auth_confirm
     #[derive(Debug, Clone)]
     pub struct DeviceAuthConfirm<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::DeviceAuthVerify, String>,
     }
 
     impl<'a> DeviceAuthConfirm<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::DeviceAuthVerify::default()),
             }
         }
@@ -21852,37 +21774,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/device/confirm`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::DeviceAuthVerify>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/device/confirm", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/device/confirm", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -21892,14 +21808,14 @@ pub mod builder {
     ///[`ClientHiddenExt::device_access_token`]: super::ClientHiddenExt::device_access_token
     #[derive(Debug, Clone)]
     pub struct DeviceAccessToken<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::DeviceAccessTokenRequest, String>,
     }
 
     impl<'a> DeviceAccessToken<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::DeviceAccessTokenRequest::default()),
             }
         }
@@ -21926,29 +21842,17 @@ pub mod builder {
 
         ///Sends a `POST` request to `/device/token`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::DeviceAccessTokenRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/device/token", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
-                .client
-                .post(__progenitor_url)
-                .form_urlencoded(&body)?
-                .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
-                _ => Err(Error::ErrorResponse(ResponseValue::stream(
-                    __progenitor_response,
-                ))),
+            let _url = format!("{}/device/token", _client.baseurl,);
+            let _request = _client.client.post(_url).form_urlencoded(&body)?.build()?;
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(_response)),
+                _ => Err(Error::ErrorResponse(ResponseValue::stream(_response))),
             }
         }
     }
@@ -21958,7 +21862,7 @@ pub mod builder {
     ///[`ClientSilosExt::group_list`]: super::ClientSilosExt::group_list
     #[derive(Debug, Clone)]
     pub struct GroupList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -21967,7 +21871,7 @@ pub mod builder {
     impl<'a> GroupList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -22011,7 +21915,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -22019,40 +21923,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/groups", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/groups", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -22118,14 +22019,14 @@ pub mod builder {
     ///[`ClientHiddenExt::login_spoof`]: super::ClientHiddenExt::login_spoof
     #[derive(Debug, Clone)]
     pub struct LoginSpoof<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::SpoofLoginBody, String>,
     }
 
     impl<'a> LoginSpoof<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::SpoofLoginBody::default()),
             }
         }
@@ -22151,37 +22052,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/login`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SpoofLoginBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/login", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/login", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -22191,7 +22086,7 @@ pub mod builder {
     ///[`ClientLoginExt::login_local`]: super::ClientLoginExt::login_local
     #[derive(Debug, Clone)]
     pub struct LoginLocal<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         body: Result<types::builder::UsernamePasswordCredentials, String>,
     }
@@ -22199,7 +22094,7 @@ pub mod builder {
     impl<'a> LoginLocal<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(types::builder::UsernamePasswordCredentials::default()),
             }
@@ -22238,7 +22133,7 @@ pub mod builder {
         ///Sends a `POST` request to `/login/{silo_name}/local`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 silo_name,
                 body,
             } = self;
@@ -22246,30 +22141,23 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::UsernamePasswordCredentials>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/login/{}/local",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
-                .client
-                .post(__progenitor_url)
-                .json(&body)
-                .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
+            let _request = _client.client.post(_url).json(&body).build()?;
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -22279,7 +22167,7 @@ pub mod builder {
     ///[`ClientLoginExt::login_saml_begin`]: super::ClientLoginExt::login_saml_begin
     #[derive(Debug, Clone)]
     pub struct LoginSamlBegin<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         provider_name: Result<types::Name, String>,
     }
@@ -22287,7 +22175,7 @@ pub mod builder {
     impl<'a> LoginSamlBegin<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 provider_name: Err("provider_name was not initialized".to_string()),
             }
@@ -22316,33 +22204,30 @@ pub mod builder {
         ///Sends a `GET` request to `/login/{silo_name}/saml/{provider_name}`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 silo_name,
                 provider_name,
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let provider_name = provider_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/login/{}/saml/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client.client.get(__progenitor_url).build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
+            let _request = _client.client.get(_url).build()?;
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -22352,7 +22237,7 @@ pub mod builder {
     ///[`ClientLoginExt::login_saml`]: super::ClientLoginExt::login_saml
     #[derive(Debug)]
     pub struct LoginSaml<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         provider_name: Result<types::Name, String>,
         body: Result<reqwest::Body, String>,
@@ -22361,7 +22246,7 @@ pub mod builder {
     impl<'a> LoginSaml<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 provider_name: Err("provider_name was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
@@ -22401,7 +22286,7 @@ pub mod builder {
         ///Sends a `POST` request to `/login/{silo_name}/saml/{provider_name}`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 silo_name,
                 provider_name,
                 body,
@@ -22409,35 +22294,32 @@ pub mod builder {
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let provider_name = provider_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/login/{}/saml/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::CONTENT_TYPE,
                     reqwest::header::HeaderValue::from_static("application/octet-stream"),
                 )
                 .body(body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -22447,44 +22329,37 @@ pub mod builder {
     ///[`ClientHiddenExt::logout`]: super::ClientHiddenExt::logout
     #[derive(Debug, Clone)]
     pub struct Logout<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> Logout<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `POST` request to `/logout`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url = format!("{}/logout", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/logout", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -22494,7 +22369,7 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_list`]: super::ClientOrganizationsExt::organization_list
     #[derive(Debug, Clone)]
     pub struct OrganizationList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameOrIdSortMode>, String>,
@@ -22503,7 +22378,7 @@ pub mod builder {
     impl<'a> OrganizationList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -22547,7 +22422,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -22555,40 +22430,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/organizations", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/organizations", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -22654,14 +22526,14 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_create`]: super::ClientOrganizationsExt::organization_create
     #[derive(Debug, Clone)]
     pub struct OrganizationCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::OrganizationCreate, String>,
     }
 
     impl<'a> OrganizationCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::OrganizationCreate::default()),
             }
         }
@@ -22689,37 +22561,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/organizations`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/organizations", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/organizations", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -22729,14 +22595,14 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_view`]: super::ClientOrganizationsExt::organization_view
     #[derive(Debug, Clone)]
     pub struct OrganizationView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
     }
 
     impl<'a> OrganizationView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
@@ -22754,37 +22620,34 @@ pub mod builder {
         ///Sends a `GET` request to `/organizations/{organization_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -22794,7 +22657,7 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_update`]: super::ClientOrganizationsExt::organization_update
     #[derive(Debug, Clone)]
     pub struct OrganizationUpdate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         body: Result<types::builder::OrganizationUpdate, String>,
     }
@@ -22802,7 +22665,7 @@ pub mod builder {
     impl<'a> OrganizationUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 body: Ok(types::builder::OrganizationUpdate::default()),
             }
@@ -22842,7 +22705,7 @@ pub mod builder {
         ///Sends a `PUT` request to `/organizations/{organization_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 body,
             } = self;
@@ -22850,34 +22713,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -22887,14 +22747,14 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_delete`]: super::ClientOrganizationsExt::organization_delete
     #[derive(Debug, Clone)]
     pub struct OrganizationDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
     }
 
     impl<'a> OrganizationDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
@@ -22912,37 +22772,34 @@ pub mod builder {
         ///Sends a `DELETE` request to `/organizations/{organization_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -22952,14 +22809,14 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_policy_view`]: super::ClientOrganizationsExt::organization_policy_view
     #[derive(Debug, Clone)]
     pub struct OrganizationPolicyView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
     }
 
     impl<'a> OrganizationPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
@@ -22979,37 +22836,34 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/policy",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -23019,7 +22873,7 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_policy_update`]: super::ClientOrganizationsExt::organization_policy_update
     #[derive(Debug, Clone)]
     pub struct OrganizationPolicyUpdate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         body: Result<types::builder::OrganizationRolePolicy, String>,
     }
@@ -23027,7 +22881,7 @@ pub mod builder {
     impl<'a> OrganizationPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 body: Ok(types::builder::OrganizationRolePolicy::default()),
             }
@@ -23069,7 +22923,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 body,
             } = self;
@@ -23077,34 +22931,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/policy",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -23114,7 +22965,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_list`]: super::ClientProjectsExt::project_list
     #[derive(Debug, Clone)]
     pub struct ProjectList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -23124,7 +22975,7 @@ pub mod builder {
     impl<'a> ProjectList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -23180,7 +23031,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 limit,
                 page_token,
@@ -23190,44 +23041,41 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -23294,7 +23142,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_create`]: super::ClientProjectsExt::project_create
     #[derive(Debug, Clone)]
     pub struct ProjectCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         body: Result<types::builder::ProjectCreate, String>,
     }
@@ -23302,7 +23150,7 @@ pub mod builder {
     impl<'a> ProjectCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 body: Ok(types::builder::ProjectCreate::default()),
             }
@@ -23341,7 +23189,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 body,
             } = self;
@@ -23349,34 +23197,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -23386,7 +23231,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_view`]: super::ClientProjectsExt::project_view
     #[derive(Debug, Clone)]
     pub struct ProjectView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
     }
@@ -23394,7 +23239,7 @@ pub mod builder {
     impl<'a> ProjectView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
             }
@@ -23424,40 +23269,37 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -23467,7 +23309,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_update`]: super::ClientProjectsExt::project_update
     #[derive(Debug, Clone)]
     pub struct ProjectUpdate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::ProjectUpdate, String>,
@@ -23476,7 +23318,7 @@ pub mod builder {
     impl<'a> ProjectUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::ProjectUpdate::default()),
@@ -23526,7 +23368,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 body,
@@ -23536,35 +23378,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -23574,7 +23413,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_delete`]: super::ClientProjectsExt::project_delete
     #[derive(Debug, Clone)]
     pub struct ProjectDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
     }
@@ -23582,7 +23421,7 @@ pub mod builder {
     impl<'a> ProjectDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
             }
@@ -23612,40 +23451,37 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -23655,7 +23491,7 @@ pub mod builder {
     ///[`ClientDisksExt::disk_list`]: super::ClientDisksExt::disk_list
     #[derive(Debug, Clone)]
     pub struct DiskList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -23666,7 +23502,7 @@ pub mod builder {
     impl<'a> DiskList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -23733,7 +23569,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 limit,
@@ -23745,45 +23581,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/disks",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -23850,7 +23683,7 @@ pub mod builder {
     ///[`ClientDisksExt::disk_create`]: super::ClientDisksExt::disk_create
     #[derive(Debug, Clone)]
     pub struct DiskCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::DiskCreate, String>,
@@ -23859,7 +23692,7 @@ pub mod builder {
     impl<'a> DiskCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::DiskCreate::default()),
@@ -23909,7 +23742,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}/disks`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 body,
@@ -23919,35 +23752,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/disks",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -23957,7 +23787,7 @@ pub mod builder {
     ///[`ClientDisksExt::disk_view`]: super::ClientDisksExt::disk_view
     #[derive(Debug, Clone)]
     pub struct DiskView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         disk_name: Result<types::Name, String>,
@@ -23966,7 +23796,7 @@ pub mod builder {
     impl<'a> DiskView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 disk_name: Err("disk_name was not initialized".to_string()),
@@ -24008,7 +23838,7 @@ pub mod builder {
         /// {disk_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 disk_name,
@@ -24016,35 +23846,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let disk_name = disk_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/disks/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -24054,7 +23881,7 @@ pub mod builder {
     ///[`ClientDisksExt::disk_delete`]: super::ClientDisksExt::disk_delete
     #[derive(Debug, Clone)]
     pub struct DiskDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         disk_name: Result<types::Name, String>,
@@ -24063,7 +23890,7 @@ pub mod builder {
     impl<'a> DiskDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 disk_name: Err("disk_name was not initialized".to_string()),
@@ -24105,7 +23932,7 @@ pub mod builder {
         /// {disk_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 disk_name,
@@ -24113,35 +23940,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let disk_name = disk_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/disks/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -24151,7 +23975,7 @@ pub mod builder {
     ///[`ClientDisksExt::disk_metrics_list`]: super::ClientDisksExt::disk_metrics_list
     #[derive(Debug, Clone)]
     pub struct DiskMetricsList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         disk_name: Result<types::Name, String>,
@@ -24165,7 +23989,7 @@ pub mod builder {
     impl<'a> DiskMetricsList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 disk_name: Err("disk_name was not initialized".to_string()),
@@ -24268,7 +24092,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::MeasurementResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 disk_name,
@@ -24286,50 +24110,47 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let start_time = start_time.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/disks/{}/metrics/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
                 encode_path(&metric_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(4usize);
+            let mut _query = Vec::with_capacity(4usize);
             if let Some(v) = &end_time {
-                __progenitor_query.push(("end_time", v.to_string()));
+                _query.push(("end_time", v.to_string()));
             }
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &start_time {
-                __progenitor_query.push(("start_time", v.to_string()));
+                _query.push(("start_time", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -24398,7 +24219,7 @@ pub mod builder {
     ///[`ClientImagesExt::image_list`]: super::ClientImagesExt::image_list
     #[derive(Debug, Clone)]
     pub struct ImageList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -24409,7 +24230,7 @@ pub mod builder {
     impl<'a> ImageList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -24476,7 +24297,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ImageResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 limit,
@@ -24488,45 +24309,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/images",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -24593,7 +24411,7 @@ pub mod builder {
     ///[`ClientImagesExt::image_create`]: super::ClientImagesExt::image_create
     #[derive(Debug, Clone)]
     pub struct ImageCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::ImageCreate, String>,
@@ -24602,7 +24420,7 @@ pub mod builder {
     impl<'a> ImageCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::ImageCreate::default()),
@@ -24652,7 +24470,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}/images`
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 body,
@@ -24662,35 +24480,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ImageCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/images",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -24700,7 +24515,7 @@ pub mod builder {
     ///[`ClientImagesExt::image_view`]: super::ClientImagesExt::image_view
     #[derive(Debug, Clone)]
     pub struct ImageView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         image_name: Result<types::Name, String>,
@@ -24709,7 +24524,7 @@ pub mod builder {
     impl<'a> ImageView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 image_name: Err("image_name was not initialized".to_string()),
@@ -24751,7 +24566,7 @@ pub mod builder {
         /// {image_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 image_name,
@@ -24759,35 +24574,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/images/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -24797,7 +24609,7 @@ pub mod builder {
     ///[`ClientImagesExt::image_delete`]: super::ClientImagesExt::image_delete
     #[derive(Debug, Clone)]
     pub struct ImageDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         image_name: Result<types::Name, String>,
@@ -24806,7 +24618,7 @@ pub mod builder {
     impl<'a> ImageDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 image_name: Err("image_name was not initialized".to_string()),
@@ -24848,7 +24660,7 @@ pub mod builder {
         /// {image_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 image_name,
@@ -24856,35 +24668,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/images/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -24894,7 +24703,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_list`]: super::ClientInstancesExt::instance_list
     #[derive(Debug, Clone)]
     pub struct InstanceList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -24905,7 +24714,7 @@ pub mod builder {
     impl<'a> InstanceList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -24973,7 +24782,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 limit,
@@ -24985,45 +24794,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -25091,7 +24897,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_create`]: super::ClientInstancesExt::instance_create
     #[derive(Debug, Clone)]
     pub struct InstanceCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::InstanceCreate, String>,
@@ -25100,7 +24906,7 @@ pub mod builder {
     impl<'a> InstanceCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::InstanceCreate::default()),
@@ -25151,7 +24957,7 @@ pub mod builder {
         /// instances`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 body,
@@ -25161,35 +24967,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -25199,7 +25002,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_view`]: super::ClientInstancesExt::instance_view
     #[derive(Debug, Clone)]
     pub struct InstanceView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25208,7 +25011,7 @@ pub mod builder {
     impl<'a> InstanceView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25250,7 +25053,7 @@ pub mod builder {
         /// instances/{instance_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25258,35 +25061,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -25296,7 +25096,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_delete`]: super::ClientInstancesExt::instance_delete
     #[derive(Debug, Clone)]
     pub struct InstanceDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25305,7 +25105,7 @@ pub mod builder {
     impl<'a> InstanceDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25347,7 +25147,7 @@ pub mod builder {
         /// instances/{instance_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25355,35 +25155,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -25393,7 +25190,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_disk_list`]: super::ClientInstancesExt::instance_disk_list
     #[derive(Debug, Clone)]
     pub struct InstanceDiskList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25405,7 +25202,7 @@ pub mod builder {
     impl<'a> InstanceDiskList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25484,7 +25281,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25498,46 +25295,43 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -25605,7 +25399,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_disk_attach`]: super::ClientInstancesExt::instance_disk_attach
     #[derive(Debug, Clone)]
     pub struct InstanceDiskAttach<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25615,7 +25409,7 @@ pub mod builder {
     impl<'a> InstanceDiskAttach<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25677,7 +25471,7 @@ pub mod builder {
         /// instances/{instance_name}/disks/attach`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25689,36 +25483,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskIdentifier>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks/attach",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                202u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                202u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -25728,7 +25519,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_disk_detach`]: super::ClientInstancesExt::instance_disk_detach
     #[derive(Debug, Clone)]
     pub struct InstanceDiskDetach<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25738,7 +25529,7 @@ pub mod builder {
     impl<'a> InstanceDiskDetach<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25800,7 +25591,7 @@ pub mod builder {
         /// instances/{instance_name}/disks/detach`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25812,36 +25603,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskIdentifier>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks/detach",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                202u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                202u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -25851,7 +25639,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_external_ip_list`]: super::ClientInstancesExt::instance_external_ip_list
     #[derive(Debug, Clone)]
     pub struct InstanceExternalIpList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25860,7 +25648,7 @@ pub mod builder {
     impl<'a> InstanceExternalIpList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25904,7 +25692,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ExternalIpResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25912,35 +25700,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/external-ips",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -25950,7 +25735,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_migrate`]: super::ClientInstancesExt::instance_migrate
     #[derive(Debug, Clone)]
     pub struct InstanceMigrate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25960,7 +25745,7 @@ pub mod builder {
     impl<'a> InstanceMigrate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26022,7 +25807,7 @@ pub mod builder {
         /// instances/{instance_name}/migrate`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26034,36 +25819,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceMigrate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/migrate",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -26073,7 +25855,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_network_interface_list`]: super::ClientInstancesExt::instance_network_interface_list
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26085,7 +25867,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26165,7 +25947,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::NetworkInterfaceResultsPage>, Error<types::Error>>
         {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26179,46 +25961,43 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -26286,7 +26065,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_network_interface_create`]: super::ClientInstancesExt::instance_network_interface_create
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26296,7 +26075,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26362,7 +26141,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26374,36 +26153,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::NetworkInterfaceCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -26413,7 +26189,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_network_interface_view`]: super::ClientInstancesExt::instance_network_interface_view
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26423,7 +26199,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26478,7 +26254,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26488,36 +26264,33 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let interface_name = interface_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -26527,7 +26300,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_network_interface_update`]: super::ClientInstancesExt::instance_network_interface_update
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceUpdate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26538,7 +26311,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26615,7 +26388,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26629,37 +26402,34 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::NetworkInterfaceUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -26669,7 +26439,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_network_interface_delete`]: super::ClientInstancesExt::instance_network_interface_delete
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26679,7 +26449,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26732,7 +26502,7 @@ pub mod builder {
         /// instances/{instance_name}/network-interfaces/{interface_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26742,36 +26512,33 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let interface_name = interface_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -26781,7 +26548,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_reboot`]: super::ClientInstancesExt::instance_reboot
     #[derive(Debug, Clone)]
     pub struct InstanceReboot<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26790,7 +26557,7 @@ pub mod builder {
     impl<'a> InstanceReboot<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26832,7 +26599,7 @@ pub mod builder {
         /// instances/{instance_name}/reboot`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26840,35 +26607,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/reboot",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                202u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                202u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -26878,7 +26642,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_serial_console`]: super::ClientInstancesExt::instance_serial_console
     #[derive(Debug, Clone)]
     pub struct InstanceSerialConsole<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26890,7 +26654,7 @@ pub mod builder {
     impl<'a> InstanceSerialConsole<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26970,7 +26734,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceSerialConsoleData>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26984,46 +26748,43 @@ pub mod builder {
             let from_start = from_start.map_err(Error::InvalidRequest)?;
             let max_bytes = max_bytes.map_err(Error::InvalidRequest)?;
             let most_recent = most_recent.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/serial-console",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &from_start {
-                __progenitor_query.push(("from_start", v.to_string()));
+                _query.push(("from_start", v.to_string()));
             }
             if let Some(v) = &max_bytes {
-                __progenitor_query.push(("max_bytes", v.to_string()));
+                _query.push(("max_bytes", v.to_string()));
             }
             if let Some(v) = &most_recent {
-                __progenitor_query.push(("most_recent", v.to_string()));
+                _query.push(("most_recent", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -27033,7 +26794,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_serial_console_stream`]: super::ClientInstancesExt::instance_serial_console_stream
     #[derive(Debug, Clone)]
     pub struct InstanceSerialConsoleStream<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -27042,7 +26803,7 @@ pub mod builder {
     impl<'a> InstanceSerialConsoleStream<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -27086,7 +26847,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -27094,16 +26855,16 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/serial-console/stream",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(reqwest::header::CONNECTION, "Upgrade")
                 .header(reqwest::header::UPGRADE, "websocket")
                 .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -27115,15 +26876,12 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                101u16 => ResponseValue::upgrade(__progenitor_response).await,
-                200..=299 => ResponseValue::upgrade(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                101u16 => ResponseValue::upgrade(_response).await,
+                200..=299 => ResponseValue::upgrade(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -27133,7 +26891,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_start`]: super::ClientInstancesExt::instance_start
     #[derive(Debug, Clone)]
     pub struct InstanceStart<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -27142,7 +26900,7 @@ pub mod builder {
     impl<'a> InstanceStart<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -27184,7 +26942,7 @@ pub mod builder {
         /// instances/{instance_name}/start`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -27192,35 +26950,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/start",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                202u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                202u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -27230,7 +26985,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_stop`]: super::ClientInstancesExt::instance_stop
     #[derive(Debug, Clone)]
     pub struct InstanceStop<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -27239,7 +26994,7 @@ pub mod builder {
     impl<'a> InstanceStop<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -27281,7 +27036,7 @@ pub mod builder {
         /// instances/{instance_name}/stop`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -27289,35 +27044,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/stop",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                202u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                202u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -27327,7 +27079,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_policy_view`]: super::ClientProjectsExt::project_policy_view
     #[derive(Debug, Clone)]
     pub struct ProjectPolicyView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
     }
@@ -27335,7 +27087,7 @@ pub mod builder {
     impl<'a> ProjectPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
             }
@@ -27367,40 +27119,37 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/policy",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -27410,7 +27159,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_policy_update`]: super::ClientProjectsExt::project_policy_update
     #[derive(Debug, Clone)]
     pub struct ProjectPolicyUpdate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::ProjectRolePolicy, String>,
@@ -27419,7 +27168,7 @@ pub mod builder {
     impl<'a> ProjectPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::ProjectRolePolicy::default()),
@@ -27473,7 +27222,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 body,
@@ -27483,35 +27232,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/policy",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -27521,7 +27267,7 @@ pub mod builder {
     ///[`ClientSnapshotsExt::snapshot_list`]: super::ClientSnapshotsExt::snapshot_list
     #[derive(Debug, Clone)]
     pub struct SnapshotList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -27532,7 +27278,7 @@ pub mod builder {
     impl<'a> SnapshotList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -27600,7 +27346,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SnapshotResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 limit,
@@ -27612,45 +27358,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/snapshots",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -27718,7 +27461,7 @@ pub mod builder {
     ///[`ClientSnapshotsExt::snapshot_create`]: super::ClientSnapshotsExt::snapshot_create
     #[derive(Debug, Clone)]
     pub struct SnapshotCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::SnapshotCreate, String>,
@@ -27727,7 +27470,7 @@ pub mod builder {
     impl<'a> SnapshotCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::SnapshotCreate::default()),
@@ -27778,7 +27521,7 @@ pub mod builder {
         /// snapshots`
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 body,
@@ -27788,35 +27531,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::SnapshotCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/snapshots",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -27826,7 +27566,7 @@ pub mod builder {
     ///[`ClientSnapshotsExt::snapshot_view`]: super::ClientSnapshotsExt::snapshot_view
     #[derive(Debug, Clone)]
     pub struct SnapshotView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         snapshot_name: Result<types::Name, String>,
@@ -27835,7 +27575,7 @@ pub mod builder {
     impl<'a> SnapshotView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 snapshot_name: Err("snapshot_name was not initialized".to_string()),
@@ -27877,7 +27617,7 @@ pub mod builder {
         /// snapshots/{snapshot_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 snapshot_name,
@@ -27885,35 +27625,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let snapshot_name = snapshot_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/snapshots/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -27923,7 +27660,7 @@ pub mod builder {
     ///[`ClientSnapshotsExt::snapshot_delete`]: super::ClientSnapshotsExt::snapshot_delete
     #[derive(Debug, Clone)]
     pub struct SnapshotDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         snapshot_name: Result<types::Name, String>,
@@ -27932,7 +27669,7 @@ pub mod builder {
     impl<'a> SnapshotDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 snapshot_name: Err("snapshot_name was not initialized".to_string()),
@@ -27974,7 +27711,7 @@ pub mod builder {
         /// snapshots/{snapshot_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 snapshot_name,
@@ -27982,35 +27719,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let snapshot_name = snapshot_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/snapshots/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -28020,7 +27754,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_list`]: super::ClientVpcsExt::vpc_list
     #[derive(Debug, Clone)]
     pub struct VpcList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -28031,7 +27765,7 @@ pub mod builder {
     impl<'a> VpcList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -28098,7 +27832,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 limit,
@@ -28110,45 +27844,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -28215,7 +27946,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_create`]: super::ClientVpcsExt::vpc_create
     #[derive(Debug, Clone)]
     pub struct VpcCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::VpcCreate, String>,
@@ -28224,7 +27955,7 @@ pub mod builder {
     impl<'a> VpcCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::VpcCreate::default()),
@@ -28274,7 +28005,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs`
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 body,
@@ -28284,35 +28015,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -28322,7 +28050,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_view`]: super::ClientVpcsExt::vpc_view
     #[derive(Debug, Clone)]
     pub struct VpcView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28331,7 +28059,7 @@ pub mod builder {
     impl<'a> VpcView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28373,7 +28101,7 @@ pub mod builder {
         /// {vpc_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28381,35 +28109,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -28419,7 +28144,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_update`]: super::ClientVpcsExt::vpc_update
     #[derive(Debug, Clone)]
     pub struct VpcUpdate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28429,7 +28154,7 @@ pub mod builder {
     impl<'a> VpcUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28491,7 +28216,7 @@ pub mod builder {
         /// {vpc_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28503,36 +28228,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -28542,7 +28264,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_delete`]: super::ClientVpcsExt::vpc_delete
     #[derive(Debug, Clone)]
     pub struct VpcDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28551,7 +28273,7 @@ pub mod builder {
     impl<'a> VpcDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28593,7 +28315,7 @@ pub mod builder {
         /// {vpc_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28601,35 +28323,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -28639,7 +28358,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_firewall_rules_view`]: super::ClientVpcsExt::vpc_firewall_rules_view
     #[derive(Debug, Clone)]
     pub struct VpcFirewallRulesView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28648,7 +28367,7 @@ pub mod builder {
     impl<'a> VpcFirewallRulesView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28692,7 +28411,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcFirewallRules>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28700,35 +28419,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -28738,7 +28454,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_firewall_rules_update`]: super::ClientVpcsExt::vpc_firewall_rules_update
     #[derive(Debug, Clone)]
     pub struct VpcFirewallRulesUpdate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28748,7 +28464,7 @@ pub mod builder {
     impl<'a> VpcFirewallRulesUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28813,7 +28529,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcFirewallRules>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28825,36 +28541,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcFirewallRuleUpdateParams>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -28864,7 +28577,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_list`]: super::ClientVpcsExt::vpc_router_list
     #[derive(Debug, Clone)]
     pub struct VpcRouterList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28876,7 +28589,7 @@ pub mod builder {
     impl<'a> VpcRouterList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28955,7 +28668,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcRouterResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28969,46 +28682,43 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -29076,7 +28786,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_create`]: super::ClientVpcsExt::vpc_router_create
     #[derive(Debug, Clone)]
     pub struct VpcRouterCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29086,7 +28796,7 @@ pub mod builder {
     impl<'a> VpcRouterCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29148,7 +28858,7 @@ pub mod builder {
         /// {vpc_name}/routers`
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29160,36 +28870,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcRouterCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -29199,7 +28906,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_view`]: super::ClientVpcsExt::vpc_router_view
     #[derive(Debug, Clone)]
     pub struct VpcRouterView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29209,7 +28916,7 @@ pub mod builder {
     impl<'a> VpcRouterView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29262,7 +28969,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29272,36 +28979,33 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -29311,7 +29015,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_update`]: super::ClientVpcsExt::vpc_router_update
     #[derive(Debug, Clone)]
     pub struct VpcRouterUpdate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29322,7 +29026,7 @@ pub mod builder {
     impl<'a> VpcRouterUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29395,7 +29099,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29409,37 +29113,34 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcRouterUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -29449,7 +29150,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_delete`]: super::ClientVpcsExt::vpc_router_delete
     #[derive(Debug, Clone)]
     pub struct VpcRouterDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29459,7 +29160,7 @@ pub mod builder {
     impl<'a> VpcRouterDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29512,7 +29213,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29522,36 +29223,33 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -29561,7 +29259,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_route_list`]: super::ClientVpcsExt::vpc_router_route_list
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29574,7 +29272,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29664,7 +29362,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::RouterRouteResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29680,47 +29378,44 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -29788,7 +29483,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_route_create`]: super::ClientVpcsExt::vpc_router_route_create
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29799,7 +29494,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29874,7 +29569,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}/routes`
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29888,37 +29583,34 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::RouterRouteCreateParams>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -29928,7 +29620,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_route_view`]: super::ClientVpcsExt::vpc_router_route_view
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29939,7 +29631,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30003,7 +29695,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}/routes/{route_name}`
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30015,37 +29707,34 @@ pub mod builder {
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
             let route_name = route_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -30055,7 +29744,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_route_update`]: super::ClientVpcsExt::vpc_router_route_update
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteUpdate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30067,7 +29756,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30153,7 +29842,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}/routes/{route_name}`
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30169,38 +29858,35 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::RouterRouteUpdateParams>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -30210,7 +29896,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_router_route_delete`]: super::ClientVpcsExt::vpc_router_route_delete
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30221,7 +29907,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30285,7 +29971,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}/routes/{route_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30297,37 +29983,34 @@ pub mod builder {
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
             let route_name = route_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -30337,7 +30020,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_subnet_list`]: super::ClientVpcsExt::vpc_subnet_list
     #[derive(Debug, Clone)]
     pub struct VpcSubnetList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30349,7 +30032,7 @@ pub mod builder {
     impl<'a> VpcSubnetList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30428,7 +30111,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcSubnetResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30442,46 +30125,43 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -30549,7 +30229,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_subnet_create`]: super::ClientVpcsExt::vpc_subnet_create
     #[derive(Debug, Clone)]
     pub struct VpcSubnetCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30559,7 +30239,7 @@ pub mod builder {
     impl<'a> VpcSubnetCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30621,7 +30301,7 @@ pub mod builder {
         /// {vpc_name}/subnets`
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30633,36 +30313,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcSubnetCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -30672,7 +30349,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_subnet_view`]: super::ClientVpcsExt::vpc_subnet_view
     #[derive(Debug, Clone)]
     pub struct VpcSubnetView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30682,7 +30359,7 @@ pub mod builder {
     impl<'a> VpcSubnetView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30735,7 +30412,7 @@ pub mod builder {
         /// {vpc_name}/subnets/{subnet_name}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30745,36 +30422,33 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -30784,7 +30458,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_subnet_update`]: super::ClientVpcsExt::vpc_subnet_update
     #[derive(Debug, Clone)]
     pub struct VpcSubnetUpdate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30795,7 +30469,7 @@ pub mod builder {
     impl<'a> VpcSubnetUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30868,7 +30542,7 @@ pub mod builder {
         /// {vpc_name}/subnets/{subnet_name}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30882,37 +30556,34 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcSubnetUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -30922,7 +30593,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_subnet_delete`]: super::ClientVpcsExt::vpc_subnet_delete
     #[derive(Debug, Clone)]
     pub struct VpcSubnetDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30932,7 +30603,7 @@ pub mod builder {
     impl<'a> VpcSubnetDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30985,7 +30656,7 @@ pub mod builder {
         /// {vpc_name}/subnets/{subnet_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30995,36 +30666,33 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -31034,7 +30702,7 @@ pub mod builder {
     ///[`ClientVpcsExt::vpc_subnet_list_network_interfaces`]: super::ClientVpcsExt::vpc_subnet_list_network_interfaces
     #[derive(Debug, Clone)]
     pub struct VpcSubnetListNetworkInterfaces<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -31047,7 +30715,7 @@ pub mod builder {
     impl<'a> VpcSubnetListNetworkInterfaces<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -31138,7 +30806,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::NetworkInterfaceResultsPage>, Error<types::Error>>
         {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -31154,47 +30822,44 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}/network-interfaces",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -31262,46 +30927,39 @@ pub mod builder {
     ///[`ClientSilosExt::policy_view`]: super::ClientSilosExt::policy_view
     #[derive(Debug, Clone)]
     pub struct PolicyView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> PolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `GET` request to `/policy`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url = format!("{}/policy", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/policy", _client.baseurl,);
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -31311,14 +30969,14 @@ pub mod builder {
     ///[`ClientSilosExt::policy_update`]: super::ClientSilosExt::policy_update
     #[derive(Debug, Clone)]
     pub struct PolicyUpdate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::SiloRolePolicy, String>,
     }
 
     impl<'a> PolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::SiloRolePolicy::default()),
             }
         }
@@ -31346,37 +31004,31 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SiloRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/policy", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/policy", _client.baseurl,);
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -31386,7 +31038,7 @@ pub mod builder {
     ///[`ClientRolesExt::role_list`]: super::ClientRolesExt::role_list
     #[derive(Debug, Clone)]
     pub struct RoleList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
     }
@@ -31394,7 +31046,7 @@ pub mod builder {
     impl<'a> RoleList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
             }
@@ -31426,43 +31078,40 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::RoleResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/roles", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let _url = format!("{}/roles", _client.baseurl,);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -31527,14 +31176,14 @@ pub mod builder {
     ///[`ClientRolesExt::role_view`]: super::ClientRolesExt::role_view
     #[derive(Debug, Clone)]
     pub struct RoleView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         role_name: Result<String, String>,
     }
 
     impl<'a> RoleView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 role_name: Err("role_name was not initialized".to_string()),
             }
         }
@@ -31551,38 +31200,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/roles/{role_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Role>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                role_name,
-            } = self;
+            let Self { _client, role_name } = self;
             let role_name = role_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/roles/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&role_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -31592,44 +31235,37 @@ pub mod builder {
     ///[`ClientHiddenExt::session_me`]: super::ClientHiddenExt::session_me
     #[derive(Debug, Clone)]
     pub struct SessionMe<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> SessionMe<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `GET` request to `/session/me`
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url = format!("{}/session/me", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/session/me", _client.baseurl,);
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -31639,7 +31275,7 @@ pub mod builder {
     ///[`ClientHiddenExt::session_me_groups`]: super::ClientHiddenExt::session_me_groups
     #[derive(Debug, Clone)]
     pub struct SessionMeGroups<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -31648,7 +31284,7 @@ pub mod builder {
     impl<'a> SessionMeGroups<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -31692,7 +31328,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -31700,40 +31336,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/session/me/groups", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/session/me/groups", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -31799,7 +31432,7 @@ pub mod builder {
     ///[`ClientSessionExt::session_sshkey_list`]: super::ClientSessionExt::session_sshkey_list
     #[derive(Debug, Clone)]
     pub struct SessionSshkeyList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameSortMode>, String>,
@@ -31808,7 +31441,7 @@ pub mod builder {
     impl<'a> SessionSshkeyList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -31852,7 +31485,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SshKeyResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -31860,40 +31493,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/session/me/sshkeys", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/session/me/sshkeys", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -31959,14 +31589,14 @@ pub mod builder {
     ///[`ClientSessionExt::session_sshkey_create`]: super::ClientSessionExt::session_sshkey_create
     #[derive(Debug, Clone)]
     pub struct SessionSshkeyCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::SshKeyCreate, String>,
     }
 
     impl<'a> SessionSshkeyCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::SshKeyCreate::default()),
             }
         }
@@ -31992,37 +31622,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/session/me/sshkeys`
         pub async fn send(self) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SshKeyCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/session/me/sshkeys", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/session/me/sshkeys", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -32032,14 +31656,14 @@ pub mod builder {
     ///[`ClientSessionExt::session_sshkey_view`]: super::ClientSessionExt::session_sshkey_view
     #[derive(Debug, Clone)]
     pub struct SessionSshkeyView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         ssh_key_name: Result<types::Name, String>,
     }
 
     impl<'a> SessionSshkeyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 ssh_key_name: Err("ssh_key_name was not initialized".to_string()),
             }
         }
@@ -32057,37 +31681,34 @@ pub mod builder {
         ///Sends a `GET` request to `/session/me/sshkeys/{ssh_key_name}`
         pub async fn send(self) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 ssh_key_name,
             } = self;
             let ssh_key_name = ssh_key_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/session/me/sshkeys/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -32097,14 +31718,14 @@ pub mod builder {
     ///[`ClientSessionExt::session_sshkey_delete`]: super::ClientSessionExt::session_sshkey_delete
     #[derive(Debug, Clone)]
     pub struct SessionSshkeyDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         ssh_key_name: Result<types::Name, String>,
     }
 
     impl<'a> SessionSshkeyDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 ssh_key_name: Err("ssh_key_name was not initialized".to_string()),
             }
         }
@@ -32122,37 +31743,34 @@ pub mod builder {
         ///Sends a `DELETE` request to `/session/me/sshkeys/{ssh_key_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 ssh_key_name,
             } = self;
             let ssh_key_name = ssh_key_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/session/me/sshkeys/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -32162,14 +31780,14 @@ pub mod builder {
     ///[`ClientSystemExt::system_image_view_by_id`]: super::ClientSystemExt::system_image_view_by_id
     #[derive(Debug, Clone)]
     pub struct SystemImageViewById<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SystemImageViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -32186,38 +31804,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/by-id/images/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/by-id/images/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -32227,14 +31839,14 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_view_by_id`]: super::ClientSystemExt::ip_pool_view_by_id
     #[derive(Debug, Clone)]
     pub struct IpPoolViewById<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> IpPoolViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -32251,38 +31863,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/by-id/ip-pools/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/by-id/ip-pools/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -32292,14 +31898,14 @@ pub mod builder {
     ///[`ClientSystemExt::silo_view_by_id`]: super::ClientSystemExt::silo_view_by_id
     #[derive(Debug, Clone)]
     pub struct SiloViewById<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SiloViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -32316,38 +31922,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/by-id/silos/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/by-id/silos/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -32357,7 +31957,7 @@ pub mod builder {
     ///[`ClientSystemExt::certificate_list`]: super::ClientSystemExt::certificate_list
     #[derive(Debug, Clone)]
     pub struct CertificateList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameSortMode>, String>,
@@ -32366,7 +31966,7 @@ pub mod builder {
     impl<'a> CertificateList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -32410,7 +32010,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::CertificateResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -32418,40 +32018,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/certificates", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/system/certificates", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -32517,14 +32114,14 @@ pub mod builder {
     ///[`ClientSystemExt::certificate_create`]: super::ClientSystemExt::certificate_create
     #[derive(Debug, Clone)]
     pub struct CertificateCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::CertificateCreate, String>,
     }
 
     impl<'a> CertificateCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::CertificateCreate::default()),
             }
         }
@@ -32552,37 +32149,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/certificates`
         pub async fn send(self) -> Result<ResponseValue<types::Certificate>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::CertificateCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/certificates", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/system/certificates", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -32592,14 +32183,14 @@ pub mod builder {
     ///[`ClientSystemExt::certificate_view`]: super::ClientSystemExt::certificate_view
     #[derive(Debug, Clone)]
     pub struct CertificateView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         certificate: Result<types::NameOrId, String>,
     }
 
     impl<'a> CertificateView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 certificate: Err("certificate was not initialized".to_string()),
             }
         }
@@ -32617,37 +32208,34 @@ pub mod builder {
         ///Sends a `GET` request to `/system/certificates/{certificate}`
         pub async fn send(self) -> Result<ResponseValue<types::Certificate>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 certificate,
             } = self;
             let certificate = certificate.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/certificates/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&certificate.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -32657,14 +32245,14 @@ pub mod builder {
     ///[`ClientSystemExt::certificate_delete`]: super::ClientSystemExt::certificate_delete
     #[derive(Debug, Clone)]
     pub struct CertificateDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         certificate: Result<types::NameOrId, String>,
     }
 
     impl<'a> CertificateDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 certificate: Err("certificate was not initialized".to_string()),
             }
         }
@@ -32682,37 +32270,34 @@ pub mod builder {
         ///Sends a `DELETE` request to `/system/certificates/{certificate}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 certificate,
             } = self;
             let certificate = certificate.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/certificates/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&certificate.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -32722,7 +32307,7 @@ pub mod builder {
     ///[`ClientSystemExt::physical_disk_list`]: super::ClientSystemExt::physical_disk_list
     #[derive(Debug, Clone)]
     pub struct PhysicalDiskList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -32731,7 +32316,7 @@ pub mod builder {
     impl<'a> PhysicalDiskList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -32775,7 +32360,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::PhysicalDiskResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -32783,41 +32368,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url =
-                format!("{}/system/hardware/disks", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/system/hardware/disks", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -32883,7 +32464,7 @@ pub mod builder {
     ///[`ClientSystemExt::rack_list`]: super::ClientSystemExt::rack_list
     #[derive(Debug, Clone)]
     pub struct RackList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -32892,7 +32473,7 @@ pub mod builder {
     impl<'a> RackList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -32936,7 +32517,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::RackResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -32944,41 +32525,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url =
-                format!("{}/system/hardware/racks", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/system/hardware/racks", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -33044,14 +32621,14 @@ pub mod builder {
     ///[`ClientSystemExt::rack_view`]: super::ClientSystemExt::rack_view
     #[derive(Debug, Clone)]
     pub struct RackView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         rack_id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> RackView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 rack_id: Err("rack_id was not initialized".to_string()),
             }
         }
@@ -33068,38 +32645,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/hardware/racks/{rack_id}`
         pub async fn send(self) -> Result<ResponseValue<types::Rack>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                rack_id,
-            } = self;
+            let Self { _client, rack_id } = self;
             let rack_id = rack_id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/hardware/racks/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&rack_id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -33109,7 +32680,7 @@ pub mod builder {
     ///[`ClientSystemExt::sled_list`]: super::ClientSystemExt::sled_list
     #[derive(Debug, Clone)]
     pub struct SledList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -33118,7 +32689,7 @@ pub mod builder {
     impl<'a> SledList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -33162,7 +32733,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SledResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -33170,41 +32741,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url =
-                format!("{}/system/hardware/sleds", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/system/hardware/sleds", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -33270,14 +32837,14 @@ pub mod builder {
     ///[`ClientSystemExt::sled_view`]: super::ClientSystemExt::sled_view
     #[derive(Debug, Clone)]
     pub struct SledView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         sled_id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SledView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 sled_id: Err("sled_id was not initialized".to_string()),
             }
         }
@@ -33294,38 +32861,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/hardware/sleds/{sled_id}`
         pub async fn send(self) -> Result<ResponseValue<types::Sled>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                sled_id,
-            } = self;
+            let Self { _client, sled_id } = self;
             let sled_id = sled_id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/hardware/sleds/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&sled_id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -33335,7 +32896,7 @@ pub mod builder {
     ///[`ClientSystemExt::sled_physical_disk_list`]: super::ClientSystemExt::sled_physical_disk_list
     #[derive(Debug, Clone)]
     pub struct SledPhysicalDiskList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         sled_id: Result<uuid::Uuid, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -33345,7 +32906,7 @@ pub mod builder {
     impl<'a> SledPhysicalDiskList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 sled_id: Err("sled_id was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -33400,7 +32961,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::PhysicalDiskResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 sled_id,
                 limit,
                 page_token,
@@ -33410,44 +32971,41 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/hardware/sleds/{}/disks",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&sled_id.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -33513,7 +33071,7 @@ pub mod builder {
     ///[`ClientSystemExt::system_image_list`]: super::ClientSystemExt::system_image_list
     #[derive(Debug, Clone)]
     pub struct SystemImageList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameSortMode>, String>,
@@ -33522,7 +33080,7 @@ pub mod builder {
     impl<'a> SystemImageList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -33566,7 +33124,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::GlobalImageResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -33574,40 +33132,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/images", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/system/images", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -33673,14 +33228,14 @@ pub mod builder {
     ///[`ClientSystemExt::system_image_create`]: super::ClientSystemExt::system_image_create
     #[derive(Debug, Clone)]
     pub struct SystemImageCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::GlobalImageCreate, String>,
     }
 
     impl<'a> SystemImageCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::GlobalImageCreate::default()),
             }
         }
@@ -33708,37 +33263,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/images`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::GlobalImageCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/images", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/system/images", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -33748,14 +33297,14 @@ pub mod builder {
     ///[`ClientSystemExt::system_image_view`]: super::ClientSystemExt::system_image_view
     #[derive(Debug, Clone)]
     pub struct SystemImageView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         image_name: Result<types::Name, String>,
     }
 
     impl<'a> SystemImageView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 image_name: Err("image_name was not initialized".to_string()),
             }
         }
@@ -33773,37 +33322,34 @@ pub mod builder {
         ///Sends a `GET` request to `/system/images/{image_name}`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 image_name,
             } = self;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/images/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&image_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -33813,14 +33359,14 @@ pub mod builder {
     ///[`ClientSystemExt::system_image_delete`]: super::ClientSystemExt::system_image_delete
     #[derive(Debug, Clone)]
     pub struct SystemImageDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         image_name: Result<types::Name, String>,
     }
 
     impl<'a> SystemImageDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 image_name: Err("image_name was not initialized".to_string()),
             }
         }
@@ -33838,37 +33384,34 @@ pub mod builder {
         ///Sends a `DELETE` request to `/system/images/{image_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 image_name,
             } = self;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/images/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&image_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -33878,7 +33421,7 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_list`]: super::ClientSystemExt::ip_pool_list
     #[derive(Debug, Clone)]
     pub struct IpPoolList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameOrIdSortMode>, String>,
@@ -33887,7 +33430,7 @@ pub mod builder {
     impl<'a> IpPoolList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -33931,7 +33474,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::IpPoolResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -33939,40 +33482,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/ip-pools", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/system/ip-pools", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -34038,14 +33578,14 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_create`]: super::ClientSystemExt::ip_pool_create
     #[derive(Debug, Clone)]
     pub struct IpPoolCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::IpPoolCreate, String>,
     }
 
     impl<'a> IpPoolCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::IpPoolCreate::default()),
             }
         }
@@ -34071,37 +33611,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/ip-pools`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::IpPoolCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/ip-pools", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/system/ip-pools", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -34111,14 +33645,14 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_view`]: super::ClientSystemExt::ip_pool_view
     #[derive(Debug, Clone)]
     pub struct IpPoolView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         pool_name: Result<types::Name, String>,
     }
 
     impl<'a> IpPoolView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
             }
         }
@@ -34135,38 +33669,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/ip-pools/{pool_name}`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                pool_name,
-            } = self;
+            let Self { _client, pool_name } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/ip-pools/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -34176,7 +33704,7 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_update`]: super::ClientSystemExt::ip_pool_update
     #[derive(Debug, Clone)]
     pub struct IpPoolUpdate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         pool_name: Result<types::Name, String>,
         body: Result<types::builder::IpPoolUpdate, String>,
     }
@@ -34184,7 +33712,7 @@ pub mod builder {
     impl<'a> IpPoolUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 body: Ok(types::builder::IpPoolUpdate::default()),
             }
@@ -34222,7 +33750,7 @@ pub mod builder {
         ///Sends a `PUT` request to `/system/ip-pools/{pool_name}`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 pool_name,
                 body,
             } = self;
@@ -34230,34 +33758,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::IpPoolUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/ip-pools/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -34267,14 +33792,14 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_delete`]: super::ClientSystemExt::ip_pool_delete
     #[derive(Debug, Clone)]
     pub struct IpPoolDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         pool_name: Result<types::Name, String>,
     }
 
     impl<'a> IpPoolDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
             }
         }
@@ -34291,38 +33816,32 @@ pub mod builder {
 
         ///Sends a `DELETE` request to `/system/ip-pools/{pool_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                pool_name,
-            } = self;
+            let Self { _client, pool_name } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/ip-pools/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -34332,7 +33851,7 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_range_list`]: super::ClientSystemExt::ip_pool_range_list
     #[derive(Debug, Clone)]
     pub struct IpPoolRangeList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         pool_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -34341,7 +33860,7 @@ pub mod builder {
     impl<'a> IpPoolRangeList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -34384,7 +33903,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 pool_name,
                 limit,
                 page_token,
@@ -34392,41 +33911,38 @@ pub mod builder {
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/ip-pools/{}/ranges",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -34491,7 +34007,7 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_range_add`]: super::ClientSystemExt::ip_pool_range_add
     #[derive(Debug, Clone)]
     pub struct IpPoolRangeAdd<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         pool_name: Result<types::Name, String>,
         body: Result<types::IpRange, String>,
     }
@@ -34499,7 +34015,7 @@ pub mod builder {
     impl<'a> IpPoolRangeAdd<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
@@ -34528,40 +34044,37 @@ pub mod builder {
         ///Sends a `POST` request to `/system/ip-pools/{pool_name}/ranges/add`
         pub async fn send(self) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 pool_name,
                 body,
             } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/ip-pools/{}/ranges/add",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -34571,7 +34084,7 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_range_remove`]: super::ClientSystemExt::ip_pool_range_remove
     #[derive(Debug, Clone)]
     pub struct IpPoolRangeRemove<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         pool_name: Result<types::Name, String>,
         body: Result<types::IpRange, String>,
     }
@@ -34579,7 +34092,7 @@ pub mod builder {
     impl<'a> IpPoolRangeRemove<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
@@ -34609,40 +34122,37 @@ pub mod builder {
         /// `/system/ip-pools/{pool_name}/ranges/remove`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 pool_name,
                 body,
             } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/ip-pools/{}/ranges/remove",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -34652,45 +34162,37 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_service_view`]: super::ClientSystemExt::ip_pool_service_view
     #[derive(Debug, Clone)]
     pub struct IpPoolServiceView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> IpPoolServiceView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `GET` request to `/system/ip-pools-service`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url =
-                format!("{}/system/ip-pools-service", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/system/ip-pools-service", _client.baseurl,);
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -34700,7 +34202,7 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_service_range_list`]: super::ClientSystemExt::ip_pool_service_range_list
     #[derive(Debug, Clone)]
     pub struct IpPoolServiceRangeList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
     }
@@ -34708,7 +34210,7 @@ pub mod builder {
     impl<'a> IpPoolServiceRangeList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
             }
@@ -34740,46 +34242,40 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
-                "{}/system/ip-pools-service/ranges",
-                __progenitor_client.baseurl,
-            );
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let _url = format!("{}/system/ip-pools-service/ranges", _client.baseurl,);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -34844,14 +34340,14 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_service_range_add`]: super::ClientSystemExt::ip_pool_service_range_add
     #[derive(Debug, Clone)]
     pub struct IpPoolServiceRangeAdd<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::IpRange, String>,
     }
 
     impl<'a> IpPoolServiceRangeAdd<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -34868,38 +34364,29 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/ip-pools-service/ranges/add`
         pub async fn send(self) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
-                "{}/system/ip-pools-service/ranges/add",
-                __progenitor_client.baseurl,
-            );
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/system/ip-pools-service/ranges/add", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -34909,14 +34396,14 @@ pub mod builder {
     ///[`ClientSystemExt::ip_pool_service_range_remove`]: super::ClientSystemExt::ip_pool_service_range_remove
     #[derive(Debug, Clone)]
     pub struct IpPoolServiceRangeRemove<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::IpRange, String>,
     }
 
     impl<'a> IpPoolServiceRangeRemove<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -34933,38 +34420,29 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/ip-pools-service/ranges/remove`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
-                "{}/system/ip-pools-service/ranges/remove",
-                __progenitor_client.baseurl,
-            );
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/system/ip-pools-service/ranges/remove", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -34974,7 +34452,7 @@ pub mod builder {
     ///[`ClientSystemExt::system_metric`]: super::ClientSystemExt::system_metric
     #[derive(Debug, Clone)]
     pub struct SystemMetric<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         metric_name: Result<types::SystemMetricName, String>,
         end_time: Result<Option<chrono::DateTime<chrono::offset::Utc>>, String>,
         id: Result<uuid::Uuid, String>,
@@ -34986,7 +34464,7 @@ pub mod builder {
     impl<'a> SystemMetric<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 metric_name: Err("metric_name was not initialized".to_string()),
                 end_time: Ok(None),
                 id: Err("id was not initialized".to_string()),
@@ -35065,7 +34543,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::MeasurementResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 metric_name,
                 end_time,
                 id,
@@ -35079,48 +34557,45 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let start_time = start_time.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/metrics/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&metric_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(5usize);
+            let mut _query = Vec::with_capacity(5usize);
             if let Some(v) = &end_time {
-                __progenitor_query.push(("end_time", v.to_string()));
+                _query.push(("end_time", v.to_string()));
             }
-            __progenitor_query.push(("id", id.to_string()));
+            _query.push(("id", id.to_string()));
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &start_time {
-                __progenitor_query.push(("start_time", v.to_string()));
+                _query.push(("start_time", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -35130,46 +34605,39 @@ pub mod builder {
     ///[`ClientPolicyExt::system_policy_view`]: super::ClientPolicyExt::system_policy_view
     #[derive(Debug, Clone)]
     pub struct SystemPolicyView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> SystemPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `GET` request to `/system/policy`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url = format!("{}/system/policy", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/system/policy", _client.baseurl,);
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -35179,14 +34647,14 @@ pub mod builder {
     ///[`ClientPolicyExt::system_policy_update`]: super::ClientPolicyExt::system_policy_update
     #[derive(Debug, Clone)]
     pub struct SystemPolicyUpdate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::FleetRolePolicy, String>,
     }
 
     impl<'a> SystemPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::FleetRolePolicy::default()),
             }
         }
@@ -35214,37 +34682,31 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::FleetRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/policy", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/system/policy", _client.baseurl,);
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -35254,7 +34716,7 @@ pub mod builder {
     ///[`ClientSystemExt::saga_list`]: super::ClientSystemExt::saga_list
     #[derive(Debug, Clone)]
     pub struct SagaList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -35263,7 +34725,7 @@ pub mod builder {
     impl<'a> SagaList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -35307,7 +34769,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SagaResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -35315,40 +34777,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/sagas", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/system/sagas", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -35414,14 +34873,14 @@ pub mod builder {
     ///[`ClientSystemExt::saga_view`]: super::ClientSystemExt::saga_view
     #[derive(Debug, Clone)]
     pub struct SagaView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         saga_id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SagaView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 saga_id: Err("saga_id was not initialized".to_string()),
             }
         }
@@ -35438,38 +34897,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/sagas/{saga_id}`
         pub async fn send(self) -> Result<ResponseValue<types::Saga>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                saga_id,
-            } = self;
+            let Self { _client, saga_id } = self;
             let saga_id = saga_id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/sagas/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&saga_id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -35479,7 +34932,7 @@ pub mod builder {
     ///[`ClientSystemExt::silo_list`]: super::ClientSystemExt::silo_list
     #[derive(Debug, Clone)]
     pub struct SiloList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameOrIdSortMode>, String>,
@@ -35488,7 +34941,7 @@ pub mod builder {
     impl<'a> SiloList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -35532,7 +34985,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SiloResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -35540,40 +34993,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/silos", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/system/silos", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -35639,14 +35089,14 @@ pub mod builder {
     ///[`ClientSystemExt::silo_create`]: super::ClientSystemExt::silo_create
     #[derive(Debug, Clone)]
     pub struct SiloCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::SiloCreate, String>,
     }
 
     impl<'a> SiloCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::SiloCreate::default()),
             }
         }
@@ -35672,37 +35122,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/silos`
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SiloCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/silos", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/system/silos", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -35712,14 +35156,14 @@ pub mod builder {
     ///[`ClientSystemExt::silo_view`]: super::ClientSystemExt::silo_view
     #[derive(Debug, Clone)]
     pub struct SiloView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
     }
 
     impl<'a> SiloView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
@@ -35736,38 +35180,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/silos/{silo_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                silo_name,
-            } = self;
+            let Self { _client, silo_name } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/silos/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -35777,14 +35215,14 @@ pub mod builder {
     ///[`ClientSystemExt::silo_delete`]: super::ClientSystemExt::silo_delete
     #[derive(Debug, Clone)]
     pub struct SiloDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
     }
 
     impl<'a> SiloDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
@@ -35801,38 +35239,32 @@ pub mod builder {
 
         ///Sends a `DELETE` request to `/system/silos/{silo_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                silo_name,
-            } = self;
+            let Self { _client, silo_name } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/silos/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -35842,7 +35274,7 @@ pub mod builder {
     ///[`ClientSystemExt::silo_identity_provider_list`]: super::ClientSystemExt::silo_identity_provider_list
     #[derive(Debug, Clone)]
     pub struct SiloIdentityProviderList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -35852,7 +35284,7 @@ pub mod builder {
     impl<'a> SiloIdentityProviderList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -35909,7 +35341,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::IdentityProviderResultsPage>, Error<types::Error>>
         {
             let Self {
-                __progenitor_client,
+                _client,
                 silo_name,
                 limit,
                 page_token,
@@ -35919,44 +35351,41 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/silos/{}/identity-providers",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -36023,7 +35452,7 @@ pub mod builder {
     ///[`ClientSystemExt::local_idp_user_create`]: super::ClientSystemExt::local_idp_user_create
     #[derive(Debug, Clone)]
     pub struct LocalIdpUserCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         body: Result<types::builder::UserCreate, String>,
     }
@@ -36031,7 +35460,7 @@ pub mod builder {
     impl<'a> LocalIdpUserCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(types::builder::UserCreate::default()),
             }
@@ -36070,7 +35499,7 @@ pub mod builder {
         /// `/system/silos/{silo_name}/identity-providers/local/users`
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 silo_name,
                 body,
             } = self;
@@ -36078,34 +35507,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::UserCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/silos/{}/identity-providers/local/users",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -36115,7 +35541,7 @@ pub mod builder {
     ///[`ClientSystemExt::local_idp_user_delete`]: super::ClientSystemExt::local_idp_user_delete
     #[derive(Debug, Clone)]
     pub struct LocalIdpUserDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         user_id: Result<uuid::Uuid, String>,
     }
@@ -36123,7 +35549,7 @@ pub mod builder {
     impl<'a> LocalIdpUserDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 user_id: Err("user_id was not initialized".to_string()),
             }
@@ -36153,40 +35579,37 @@ pub mod builder {
         /// `/system/silos/{silo_name}/identity-providers/local/users/{user_id}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 silo_name,
                 user_id,
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let user_id = user_id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/silos/{}/identity-providers/local/users/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -36196,7 +35619,7 @@ pub mod builder {
     ///[`ClientSystemExt::local_idp_user_set_password`]: super::ClientSystemExt::local_idp_user_set_password
     #[derive(Debug, Clone)]
     pub struct LocalIdpUserSetPassword<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         user_id: Result<uuid::Uuid, String>,
         body: Result<types::UserPassword, String>,
@@ -36205,7 +35628,7 @@ pub mod builder {
     impl<'a> LocalIdpUserSetPassword<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 user_id: Err("user_id was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
@@ -36247,7 +35670,7 @@ pub mod builder {
         /// set-password`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 silo_name,
                 user_id,
                 body,
@@ -36255,35 +35678,32 @@ pub mod builder {
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let user_id = user_id.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/silos/{}/identity-providers/local/users/{}/set-password",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -36293,7 +35713,7 @@ pub mod builder {
     ///[`ClientSystemExt::saml_identity_provider_create`]: super::ClientSystemExt::saml_identity_provider_create
     #[derive(Debug, Clone)]
     pub struct SamlIdentityProviderCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         body: Result<types::builder::SamlIdentityProviderCreate, String>,
     }
@@ -36301,7 +35721,7 @@ pub mod builder {
     impl<'a> SamlIdentityProviderCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(types::builder::SamlIdentityProviderCreate::default()),
             }
@@ -36343,7 +35763,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SamlIdentityProvider>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 silo_name,
                 body,
             } = self;
@@ -36351,34 +35771,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::SamlIdentityProviderCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/silos/{}/identity-providers/saml",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -36388,7 +35805,7 @@ pub mod builder {
     ///[`ClientSystemExt::saml_identity_provider_view`]: super::ClientSystemExt::saml_identity_provider_view
     #[derive(Debug, Clone)]
     pub struct SamlIdentityProviderView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         provider_name: Result<types::Name, String>,
     }
@@ -36396,7 +35813,7 @@ pub mod builder {
     impl<'a> SamlIdentityProviderView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 provider_name: Err("provider_name was not initialized".to_string()),
             }
@@ -36428,40 +35845,37 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SamlIdentityProvider>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 silo_name,
                 provider_name,
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let provider_name = provider_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/silos/{}/identity-providers/saml/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -36471,14 +35885,14 @@ pub mod builder {
     ///[`ClientSystemExt::silo_policy_view`]: super::ClientSystemExt::silo_policy_view
     #[derive(Debug, Clone)]
     pub struct SiloPolicyView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
     }
 
     impl<'a> SiloPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
@@ -36497,38 +35911,32 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                silo_name,
-            } = self;
+            let Self { _client, silo_name } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/silos/{}/policy",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -36538,7 +35946,7 @@ pub mod builder {
     ///[`ClientSystemExt::silo_policy_update`]: super::ClientSystemExt::silo_policy_update
     #[derive(Debug, Clone)]
     pub struct SiloPolicyUpdate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         body: Result<types::builder::SiloRolePolicy, String>,
     }
@@ -36546,7 +35954,7 @@ pub mod builder {
     impl<'a> SiloPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(types::builder::SiloRolePolicy::default()),
             }
@@ -36586,7 +35994,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 silo_name,
                 body,
             } = self;
@@ -36594,34 +36002,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::SiloRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/silos/{}/policy",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -36631,7 +36036,7 @@ pub mod builder {
     ///[`ClientSystemExt::silo_users_list`]: super::ClientSystemExt::silo_users_list
     #[derive(Debug, Clone)]
     pub struct SiloUsersList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -36641,7 +36046,7 @@ pub mod builder {
     impl<'a> SiloUsersList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -36696,7 +36101,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 silo_name,
                 limit,
                 page_token,
@@ -36706,44 +36111,41 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/silos/{}/users/all",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -36809,7 +36211,7 @@ pub mod builder {
     ///[`ClientSystemExt::silo_user_view`]: super::ClientSystemExt::silo_user_view
     #[derive(Debug, Clone)]
     pub struct SiloUserView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         user_id: Result<uuid::Uuid, String>,
     }
@@ -36817,7 +36219,7 @@ pub mod builder {
     impl<'a> SiloUserView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 user_id: Err("user_id was not initialized".to_string()),
             }
@@ -36847,40 +36249,37 @@ pub mod builder {
         /// `/system/silos/{silo_name}/users/id/{user_id}`
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 silo_name,
                 user_id,
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let user_id = user_id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/silos/{}/users/id/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -36890,7 +36289,7 @@ pub mod builder {
     ///[`ClientSystemExt::system_user_list`]: super::ClientSystemExt::system_user_list
     #[derive(Debug, Clone)]
     pub struct SystemUserList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameSortMode>, String>,
@@ -36899,7 +36298,7 @@ pub mod builder {
     impl<'a> SystemUserList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -36943,7 +36342,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::UserBuiltinResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -36951,40 +36350,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/user", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/system/user", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -37050,14 +36446,14 @@ pub mod builder {
     ///[`ClientSystemExt::system_user_view`]: super::ClientSystemExt::system_user_view
     #[derive(Debug, Clone)]
     pub struct SystemUserView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         user_name: Result<types::Name, String>,
     }
 
     impl<'a> SystemUserView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 user_name: Err("user_name was not initialized".to_string()),
             }
         }
@@ -37074,38 +36470,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/user/{user_name}`
         pub async fn send(self) -> Result<ResponseValue<types::UserBuiltin>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                user_name,
-            } = self;
+            let Self { _client, user_name } = self;
             let user_name = user_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/user/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&user_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -37115,7 +36505,7 @@ pub mod builder {
     ///[`ClientMetricsExt::timeseries_schema_get`]: super::ClientMetricsExt::timeseries_schema_get
     #[derive(Debug, Clone)]
     pub struct TimeseriesSchemaGet<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
     }
@@ -37123,7 +36513,7 @@ pub mod builder {
     impl<'a> TimeseriesSchemaGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
             }
@@ -37156,43 +36546,40 @@ pub mod builder {
         ) -> Result<ResponseValue<types::TimeseriesSchemaResultsPage>, Error<types::Error>>
         {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/timeseries/schema", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let _url = format!("{}/timeseries/schema", _client.baseurl,);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -37257,7 +36644,7 @@ pub mod builder {
     ///[`ClientSilosExt::user_list`]: super::ClientSilosExt::user_list
     #[derive(Debug, Clone)]
     pub struct UserList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -37266,7 +36653,7 @@ pub mod builder {
     impl<'a> UserList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -37310,7 +36697,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -37318,40 +36705,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/users", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/users", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -37417,7 +36801,7 @@ pub mod builder {
     ///[`ClientDisksExt::disk_list_v1`]: super::ClientDisksExt::disk_list_v1
     #[derive(Debug, Clone)]
     pub struct DiskListV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         organization: Result<Option<types::NameOrId>, String>,
         page_token: Result<Option<String>, String>,
@@ -37428,7 +36812,7 @@ pub mod builder {
     impl<'a> DiskListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 organization: Ok(None),
                 page_token: Ok(None),
@@ -37496,7 +36880,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 organization,
                 page_token,
@@ -37508,46 +36892,43 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/disks", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(5usize);
+            let _url = format!("{}/v1/disks", _client.baseurl,);
+            let mut _query = Vec::with_capacity(5usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -37615,7 +36996,7 @@ pub mod builder {
     ///[`ClientDisksExt::disk_create_v1`]: super::ClientDisksExt::disk_create_v1
     #[derive(Debug, Clone)]
     pub struct DiskCreateV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<types::NameOrId, String>,
         body: Result<types::builder::DiskCreate, String>,
@@ -37624,7 +37005,7 @@ pub mod builder {
     impl<'a> DiskCreateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization: Ok(None),
                 project: Err("project was not initialized".to_string()),
                 body: Ok(types::builder::DiskCreate::default()),
@@ -37674,7 +37055,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/disks`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization,
                 project,
                 body,
@@ -37684,36 +37065,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/disks", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let _url = format!("{}/v1/disks", _client.baseurl,);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
-            __progenitor_query.push(("project", project.to_string()));
-            let __progenitor_request = __progenitor_client
+            _query.push(("project", project.to_string()));
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -37723,7 +37101,7 @@ pub mod builder {
     ///[`ClientDisksExt::disk_view_v1`]: super::ClientDisksExt::disk_view_v1
     #[derive(Debug, Clone)]
     pub struct DiskViewV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         disk: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -37732,7 +37110,7 @@ pub mod builder {
     impl<'a> DiskViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 disk: Err("disk was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -37774,7 +37152,7 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/disks/{disk}`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 disk,
                 organization,
                 project,
@@ -37782,41 +37160,38 @@ pub mod builder {
             let disk = disk.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/disks/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&disk.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -37826,7 +37201,7 @@ pub mod builder {
     ///[`ClientDisksExt::disk_delete_v1`]: super::ClientDisksExt::disk_delete_v1
     #[derive(Debug, Clone)]
     pub struct DiskDeleteV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         disk: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -37835,7 +37210,7 @@ pub mod builder {
     impl<'a> DiskDeleteV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 disk: Err("disk was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -37877,7 +37252,7 @@ pub mod builder {
         ///Sends a `DELETE` request to `/v1/disks/{disk}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 disk,
                 organization,
                 project,
@@ -37885,41 +37260,38 @@ pub mod builder {
             let disk = disk.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/disks/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&disk.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -37929,7 +37301,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_list_v1`]: super::ClientInstancesExt::instance_list_v1
     #[derive(Debug, Clone)]
     pub struct InstanceListV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         organization: Result<Option<types::NameOrId>, String>,
         page_token: Result<Option<String>, String>,
@@ -37940,7 +37312,7 @@ pub mod builder {
     impl<'a> InstanceListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 organization: Ok(None),
                 page_token: Ok(None),
@@ -38008,7 +37380,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 organization,
                 page_token,
@@ -38020,46 +37392,43 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/instances", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(5usize);
+            let _url = format!("{}/v1/instances", _client.baseurl,);
+            let mut _query = Vec::with_capacity(5usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -38127,7 +37496,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_create_v1`]: super::ClientInstancesExt::instance_create_v1
     #[derive(Debug, Clone)]
     pub struct InstanceCreateV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<types::NameOrId, String>,
         body: Result<types::builder::InstanceCreate, String>,
@@ -38136,7 +37505,7 @@ pub mod builder {
     impl<'a> InstanceCreateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization: Ok(None),
                 project: Err("project was not initialized".to_string()),
                 body: Ok(types::builder::InstanceCreate::default()),
@@ -38186,7 +37555,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization,
                 project,
                 body,
@@ -38196,36 +37565,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/instances", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let _url = format!("{}/v1/instances", _client.baseurl,);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
-            __progenitor_query.push(("project", project.to_string()));
-            let __progenitor_request = __progenitor_client
+            _query.push(("project", project.to_string()));
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -38235,7 +37601,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_view_v1`]: super::ClientInstancesExt::instance_view_v1
     #[derive(Debug, Clone)]
     pub struct InstanceViewV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38244,7 +37610,7 @@ pub mod builder {
     impl<'a> InstanceViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38286,7 +37652,7 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/instances/{instance}`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 instance,
                 organization,
                 project,
@@ -38294,41 +37660,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/instances/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -38338,7 +37701,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_delete_v1`]: super::ClientInstancesExt::instance_delete_v1
     #[derive(Debug, Clone)]
     pub struct InstanceDeleteV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38347,7 +37710,7 @@ pub mod builder {
     impl<'a> InstanceDeleteV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38389,7 +37752,7 @@ pub mod builder {
         ///Sends a `DELETE` request to `/v1/instances/{instance}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 instance,
                 organization,
                 project,
@@ -38397,41 +37760,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/instances/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -38441,7 +37801,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_disk_list_v1`]: super::ClientInstancesExt::instance_disk_list_v1
     #[derive(Debug, Clone)]
     pub struct InstanceDiskListV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         organization: Result<Option<types::NameOrId>, String>,
@@ -38453,7 +37813,7 @@ pub mod builder {
     impl<'a> InstanceDiskListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 instance: Err("instance was not initialized".to_string()),
                 limit: Ok(None),
                 organization: Ok(None),
@@ -38532,7 +37892,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 instance,
                 limit,
                 organization,
@@ -38546,50 +37906,47 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/instances/{}/disks",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(5usize);
+            let mut _query = Vec::with_capacity(5usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -38657,7 +38014,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_disk_attach_v1`]: super::ClientInstancesExt::instance_disk_attach_v1
     #[derive(Debug, Clone)]
     pub struct InstanceDiskAttachV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38667,7 +38024,7 @@ pub mod builder {
     impl<'a> InstanceDiskAttachV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38729,7 +38086,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/disks/attach`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 instance,
                 organization,
                 project,
@@ -38741,42 +38098,39 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskPath>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/instances/{}/disks/attach",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                202u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                202u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -38786,7 +38140,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_disk_detach_v1`]: super::ClientInstancesExt::instance_disk_detach_v1
     #[derive(Debug, Clone)]
     pub struct InstanceDiskDetachV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38796,7 +38150,7 @@ pub mod builder {
     impl<'a> InstanceDiskDetachV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38858,7 +38212,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/disks/detach`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 instance,
                 organization,
                 project,
@@ -38870,42 +38224,39 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskPath>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/instances/{}/disks/detach",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                202u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                202u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -38915,7 +38266,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_migrate_v1`]: super::ClientInstancesExt::instance_migrate_v1
     #[derive(Debug, Clone)]
     pub struct InstanceMigrateV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38925,7 +38276,7 @@ pub mod builder {
     impl<'a> InstanceMigrateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38987,7 +38338,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/migrate`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 instance,
                 organization,
                 project,
@@ -38999,42 +38350,39 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceMigrate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/instances/{}/migrate",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -39044,7 +38392,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_reboot_v1`]: super::ClientInstancesExt::instance_reboot_v1
     #[derive(Debug, Clone)]
     pub struct InstanceRebootV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -39053,7 +38401,7 @@ pub mod builder {
     impl<'a> InstanceRebootV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -39095,7 +38443,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/reboot`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 instance,
                 organization,
                 project,
@@ -39103,41 +38451,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/instances/{}/reboot",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                202u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                202u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -39147,7 +38492,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_serial_console_v1`]: super::ClientInstancesExt::instance_serial_console_v1
     #[derive(Debug, Clone)]
     pub struct InstanceSerialConsoleV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         from_start: Result<Option<u64>, String>,
         max_bytes: Result<Option<u64>, String>,
@@ -39159,7 +38504,7 @@ pub mod builder {
     impl<'a> InstanceSerialConsoleV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 instance: Err("instance was not initialized".to_string()),
                 from_start: Ok(None),
                 max_bytes: Ok(None),
@@ -39239,7 +38584,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceSerialConsoleData>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 instance,
                 from_start,
                 max_bytes,
@@ -39253,50 +38598,47 @@ pub mod builder {
             let most_recent = most_recent.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/instances/{}/serial-console",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(5usize);
+            let mut _query = Vec::with_capacity(5usize);
             if let Some(v) = &from_start {
-                __progenitor_query.push(("from_start", v.to_string()));
+                _query.push(("from_start", v.to_string()));
             }
             if let Some(v) = &max_bytes {
-                __progenitor_query.push(("max_bytes", v.to_string()));
+                _query.push(("max_bytes", v.to_string()));
             }
             if let Some(v) = &most_recent {
-                __progenitor_query.push(("most_recent", v.to_string()));
+                _query.push(("most_recent", v.to_string()));
             }
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -39306,7 +38648,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_serial_console_stream_v1`]: super::ClientInstancesExt::instance_serial_console_stream_v1
     #[derive(Debug, Clone)]
     pub struct InstanceSerialConsoleStreamV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -39315,7 +38657,7 @@ pub mod builder {
     impl<'a> InstanceSerialConsoleStreamV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -39360,7 +38702,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
             let Self {
-                __progenitor_client,
+                _client,
                 instance,
                 organization,
                 project,
@@ -39368,22 +38710,22 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/instances/{}/serial-console/stream",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
-                .query(&__progenitor_query)
+                .get(_url)
+                .query(&_query)
                 .header(reqwest::header::CONNECTION, "Upgrade")
                 .header(reqwest::header::UPGRADE, "websocket")
                 .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -39395,15 +38737,12 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                101u16 => ResponseValue::upgrade(__progenitor_response).await,
-                200..=299 => ResponseValue::upgrade(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                101u16 => ResponseValue::upgrade(_response).await,
+                200..=299 => ResponseValue::upgrade(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -39413,7 +38752,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_start_v1`]: super::ClientInstancesExt::instance_start_v1
     #[derive(Debug, Clone)]
     pub struct InstanceStartV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -39422,7 +38761,7 @@ pub mod builder {
     impl<'a> InstanceStartV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -39464,7 +38803,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/start`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 instance,
                 organization,
                 project,
@@ -39472,41 +38811,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/instances/{}/start",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                202u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                202u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -39516,7 +38852,7 @@ pub mod builder {
     ///[`ClientInstancesExt::instance_stop_v1`]: super::ClientInstancesExt::instance_stop_v1
     #[derive(Debug, Clone)]
     pub struct InstanceStopV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -39525,7 +38861,7 @@ pub mod builder {
     impl<'a> InstanceStopV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -39567,7 +38903,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/stop`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 instance,
                 organization,
                 project,
@@ -39575,41 +38911,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/instances/{}/stop",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                202u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                202u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -39619,7 +38952,7 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_list_v1`]: super::ClientOrganizationsExt::organization_list_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationListV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameOrIdSortMode>, String>,
@@ -39628,7 +38961,7 @@ pub mod builder {
     impl<'a> OrganizationListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -39672,7 +39005,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -39680,40 +39013,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/organizations", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/v1/organizations", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -39779,14 +39109,14 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_create_v1`]: super::ClientOrganizationsExt::organization_create_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationCreateV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::OrganizationCreate, String>,
     }
 
     impl<'a> OrganizationCreateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::OrganizationCreate::default()),
             }
         }
@@ -39814,37 +39144,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/organizations`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/organizations", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/v1/organizations", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -39854,14 +39178,14 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_view_v1`]: super::ClientOrganizationsExt::organization_view_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationViewV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
     }
 
     impl<'a> OrganizationViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization: Err("organization was not initialized".to_string()),
             }
         }
@@ -39879,37 +39203,34 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/organizations/{organization}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization,
             } = self;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/organizations/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -39919,7 +39240,7 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_update_v1`]: super::ClientOrganizationsExt::organization_update_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationUpdateV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
         body: Result<types::builder::OrganizationUpdate, String>,
     }
@@ -39927,7 +39248,7 @@ pub mod builder {
     impl<'a> OrganizationUpdateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization: Err("organization was not initialized".to_string()),
                 body: Ok(types::builder::OrganizationUpdate::default()),
             }
@@ -39967,7 +39288,7 @@ pub mod builder {
         ///Sends a `PUT` request to `/v1/organizations/{organization}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization,
                 body,
             } = self;
@@ -39975,34 +39296,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/organizations/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -40012,14 +39330,14 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_delete_v1`]: super::ClientOrganizationsExt::organization_delete_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationDeleteV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
     }
 
     impl<'a> OrganizationDeleteV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization: Err("organization was not initialized".to_string()),
             }
         }
@@ -40037,37 +39355,34 @@ pub mod builder {
         ///Sends a `DELETE` request to `/v1/organizations/{organization}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization,
             } = self;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/organizations/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -40077,14 +39392,14 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_policy_view_v1`]: super::ClientOrganizationsExt::organization_policy_view_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationPolicyViewV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
     }
 
     impl<'a> OrganizationPolicyViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization: Err("organization was not initialized".to_string()),
             }
         }
@@ -40104,37 +39419,34 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization,
             } = self;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/organizations/{}/policy",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -40144,7 +39456,7 @@ pub mod builder {
     ///[`ClientOrganizationsExt::organization_policy_update_v1`]: super::ClientOrganizationsExt::organization_policy_update_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationPolicyUpdateV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
         body: Result<types::builder::OrganizationRolePolicy, String>,
     }
@@ -40152,7 +39464,7 @@ pub mod builder {
     impl<'a> OrganizationPolicyUpdateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization: Err("organization was not initialized".to_string()),
                 body: Ok(types::builder::OrganizationRolePolicy::default()),
             }
@@ -40194,7 +39506,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization,
                 body,
             } = self;
@@ -40202,34 +39514,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/organizations/{}/policy",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -40239,7 +39548,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_list_v1`]: super::ClientProjectsExt::project_list_v1
     #[derive(Debug, Clone)]
     pub struct ProjectListV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         organization: Result<Option<types::NameOrId>, String>,
         page_token: Result<Option<String>, String>,
@@ -40249,7 +39558,7 @@ pub mod builder {
     impl<'a> ProjectListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 organization: Ok(None),
                 page_token: Ok(None),
@@ -40305,7 +39614,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 organization,
                 page_token,
@@ -40315,43 +39624,40 @@ pub mod builder {
             let organization = organization.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/projects", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(4usize);
+            let _url = format!("{}/v1/projects", _client.baseurl,);
+            let mut _query = Vec::with_capacity(4usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -40418,7 +39724,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_create_v1`]: super::ClientProjectsExt::project_create_v1
     #[derive(Debug, Clone)]
     pub struct ProjectCreateV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
         body: Result<types::builder::ProjectCreate, String>,
     }
@@ -40426,7 +39732,7 @@ pub mod builder {
     impl<'a> ProjectCreateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization: Err("organization was not initialized".to_string()),
                 body: Ok(types::builder::ProjectCreate::default()),
             }
@@ -40464,7 +39770,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/projects`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization,
                 body,
             } = self;
@@ -40472,33 +39778,30 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/projects", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(1usize);
-            __progenitor_query.push(("organization", organization.to_string()));
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/v1/projects", _client.baseurl,);
+            let mut _query = Vec::with_capacity(1usize);
+            _query.push(("organization", organization.to_string()));
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -40508,7 +39811,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_view_v1`]: super::ClientProjectsExt::project_view_v1
     #[derive(Debug, Clone)]
     pub struct ProjectViewV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
     }
@@ -40516,7 +39819,7 @@ pub mod builder {
     impl<'a> ProjectViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
             }
@@ -40546,44 +39849,41 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/projects/{project}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 project,
                 organization,
             } = self;
             let project = project.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/projects/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(1usize);
+            let mut _query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -40593,7 +39893,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_update_v1`]: super::ClientProjectsExt::project_update_v1
     #[derive(Debug, Clone)]
     pub struct ProjectUpdateV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         body: Result<types::builder::ProjectUpdate, String>,
@@ -40602,7 +39902,7 @@ pub mod builder {
     impl<'a> ProjectUpdateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
                 body: Ok(types::builder::ProjectUpdate::default()),
@@ -40652,7 +39952,7 @@ pub mod builder {
         ///Sends a `PUT` request to `/v1/projects/{project}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 project,
                 organization,
                 body,
@@ -40662,39 +39962,36 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/projects/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(1usize);
+            let mut _query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -40704,7 +40001,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_delete_v1`]: super::ClientProjectsExt::project_delete_v1
     #[derive(Debug, Clone)]
     pub struct ProjectDeleteV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
     }
@@ -40712,7 +40009,7 @@ pub mod builder {
     impl<'a> ProjectDeleteV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
             }
@@ -40742,44 +40039,41 @@ pub mod builder {
         ///Sends a `DELETE` request to `/v1/projects/{project}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 project,
                 organization,
             } = self;
             let project = project.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/projects/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(1usize);
+            let mut _query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -40789,7 +40083,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_policy_view_v1`]: super::ClientProjectsExt::project_policy_view_v1
     #[derive(Debug, Clone)]
     pub struct ProjectPolicyViewV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
     }
@@ -40797,7 +40091,7 @@ pub mod builder {
     impl<'a> ProjectPolicyViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
             }
@@ -40829,44 +40123,41 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 project,
                 organization,
             } = self;
             let project = project.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/projects/{}/policy",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(1usize);
+            let mut _query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -40876,7 +40167,7 @@ pub mod builder {
     ///[`ClientProjectsExt::project_policy_update_v1`]: super::ClientProjectsExt::project_policy_update_v1
     #[derive(Debug, Clone)]
     pub struct ProjectPolicyUpdateV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         body: Result<types::builder::ProjectRolePolicy, String>,
@@ -40885,7 +40176,7 @@ pub mod builder {
     impl<'a> ProjectPolicyUpdateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
                 body: Ok(types::builder::ProjectRolePolicy::default()),
@@ -40939,7 +40230,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 project,
                 organization,
                 body,
@@ -40949,39 +40240,36 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/projects/{}/policy",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(1usize);
+            let mut _query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -40991,7 +40279,7 @@ pub mod builder {
     ///[`ClientSystemExt::system_component_version_list`]: super::ClientSystemExt::system_component_version_list
     #[derive(Debug, Clone)]
     pub struct SystemComponentVersionList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -41000,7 +40288,7 @@ pub mod builder {
     impl<'a> SystemComponentVersionList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -41045,7 +40333,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::UpdateableComponentResultsPage>, Error<types::Error>>
         {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -41053,43 +40341,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
-                "{}/v1/system/update/components",
-                __progenitor_client.baseurl,
-            );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/v1/system/update/components", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -41156,7 +40438,7 @@ pub mod builder {
     ///[`ClientSystemExt::update_deployments_list`]: super::ClientSystemExt::update_deployments_list
     #[derive(Debug, Clone)]
     pub struct UpdateDeploymentsList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -41165,7 +40447,7 @@ pub mod builder {
     impl<'a> UpdateDeploymentsList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -41210,7 +40492,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::UpdateDeploymentResultsPage>, Error<types::Error>>
         {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -41218,43 +40500,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
-                "{}/v1/system/update/deployments",
-                __progenitor_client.baseurl,
-            );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/v1/system/update/deployments", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -41320,14 +40596,14 @@ pub mod builder {
     ///[`ClientSystemExt::update_deployment_view`]: super::ClientSystemExt::update_deployment_view
     #[derive(Debug, Clone)]
     pub struct UpdateDeploymentView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> UpdateDeploymentView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -41346,38 +40622,32 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/system/update/deployments/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -41387,45 +40657,37 @@ pub mod builder {
     ///[`ClientSystemExt::system_update_refresh`]: super::ClientSystemExt::system_update_refresh
     #[derive(Debug, Clone)]
     pub struct SystemUpdateRefresh<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> SystemUpdateRefresh<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `POST` request to `/v1/system/update/refresh`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url =
-                format!("{}/v1/system/update/refresh", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/v1/system/update/refresh", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -41435,14 +40697,14 @@ pub mod builder {
     ///[`ClientSystemExt::system_update_start`]: super::ClientSystemExt::system_update_start
     #[derive(Debug, Clone)]
     pub struct SystemUpdateStart<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::SystemUpdateStart, String>,
     }
 
     impl<'a> SystemUpdateStart<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::SystemUpdateStart::default()),
             }
         }
@@ -41472,38 +40734,31 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SystemUpdateStart>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url =
-                format!("{}/v1/system/update/start", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/v1/system/update/start", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                202u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                202u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -41513,45 +40768,37 @@ pub mod builder {
     ///[`ClientSystemExt::system_update_stop`]: super::ClientSystemExt::system_update_stop
     #[derive(Debug, Clone)]
     pub struct SystemUpdateStop<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> SystemUpdateStop<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `POST` request to `/v1/system/update/stop`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url =
-                format!("{}/v1/system/update/stop", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/v1/system/update/stop", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -41561,7 +40808,7 @@ pub mod builder {
     ///[`ClientSystemExt::system_update_list`]: super::ClientSystemExt::system_update_list
     #[derive(Debug, Clone)]
     pub struct SystemUpdateList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -41570,7 +40817,7 @@ pub mod builder {
     impl<'a> SystemUpdateList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -41614,7 +40861,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SystemUpdateResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -41622,41 +40869,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url =
-                format!("{}/v1/system/update/updates", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/v1/system/update/updates", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -41722,14 +40965,14 @@ pub mod builder {
     ///[`ClientSystemExt::system_update_view`]: super::ClientSystemExt::system_update_view
     #[derive(Debug, Clone)]
     pub struct SystemUpdateView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         version: Result<types::SemverVersion, String>,
     }
 
     impl<'a> SystemUpdateView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 version: Err("version was not initialized".to_string()),
             }
         }
@@ -41746,38 +40989,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/v1/system/update/updates/{version}`
         pub async fn send(self) -> Result<ResponseValue<types::SystemUpdate>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                version,
-            } = self;
+            let Self { _client, version } = self;
             let version = version.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/system/update/updates/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&version.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -41787,14 +41024,14 @@ pub mod builder {
     ///[`ClientSystemExt::system_update_components_list`]: super::ClientSystemExt::system_update_components_list
     #[derive(Debug, Clone)]
     pub struct SystemUpdateComponentsList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         version: Result<types::SemverVersion, String>,
     }
 
     impl<'a> SystemUpdateComponentsList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 version: Err("version was not initialized".to_string()),
             }
         }
@@ -41814,38 +41051,32 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::ComponentUpdateResultsPage>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                version,
-            } = self;
+            let Self { _client, version } = self;
             let version = version.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/system/update/updates/{}/components",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&version.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -41855,47 +41086,39 @@ pub mod builder {
     ///[`ClientSystemExt::system_version`]: super::ClientSystemExt::system_version
     #[derive(Debug, Clone)]
     pub struct SystemVersion<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> SystemVersion<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `GET` request to `/v1/system/update/version`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SystemVersion>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url =
-                format!("{}/v1/system/update/version", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/v1/system/update/version", _client.baseurl,);
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/nexus-builder.out
+++ b/progenitor-impl/tests/output/nexus-builder.out
@@ -20827,14 +20827,14 @@ pub mod builder {
     ///[`Client::disk_view_by_id`]: super::Client::disk_view_by_id
     #[derive(Debug, Clone)]
     pub struct DiskViewById<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> DiskViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -20851,32 +20851,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/disks/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/by-id/disks/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -20886,14 +20886,14 @@ pub mod builder {
     ///[`Client::image_view_by_id`]: super::Client::image_view_by_id
     #[derive(Debug, Clone)]
     pub struct ImageViewById<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> ImageViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -20910,32 +20910,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/images/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/by-id/images/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -20945,14 +20945,14 @@ pub mod builder {
     ///[`Client::instance_view_by_id`]: super::Client::instance_view_by_id
     #[derive(Debug, Clone)]
     pub struct InstanceViewById<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> InstanceViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -20969,32 +20969,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/instances/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/by-id/instances/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -21004,14 +21004,14 @@ pub mod builder {
     ///[`Client::instance_network_interface_view_by_id`]: super::Client::instance_network_interface_view_by_id
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceViewById<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> InstanceNetworkInterfaceViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21030,32 +21030,32 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/by-id/network-interfaces/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -21065,14 +21065,14 @@ pub mod builder {
     ///[`Client::organization_view_by_id`]: super::Client::organization_view_by_id
     #[derive(Debug, Clone)]
     pub struct OrganizationViewById<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> OrganizationViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21089,32 +21089,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/organizations/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/by-id/organizations/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -21124,14 +21124,14 @@ pub mod builder {
     ///[`Client::project_view_by_id`]: super::Client::project_view_by_id
     #[derive(Debug, Clone)]
     pub struct ProjectViewById<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> ProjectViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21148,32 +21148,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/projects/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/by-id/projects/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -21183,14 +21183,14 @@ pub mod builder {
     ///[`Client::snapshot_view_by_id`]: super::Client::snapshot_view_by_id
     #[derive(Debug, Clone)]
     pub struct SnapshotViewById<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SnapshotViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21207,32 +21207,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/snapshots/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/by-id/snapshots/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -21242,14 +21242,14 @@ pub mod builder {
     ///[`Client::vpc_router_route_view_by_id`]: super::Client::vpc_router_route_view_by_id
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteViewById<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcRouterRouteViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21266,32 +21266,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/vpc-router-routes/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/by-id/vpc-router-routes/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -21301,14 +21301,14 @@ pub mod builder {
     ///[`Client::vpc_router_view_by_id`]: super::Client::vpc_router_view_by_id
     #[derive(Debug, Clone)]
     pub struct VpcRouterViewById<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcRouterViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21325,32 +21325,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/vpc-routers/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/by-id/vpc-routers/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -21360,14 +21360,14 @@ pub mod builder {
     ///[`Client::vpc_subnet_view_by_id`]: super::Client::vpc_subnet_view_by_id
     #[derive(Debug, Clone)]
     pub struct VpcSubnetViewById<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcSubnetViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21384,32 +21384,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/vpc-subnets/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/by-id/vpc-subnets/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -21419,14 +21419,14 @@ pub mod builder {
     ///[`Client::vpc_view_by_id`]: super::Client::vpc_view_by_id
     #[derive(Debug, Clone)]
     pub struct VpcViewById<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21443,32 +21443,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/vpcs/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/by-id/vpcs/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -21478,14 +21478,14 @@ pub mod builder {
     ///[`Client::device_auth_request`]: super::Client::device_auth_request
     #[derive(Debug, Clone)]
     pub struct DeviceAuthRequest<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::DeviceAuthRequest, String>,
     }
 
     impl<'a> DeviceAuthRequest<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::DeviceAuthRequest::default()),
             }
         }
@@ -21513,17 +21513,17 @@ pub mod builder {
 
         ///Sends a `POST` request to `/device/auth`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::DeviceAuthRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/device/auth", _client.baseurl,);
-            let _request = _client.client.post(_url).form_urlencoded(&body)?.build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(_response)),
-                _ => Err(Error::ErrorResponse(ResponseValue::stream(_response))),
+            let url = format!("{}/device/auth", client.baseurl,);
+            let request = client.client.post(url).form_urlencoded(&body)?.build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(response)),
+                _ => Err(Error::ErrorResponse(ResponseValue::stream(response))),
             }
         }
     }
@@ -21533,14 +21533,14 @@ pub mod builder {
     ///[`Client::device_auth_confirm`]: super::Client::device_auth_confirm
     #[derive(Debug, Clone)]
     pub struct DeviceAuthConfirm<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::DeviceAuthVerify, String>,
     }
 
     impl<'a> DeviceAuthConfirm<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::DeviceAuthVerify::default()),
             }
         }
@@ -21568,31 +21568,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/device/confirm`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::DeviceAuthVerify>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/device/confirm", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/device/confirm", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -21602,14 +21602,14 @@ pub mod builder {
     ///[`Client::device_access_token`]: super::Client::device_access_token
     #[derive(Debug, Clone)]
     pub struct DeviceAccessToken<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::DeviceAccessTokenRequest, String>,
     }
 
     impl<'a> DeviceAccessToken<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::DeviceAccessTokenRequest::default()),
             }
         }
@@ -21636,17 +21636,17 @@ pub mod builder {
 
         ///Sends a `POST` request to `/device/token`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::DeviceAccessTokenRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/device/token", _client.baseurl,);
-            let _request = _client.client.post(_url).form_urlencoded(&body)?.build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(_response)),
-                _ => Err(Error::ErrorResponse(ResponseValue::stream(_response))),
+            let url = format!("{}/device/token", client.baseurl,);
+            let request = client.client.post(url).form_urlencoded(&body)?.build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(response)),
+                _ => Err(Error::ErrorResponse(ResponseValue::stream(response))),
             }
         }
     }
@@ -21656,7 +21656,7 @@ pub mod builder {
     ///[`Client::group_list`]: super::Client::group_list
     #[derive(Debug, Clone)]
     pub struct GroupList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -21665,7 +21665,7 @@ pub mod builder {
     impl<'a> GroupList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -21709,7 +21709,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -21717,37 +21717,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/groups", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/groups", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -21813,14 +21813,14 @@ pub mod builder {
     ///[`Client::login_spoof`]: super::Client::login_spoof
     #[derive(Debug, Clone)]
     pub struct LoginSpoof<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::SpoofLoginBody, String>,
     }
 
     impl<'a> LoginSpoof<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::SpoofLoginBody::default()),
             }
         }
@@ -21846,31 +21846,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/login`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SpoofLoginBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/login", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/login", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -21880,7 +21880,7 @@ pub mod builder {
     ///[`Client::login_local`]: super::Client::login_local
     #[derive(Debug, Clone)]
     pub struct LoginLocal<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         body: Result<types::builder::UsernamePasswordCredentials, String>,
     }
@@ -21888,7 +21888,7 @@ pub mod builder {
     impl<'a> LoginLocal<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(types::builder::UsernamePasswordCredentials::default()),
             }
@@ -21927,7 +21927,7 @@ pub mod builder {
         ///Sends a `POST` request to `/login/{silo_name}/local`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 silo_name,
                 body,
             } = self;
@@ -21935,23 +21935,23 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::UsernamePasswordCredentials>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/login/{}/local",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let _request = _client.client.post(_url).json(&body).build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(_response)),
+            let request = client.client.post(url).json(&body).build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -21961,7 +21961,7 @@ pub mod builder {
     ///[`Client::login_saml_begin`]: super::Client::login_saml_begin
     #[derive(Debug, Clone)]
     pub struct LoginSamlBegin<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         provider_name: Result<types::Name, String>,
     }
@@ -21969,7 +21969,7 @@ pub mod builder {
     impl<'a> LoginSamlBegin<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 provider_name: Err("provider_name was not initialized".to_string()),
             }
@@ -21998,30 +21998,30 @@ pub mod builder {
         ///Sends a `GET` request to `/login/{silo_name}/saml/{provider_name}`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 silo_name,
                 provider_name,
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let provider_name = provider_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/login/{}/saml/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let _request = _client.client.get(_url).build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(_response)),
+            let request = client.client.get(url).build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -22031,7 +22031,7 @@ pub mod builder {
     ///[`Client::login_saml`]: super::Client::login_saml
     #[derive(Debug)]
     pub struct LoginSaml<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         provider_name: Result<types::Name, String>,
         body: Result<reqwest::Body, String>,
@@ -22040,7 +22040,7 @@ pub mod builder {
     impl<'a> LoginSaml<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 provider_name: Err("provider_name was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
@@ -22080,7 +22080,7 @@ pub mod builder {
         ///Sends a `POST` request to `/login/{silo_name}/saml/{provider_name}`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 silo_name,
                 provider_name,
                 body,
@@ -22088,32 +22088,32 @@ pub mod builder {
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let provider_name = provider_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/login/{}/saml/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::CONTENT_TYPE,
                     reqwest::header::HeaderValue::from_static("application/octet-stream"),
                 )
                 .body(body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -22123,37 +22123,37 @@ pub mod builder {
     ///[`Client::logout`]: super::Client::logout
     #[derive(Debug, Clone)]
     pub struct Logout<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> Logout<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `POST` request to `/logout`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { _client } = self;
-            let _url = format!("{}/logout", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/logout", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -22163,7 +22163,7 @@ pub mod builder {
     ///[`Client::organization_list`]: super::Client::organization_list
     #[derive(Debug, Clone)]
     pub struct OrganizationList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameOrIdSortMode>, String>,
@@ -22172,7 +22172,7 @@ pub mod builder {
     impl<'a> OrganizationList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -22216,7 +22216,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -22224,37 +22224,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/organizations", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/organizations", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -22320,14 +22320,14 @@ pub mod builder {
     ///[`Client::organization_create`]: super::Client::organization_create
     #[derive(Debug, Clone)]
     pub struct OrganizationCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::OrganizationCreate, String>,
     }
 
     impl<'a> OrganizationCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::OrganizationCreate::default()),
             }
         }
@@ -22355,31 +22355,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/organizations`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/organizations", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/organizations", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -22389,14 +22389,14 @@ pub mod builder {
     ///[`Client::organization_view`]: super::Client::organization_view
     #[derive(Debug, Clone)]
     pub struct OrganizationView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
     }
 
     impl<'a> OrganizationView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
@@ -22414,34 +22414,34 @@ pub mod builder {
         ///Sends a `GET` request to `/organizations/{organization_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -22451,7 +22451,7 @@ pub mod builder {
     ///[`Client::organization_update`]: super::Client::organization_update
     #[derive(Debug, Clone)]
     pub struct OrganizationUpdate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         body: Result<types::builder::OrganizationUpdate, String>,
     }
@@ -22459,7 +22459,7 @@ pub mod builder {
     impl<'a> OrganizationUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 body: Ok(types::builder::OrganizationUpdate::default()),
             }
@@ -22499,7 +22499,7 @@ pub mod builder {
         ///Sends a `PUT` request to `/organizations/{organization_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 body,
             } = self;
@@ -22507,31 +22507,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -22541,14 +22541,14 @@ pub mod builder {
     ///[`Client::organization_delete`]: super::Client::organization_delete
     #[derive(Debug, Clone)]
     pub struct OrganizationDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
     }
 
     impl<'a> OrganizationDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
@@ -22566,34 +22566,34 @@ pub mod builder {
         ///Sends a `DELETE` request to `/organizations/{organization_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -22603,14 +22603,14 @@ pub mod builder {
     ///[`Client::organization_policy_view`]: super::Client::organization_policy_view
     #[derive(Debug, Clone)]
     pub struct OrganizationPolicyView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
     }
 
     impl<'a> OrganizationPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
@@ -22630,34 +22630,34 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/policy",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -22667,7 +22667,7 @@ pub mod builder {
     ///[`Client::organization_policy_update`]: super::Client::organization_policy_update
     #[derive(Debug, Clone)]
     pub struct OrganizationPolicyUpdate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         body: Result<types::builder::OrganizationRolePolicy, String>,
     }
@@ -22675,7 +22675,7 @@ pub mod builder {
     impl<'a> OrganizationPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 body: Ok(types::builder::OrganizationRolePolicy::default()),
             }
@@ -22717,7 +22717,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 body,
             } = self;
@@ -22725,31 +22725,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/policy",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -22759,7 +22759,7 @@ pub mod builder {
     ///[`Client::project_list`]: super::Client::project_list
     #[derive(Debug, Clone)]
     pub struct ProjectList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -22769,7 +22769,7 @@ pub mod builder {
     impl<'a> ProjectList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -22825,7 +22825,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 limit,
                 page_token,
@@ -22835,41 +22835,41 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -22936,7 +22936,7 @@ pub mod builder {
     ///[`Client::project_create`]: super::Client::project_create
     #[derive(Debug, Clone)]
     pub struct ProjectCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         body: Result<types::builder::ProjectCreate, String>,
     }
@@ -22944,7 +22944,7 @@ pub mod builder {
     impl<'a> ProjectCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 body: Ok(types::builder::ProjectCreate::default()),
             }
@@ -22983,7 +22983,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 body,
             } = self;
@@ -22991,31 +22991,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -23025,7 +23025,7 @@ pub mod builder {
     ///[`Client::project_view`]: super::Client::project_view
     #[derive(Debug, Clone)]
     pub struct ProjectView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
     }
@@ -23033,7 +23033,7 @@ pub mod builder {
     impl<'a> ProjectView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
             }
@@ -23063,37 +23063,37 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -23103,7 +23103,7 @@ pub mod builder {
     ///[`Client::project_update`]: super::Client::project_update
     #[derive(Debug, Clone)]
     pub struct ProjectUpdate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::ProjectUpdate, String>,
@@ -23112,7 +23112,7 @@ pub mod builder {
     impl<'a> ProjectUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::ProjectUpdate::default()),
@@ -23162,7 +23162,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 body,
@@ -23172,32 +23172,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -23207,7 +23207,7 @@ pub mod builder {
     ///[`Client::project_delete`]: super::Client::project_delete
     #[derive(Debug, Clone)]
     pub struct ProjectDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
     }
@@ -23215,7 +23215,7 @@ pub mod builder {
     impl<'a> ProjectDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
             }
@@ -23245,37 +23245,37 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -23285,7 +23285,7 @@ pub mod builder {
     ///[`Client::disk_list`]: super::Client::disk_list
     #[derive(Debug, Clone)]
     pub struct DiskList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -23296,7 +23296,7 @@ pub mod builder {
     impl<'a> DiskList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -23363,7 +23363,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 limit,
@@ -23375,42 +23375,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/disks",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -23477,7 +23477,7 @@ pub mod builder {
     ///[`Client::disk_create`]: super::Client::disk_create
     #[derive(Debug, Clone)]
     pub struct DiskCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::DiskCreate, String>,
@@ -23486,7 +23486,7 @@ pub mod builder {
     impl<'a> DiskCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::DiskCreate::default()),
@@ -23536,7 +23536,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}/disks`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 body,
@@ -23546,32 +23546,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/disks",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -23581,7 +23581,7 @@ pub mod builder {
     ///[`Client::disk_view`]: super::Client::disk_view
     #[derive(Debug, Clone)]
     pub struct DiskView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         disk_name: Result<types::Name, String>,
@@ -23590,7 +23590,7 @@ pub mod builder {
     impl<'a> DiskView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 disk_name: Err("disk_name was not initialized".to_string()),
@@ -23632,7 +23632,7 @@ pub mod builder {
         /// {disk_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 disk_name,
@@ -23640,32 +23640,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let disk_name = disk_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/disks/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -23675,7 +23675,7 @@ pub mod builder {
     ///[`Client::disk_delete`]: super::Client::disk_delete
     #[derive(Debug, Clone)]
     pub struct DiskDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         disk_name: Result<types::Name, String>,
@@ -23684,7 +23684,7 @@ pub mod builder {
     impl<'a> DiskDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 disk_name: Err("disk_name was not initialized".to_string()),
@@ -23726,7 +23726,7 @@ pub mod builder {
         /// {disk_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 disk_name,
@@ -23734,32 +23734,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let disk_name = disk_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/disks/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -23769,7 +23769,7 @@ pub mod builder {
     ///[`Client::disk_metrics_list`]: super::Client::disk_metrics_list
     #[derive(Debug, Clone)]
     pub struct DiskMetricsList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         disk_name: Result<types::Name, String>,
@@ -23783,7 +23783,7 @@ pub mod builder {
     impl<'a> DiskMetricsList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 disk_name: Err("disk_name was not initialized".to_string()),
@@ -23886,7 +23886,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::MeasurementResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 disk_name,
@@ -23904,47 +23904,47 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let start_time = start_time.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/disks/{}/metrics/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
                 encode_path(&metric_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(4usize);
+            let mut query = Vec::with_capacity(4usize);
             if let Some(v) = &end_time {
-                _query.push(("end_time", v.to_string()));
+                query.push(("end_time", v.to_string()));
             }
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &start_time {
-                _query.push(("start_time", v.to_string()));
+                query.push(("start_time", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -24013,7 +24013,7 @@ pub mod builder {
     ///[`Client::image_list`]: super::Client::image_list
     #[derive(Debug, Clone)]
     pub struct ImageList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -24024,7 +24024,7 @@ pub mod builder {
     impl<'a> ImageList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -24091,7 +24091,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ImageResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 limit,
@@ -24103,42 +24103,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/images",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -24205,7 +24205,7 @@ pub mod builder {
     ///[`Client::image_create`]: super::Client::image_create
     #[derive(Debug, Clone)]
     pub struct ImageCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::ImageCreate, String>,
@@ -24214,7 +24214,7 @@ pub mod builder {
     impl<'a> ImageCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::ImageCreate::default()),
@@ -24264,7 +24264,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}/images`
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 body,
@@ -24274,32 +24274,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ImageCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/images",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -24309,7 +24309,7 @@ pub mod builder {
     ///[`Client::image_view`]: super::Client::image_view
     #[derive(Debug, Clone)]
     pub struct ImageView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         image_name: Result<types::Name, String>,
@@ -24318,7 +24318,7 @@ pub mod builder {
     impl<'a> ImageView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 image_name: Err("image_name was not initialized".to_string()),
@@ -24360,7 +24360,7 @@ pub mod builder {
         /// {image_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 image_name,
@@ -24368,32 +24368,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/images/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -24403,7 +24403,7 @@ pub mod builder {
     ///[`Client::image_delete`]: super::Client::image_delete
     #[derive(Debug, Clone)]
     pub struct ImageDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         image_name: Result<types::Name, String>,
@@ -24412,7 +24412,7 @@ pub mod builder {
     impl<'a> ImageDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 image_name: Err("image_name was not initialized".to_string()),
@@ -24454,7 +24454,7 @@ pub mod builder {
         /// {image_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 image_name,
@@ -24462,32 +24462,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/images/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -24497,7 +24497,7 @@ pub mod builder {
     ///[`Client::instance_list`]: super::Client::instance_list
     #[derive(Debug, Clone)]
     pub struct InstanceList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -24508,7 +24508,7 @@ pub mod builder {
     impl<'a> InstanceList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -24576,7 +24576,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 limit,
@@ -24588,42 +24588,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -24691,7 +24691,7 @@ pub mod builder {
     ///[`Client::instance_create`]: super::Client::instance_create
     #[derive(Debug, Clone)]
     pub struct InstanceCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::InstanceCreate, String>,
@@ -24700,7 +24700,7 @@ pub mod builder {
     impl<'a> InstanceCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::InstanceCreate::default()),
@@ -24751,7 +24751,7 @@ pub mod builder {
         /// instances`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 body,
@@ -24761,32 +24761,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -24796,7 +24796,7 @@ pub mod builder {
     ///[`Client::instance_view`]: super::Client::instance_view
     #[derive(Debug, Clone)]
     pub struct InstanceView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -24805,7 +24805,7 @@ pub mod builder {
     impl<'a> InstanceView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -24847,7 +24847,7 @@ pub mod builder {
         /// instances/{instance_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -24855,32 +24855,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -24890,7 +24890,7 @@ pub mod builder {
     ///[`Client::instance_delete`]: super::Client::instance_delete
     #[derive(Debug, Clone)]
     pub struct InstanceDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -24899,7 +24899,7 @@ pub mod builder {
     impl<'a> InstanceDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -24941,7 +24941,7 @@ pub mod builder {
         /// instances/{instance_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -24949,32 +24949,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -24984,7 +24984,7 @@ pub mod builder {
     ///[`Client::instance_disk_list`]: super::Client::instance_disk_list
     #[derive(Debug, Clone)]
     pub struct InstanceDiskList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -24996,7 +24996,7 @@ pub mod builder {
     impl<'a> InstanceDiskList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25075,7 +25075,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25089,43 +25089,43 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -25193,7 +25193,7 @@ pub mod builder {
     ///[`Client::instance_disk_attach`]: super::Client::instance_disk_attach
     #[derive(Debug, Clone)]
     pub struct InstanceDiskAttach<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25203,7 +25203,7 @@ pub mod builder {
     impl<'a> InstanceDiskAttach<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25265,7 +25265,7 @@ pub mod builder {
         /// instances/{instance_name}/disks/attach`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25277,33 +25277,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskIdentifier>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks/attach",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                202u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                202u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -25313,7 +25313,7 @@ pub mod builder {
     ///[`Client::instance_disk_detach`]: super::Client::instance_disk_detach
     #[derive(Debug, Clone)]
     pub struct InstanceDiskDetach<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25323,7 +25323,7 @@ pub mod builder {
     impl<'a> InstanceDiskDetach<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25385,7 +25385,7 @@ pub mod builder {
         /// instances/{instance_name}/disks/detach`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25397,33 +25397,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskIdentifier>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks/detach",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                202u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                202u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -25433,7 +25433,7 @@ pub mod builder {
     ///[`Client::instance_external_ip_list`]: super::Client::instance_external_ip_list
     #[derive(Debug, Clone)]
     pub struct InstanceExternalIpList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25442,7 +25442,7 @@ pub mod builder {
     impl<'a> InstanceExternalIpList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25486,7 +25486,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ExternalIpResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25494,32 +25494,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/external-ips",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -25529,7 +25529,7 @@ pub mod builder {
     ///[`Client::instance_migrate`]: super::Client::instance_migrate
     #[derive(Debug, Clone)]
     pub struct InstanceMigrate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25539,7 +25539,7 @@ pub mod builder {
     impl<'a> InstanceMigrate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25601,7 +25601,7 @@ pub mod builder {
         /// instances/{instance_name}/migrate`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25613,33 +25613,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceMigrate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/migrate",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -25649,7 +25649,7 @@ pub mod builder {
     ///[`Client::instance_network_interface_list`]: super::Client::instance_network_interface_list
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25661,7 +25661,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25741,7 +25741,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::NetworkInterfaceResultsPage>, Error<types::Error>>
         {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25755,43 +25755,43 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -25859,7 +25859,7 @@ pub mod builder {
     ///[`Client::instance_network_interface_create`]: super::Client::instance_network_interface_create
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25869,7 +25869,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25935,7 +25935,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25947,33 +25947,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::NetworkInterfaceCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -25983,7 +25983,7 @@ pub mod builder {
     ///[`Client::instance_network_interface_view`]: super::Client::instance_network_interface_view
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25993,7 +25993,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26048,7 +26048,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26058,33 +26058,33 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let interface_name = interface_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -26094,7 +26094,7 @@ pub mod builder {
     ///[`Client::instance_network_interface_update`]: super::Client::instance_network_interface_update
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceUpdate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26105,7 +26105,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26182,7 +26182,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26196,34 +26196,34 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::NetworkInterfaceUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -26233,7 +26233,7 @@ pub mod builder {
     ///[`Client::instance_network_interface_delete`]: super::Client::instance_network_interface_delete
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26243,7 +26243,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26296,7 +26296,7 @@ pub mod builder {
         /// instances/{instance_name}/network-interfaces/{interface_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26306,33 +26306,33 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let interface_name = interface_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -26342,7 +26342,7 @@ pub mod builder {
     ///[`Client::instance_reboot`]: super::Client::instance_reboot
     #[derive(Debug, Clone)]
     pub struct InstanceReboot<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26351,7 +26351,7 @@ pub mod builder {
     impl<'a> InstanceReboot<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26393,7 +26393,7 @@ pub mod builder {
         /// instances/{instance_name}/reboot`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26401,32 +26401,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/reboot",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                202u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                202u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -26436,7 +26436,7 @@ pub mod builder {
     ///[`Client::instance_serial_console`]: super::Client::instance_serial_console
     #[derive(Debug, Clone)]
     pub struct InstanceSerialConsole<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26448,7 +26448,7 @@ pub mod builder {
     impl<'a> InstanceSerialConsole<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26528,7 +26528,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceSerialConsoleData>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26542,43 +26542,43 @@ pub mod builder {
             let from_start = from_start.map_err(Error::InvalidRequest)?;
             let max_bytes = max_bytes.map_err(Error::InvalidRequest)?;
             let most_recent = most_recent.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/serial-console",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &from_start {
-                _query.push(("from_start", v.to_string()));
+                query.push(("from_start", v.to_string()));
             }
             if let Some(v) = &max_bytes {
-                _query.push(("max_bytes", v.to_string()));
+                query.push(("max_bytes", v.to_string()));
             }
             if let Some(v) = &most_recent {
-                _query.push(("most_recent", v.to_string()));
+                query.push(("most_recent", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -26588,7 +26588,7 @@ pub mod builder {
     ///[`Client::instance_serial_console_stream`]: super::Client::instance_serial_console_stream
     #[derive(Debug, Clone)]
     pub struct InstanceSerialConsoleStream<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26597,7 +26597,7 @@ pub mod builder {
     impl<'a> InstanceSerialConsoleStream<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26641,7 +26641,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26649,16 +26649,16 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/serial-console/stream",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(reqwest::header::CONNECTION, "Upgrade")
                 .header(reqwest::header::UPGRADE, "websocket")
                 .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -26670,12 +26670,12 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                101u16 => ResponseValue::upgrade(_response).await,
-                200..=299 => ResponseValue::upgrade(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                101u16 => ResponseValue::upgrade(response).await,
+                200..=299 => ResponseValue::upgrade(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -26685,7 +26685,7 @@ pub mod builder {
     ///[`Client::instance_start`]: super::Client::instance_start
     #[derive(Debug, Clone)]
     pub struct InstanceStart<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26694,7 +26694,7 @@ pub mod builder {
     impl<'a> InstanceStart<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26736,7 +26736,7 @@ pub mod builder {
         /// instances/{instance_name}/start`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26744,32 +26744,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/start",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                202u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                202u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -26779,7 +26779,7 @@ pub mod builder {
     ///[`Client::instance_stop`]: super::Client::instance_stop
     #[derive(Debug, Clone)]
     pub struct InstanceStop<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26788,7 +26788,7 @@ pub mod builder {
     impl<'a> InstanceStop<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26830,7 +26830,7 @@ pub mod builder {
         /// instances/{instance_name}/stop`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26838,32 +26838,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/stop",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                202u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                202u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -26873,7 +26873,7 @@ pub mod builder {
     ///[`Client::project_policy_view`]: super::Client::project_policy_view
     #[derive(Debug, Clone)]
     pub struct ProjectPolicyView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
     }
@@ -26881,7 +26881,7 @@ pub mod builder {
     impl<'a> ProjectPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
             }
@@ -26913,37 +26913,37 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/policy",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -26953,7 +26953,7 @@ pub mod builder {
     ///[`Client::project_policy_update`]: super::Client::project_policy_update
     #[derive(Debug, Clone)]
     pub struct ProjectPolicyUpdate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::ProjectRolePolicy, String>,
@@ -26962,7 +26962,7 @@ pub mod builder {
     impl<'a> ProjectPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::ProjectRolePolicy::default()),
@@ -27016,7 +27016,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 body,
@@ -27026,32 +27026,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/policy",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -27061,7 +27061,7 @@ pub mod builder {
     ///[`Client::snapshot_list`]: super::Client::snapshot_list
     #[derive(Debug, Clone)]
     pub struct SnapshotList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -27072,7 +27072,7 @@ pub mod builder {
     impl<'a> SnapshotList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -27140,7 +27140,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SnapshotResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 limit,
@@ -27152,42 +27152,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/snapshots",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -27255,7 +27255,7 @@ pub mod builder {
     ///[`Client::snapshot_create`]: super::Client::snapshot_create
     #[derive(Debug, Clone)]
     pub struct SnapshotCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::SnapshotCreate, String>,
@@ -27264,7 +27264,7 @@ pub mod builder {
     impl<'a> SnapshotCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::SnapshotCreate::default()),
@@ -27315,7 +27315,7 @@ pub mod builder {
         /// snapshots`
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 body,
@@ -27325,32 +27325,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::SnapshotCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/snapshots",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -27360,7 +27360,7 @@ pub mod builder {
     ///[`Client::snapshot_view`]: super::Client::snapshot_view
     #[derive(Debug, Clone)]
     pub struct SnapshotView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         snapshot_name: Result<types::Name, String>,
@@ -27369,7 +27369,7 @@ pub mod builder {
     impl<'a> SnapshotView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 snapshot_name: Err("snapshot_name was not initialized".to_string()),
@@ -27411,7 +27411,7 @@ pub mod builder {
         /// snapshots/{snapshot_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 snapshot_name,
@@ -27419,32 +27419,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let snapshot_name = snapshot_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/snapshots/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -27454,7 +27454,7 @@ pub mod builder {
     ///[`Client::snapshot_delete`]: super::Client::snapshot_delete
     #[derive(Debug, Clone)]
     pub struct SnapshotDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         snapshot_name: Result<types::Name, String>,
@@ -27463,7 +27463,7 @@ pub mod builder {
     impl<'a> SnapshotDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 snapshot_name: Err("snapshot_name was not initialized".to_string()),
@@ -27505,7 +27505,7 @@ pub mod builder {
         /// snapshots/{snapshot_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 snapshot_name,
@@ -27513,32 +27513,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let snapshot_name = snapshot_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/snapshots/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -27548,7 +27548,7 @@ pub mod builder {
     ///[`Client::vpc_list`]: super::Client::vpc_list
     #[derive(Debug, Clone)]
     pub struct VpcList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -27559,7 +27559,7 @@ pub mod builder {
     impl<'a> VpcList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -27626,7 +27626,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 limit,
@@ -27638,42 +27638,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -27740,7 +27740,7 @@ pub mod builder {
     ///[`Client::vpc_create`]: super::Client::vpc_create
     #[derive(Debug, Clone)]
     pub struct VpcCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::VpcCreate, String>,
@@ -27749,7 +27749,7 @@ pub mod builder {
     impl<'a> VpcCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::VpcCreate::default()),
@@ -27799,7 +27799,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs`
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 body,
@@ -27809,32 +27809,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -27844,7 +27844,7 @@ pub mod builder {
     ///[`Client::vpc_view`]: super::Client::vpc_view
     #[derive(Debug, Clone)]
     pub struct VpcView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -27853,7 +27853,7 @@ pub mod builder {
     impl<'a> VpcView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -27895,7 +27895,7 @@ pub mod builder {
         /// {vpc_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -27903,32 +27903,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -27938,7 +27938,7 @@ pub mod builder {
     ///[`Client::vpc_update`]: super::Client::vpc_update
     #[derive(Debug, Clone)]
     pub struct VpcUpdate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -27948,7 +27948,7 @@ pub mod builder {
     impl<'a> VpcUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28010,7 +28010,7 @@ pub mod builder {
         /// {vpc_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28022,33 +28022,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -28058,7 +28058,7 @@ pub mod builder {
     ///[`Client::vpc_delete`]: super::Client::vpc_delete
     #[derive(Debug, Clone)]
     pub struct VpcDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28067,7 +28067,7 @@ pub mod builder {
     impl<'a> VpcDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28109,7 +28109,7 @@ pub mod builder {
         /// {vpc_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28117,32 +28117,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -28152,7 +28152,7 @@ pub mod builder {
     ///[`Client::vpc_firewall_rules_view`]: super::Client::vpc_firewall_rules_view
     #[derive(Debug, Clone)]
     pub struct VpcFirewallRulesView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28161,7 +28161,7 @@ pub mod builder {
     impl<'a> VpcFirewallRulesView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28205,7 +28205,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcFirewallRules>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28213,32 +28213,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -28248,7 +28248,7 @@ pub mod builder {
     ///[`Client::vpc_firewall_rules_update`]: super::Client::vpc_firewall_rules_update
     #[derive(Debug, Clone)]
     pub struct VpcFirewallRulesUpdate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28258,7 +28258,7 @@ pub mod builder {
     impl<'a> VpcFirewallRulesUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28323,7 +28323,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcFirewallRules>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28335,33 +28335,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcFirewallRuleUpdateParams>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -28371,7 +28371,7 @@ pub mod builder {
     ///[`Client::vpc_router_list`]: super::Client::vpc_router_list
     #[derive(Debug, Clone)]
     pub struct VpcRouterList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28383,7 +28383,7 @@ pub mod builder {
     impl<'a> VpcRouterList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28462,7 +28462,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcRouterResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28476,43 +28476,43 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -28580,7 +28580,7 @@ pub mod builder {
     ///[`Client::vpc_router_create`]: super::Client::vpc_router_create
     #[derive(Debug, Clone)]
     pub struct VpcRouterCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28590,7 +28590,7 @@ pub mod builder {
     impl<'a> VpcRouterCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28652,7 +28652,7 @@ pub mod builder {
         /// {vpc_name}/routers`
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28664,33 +28664,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcRouterCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -28700,7 +28700,7 @@ pub mod builder {
     ///[`Client::vpc_router_view`]: super::Client::vpc_router_view
     #[derive(Debug, Clone)]
     pub struct VpcRouterView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28710,7 +28710,7 @@ pub mod builder {
     impl<'a> VpcRouterView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28763,7 +28763,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28773,33 +28773,33 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -28809,7 +28809,7 @@ pub mod builder {
     ///[`Client::vpc_router_update`]: super::Client::vpc_router_update
     #[derive(Debug, Clone)]
     pub struct VpcRouterUpdate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28820,7 +28820,7 @@ pub mod builder {
     impl<'a> VpcRouterUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28893,7 +28893,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28907,34 +28907,34 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcRouterUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -28944,7 +28944,7 @@ pub mod builder {
     ///[`Client::vpc_router_delete`]: super::Client::vpc_router_delete
     #[derive(Debug, Clone)]
     pub struct VpcRouterDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28954,7 +28954,7 @@ pub mod builder {
     impl<'a> VpcRouterDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29007,7 +29007,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29017,33 +29017,33 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -29053,7 +29053,7 @@ pub mod builder {
     ///[`Client::vpc_router_route_list`]: super::Client::vpc_router_route_list
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29066,7 +29066,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29156,7 +29156,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::RouterRouteResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29172,44 +29172,44 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -29277,7 +29277,7 @@ pub mod builder {
     ///[`Client::vpc_router_route_create`]: super::Client::vpc_router_route_create
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29288,7 +29288,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29363,7 +29363,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}/routes`
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29377,34 +29377,34 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::RouterRouteCreateParams>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -29414,7 +29414,7 @@ pub mod builder {
     ///[`Client::vpc_router_route_view`]: super::Client::vpc_router_route_view
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29425,7 +29425,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29489,7 +29489,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}/routes/{route_name}`
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29501,34 +29501,34 @@ pub mod builder {
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
             let route_name = route_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -29538,7 +29538,7 @@ pub mod builder {
     ///[`Client::vpc_router_route_update`]: super::Client::vpc_router_route_update
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteUpdate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29550,7 +29550,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29636,7 +29636,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}/routes/{route_name}`
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29652,35 +29652,35 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::RouterRouteUpdateParams>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -29690,7 +29690,7 @@ pub mod builder {
     ///[`Client::vpc_router_route_delete`]: super::Client::vpc_router_route_delete
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29701,7 +29701,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29765,7 +29765,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}/routes/{route_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29777,34 +29777,34 @@ pub mod builder {
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
             let route_name = route_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -29814,7 +29814,7 @@ pub mod builder {
     ///[`Client::vpc_subnet_list`]: super::Client::vpc_subnet_list
     #[derive(Debug, Clone)]
     pub struct VpcSubnetList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29826,7 +29826,7 @@ pub mod builder {
     impl<'a> VpcSubnetList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29905,7 +29905,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcSubnetResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29919,43 +29919,43 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -30023,7 +30023,7 @@ pub mod builder {
     ///[`Client::vpc_subnet_create`]: super::Client::vpc_subnet_create
     #[derive(Debug, Clone)]
     pub struct VpcSubnetCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30033,7 +30033,7 @@ pub mod builder {
     impl<'a> VpcSubnetCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30095,7 +30095,7 @@ pub mod builder {
         /// {vpc_name}/subnets`
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30107,33 +30107,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcSubnetCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -30143,7 +30143,7 @@ pub mod builder {
     ///[`Client::vpc_subnet_view`]: super::Client::vpc_subnet_view
     #[derive(Debug, Clone)]
     pub struct VpcSubnetView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30153,7 +30153,7 @@ pub mod builder {
     impl<'a> VpcSubnetView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30206,7 +30206,7 @@ pub mod builder {
         /// {vpc_name}/subnets/{subnet_name}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30216,33 +30216,33 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -30252,7 +30252,7 @@ pub mod builder {
     ///[`Client::vpc_subnet_update`]: super::Client::vpc_subnet_update
     #[derive(Debug, Clone)]
     pub struct VpcSubnetUpdate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30263,7 +30263,7 @@ pub mod builder {
     impl<'a> VpcSubnetUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30336,7 +30336,7 @@ pub mod builder {
         /// {vpc_name}/subnets/{subnet_name}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30350,34 +30350,34 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcSubnetUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -30387,7 +30387,7 @@ pub mod builder {
     ///[`Client::vpc_subnet_delete`]: super::Client::vpc_subnet_delete
     #[derive(Debug, Clone)]
     pub struct VpcSubnetDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30397,7 +30397,7 @@ pub mod builder {
     impl<'a> VpcSubnetDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30450,7 +30450,7 @@ pub mod builder {
         /// {vpc_name}/subnets/{subnet_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30460,33 +30460,33 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -30496,7 +30496,7 @@ pub mod builder {
     ///[`Client::vpc_subnet_list_network_interfaces`]: super::Client::vpc_subnet_list_network_interfaces
     #[derive(Debug, Clone)]
     pub struct VpcSubnetListNetworkInterfaces<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30509,7 +30509,7 @@ pub mod builder {
     impl<'a> VpcSubnetListNetworkInterfaces<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30600,7 +30600,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::NetworkInterfaceResultsPage>, Error<types::Error>>
         {
             let Self {
-                _client,
+                client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30616,44 +30616,44 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}/network-interfaces",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -30721,39 +30721,39 @@ pub mod builder {
     ///[`Client::policy_view`]: super::Client::policy_view
     #[derive(Debug, Clone)]
     pub struct PolicyView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> PolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `GET` request to `/policy`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-            let Self { _client } = self;
-            let _url = format!("{}/policy", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/policy", client.baseurl,);
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -30763,14 +30763,14 @@ pub mod builder {
     ///[`Client::policy_update`]: super::Client::policy_update
     #[derive(Debug, Clone)]
     pub struct PolicyUpdate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::SiloRolePolicy, String>,
     }
 
     impl<'a> PolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::SiloRolePolicy::default()),
             }
         }
@@ -30798,31 +30798,31 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SiloRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/policy", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/policy", client.baseurl,);
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -30832,7 +30832,7 @@ pub mod builder {
     ///[`Client::role_list`]: super::Client::role_list
     #[derive(Debug, Clone)]
     pub struct RoleList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
     }
@@ -30840,7 +30840,7 @@ pub mod builder {
     impl<'a> RoleList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
             }
@@ -30872,40 +30872,40 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::RoleResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/roles", _client.baseurl,);
-            let mut _query = Vec::with_capacity(2usize);
+            let url = format!("{}/roles", client.baseurl,);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -30970,14 +30970,14 @@ pub mod builder {
     ///[`Client::role_view`]: super::Client::role_view
     #[derive(Debug, Clone)]
     pub struct RoleView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         role_name: Result<String, String>,
     }
 
     impl<'a> RoleView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 role_name: Err("role_name was not initialized".to_string()),
             }
         }
@@ -30994,32 +30994,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/roles/{role_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Role>, Error<types::Error>> {
-            let Self { _client, role_name } = self;
+            let Self { client, role_name } = self;
             let role_name = role_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/roles/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&role_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -31029,37 +31029,37 @@ pub mod builder {
     ///[`Client::session_me`]: super::Client::session_me
     #[derive(Debug, Clone)]
     pub struct SessionMe<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> SessionMe<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `GET` request to `/session/me`
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
-            let Self { _client } = self;
-            let _url = format!("{}/session/me", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/session/me", client.baseurl,);
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -31069,7 +31069,7 @@ pub mod builder {
     ///[`Client::session_me_groups`]: super::Client::session_me_groups
     #[derive(Debug, Clone)]
     pub struct SessionMeGroups<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -31078,7 +31078,7 @@ pub mod builder {
     impl<'a> SessionMeGroups<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -31122,7 +31122,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -31130,37 +31130,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/session/me/groups", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/session/me/groups", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -31226,7 +31226,7 @@ pub mod builder {
     ///[`Client::session_sshkey_list`]: super::Client::session_sshkey_list
     #[derive(Debug, Clone)]
     pub struct SessionSshkeyList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameSortMode>, String>,
@@ -31235,7 +31235,7 @@ pub mod builder {
     impl<'a> SessionSshkeyList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -31279,7 +31279,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SshKeyResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -31287,37 +31287,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/session/me/sshkeys", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/session/me/sshkeys", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -31383,14 +31383,14 @@ pub mod builder {
     ///[`Client::session_sshkey_create`]: super::Client::session_sshkey_create
     #[derive(Debug, Clone)]
     pub struct SessionSshkeyCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::SshKeyCreate, String>,
     }
 
     impl<'a> SessionSshkeyCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::SshKeyCreate::default()),
             }
         }
@@ -31416,31 +31416,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/session/me/sshkeys`
         pub async fn send(self) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SshKeyCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/session/me/sshkeys", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/session/me/sshkeys", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -31450,14 +31450,14 @@ pub mod builder {
     ///[`Client::session_sshkey_view`]: super::Client::session_sshkey_view
     #[derive(Debug, Clone)]
     pub struct SessionSshkeyView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         ssh_key_name: Result<types::Name, String>,
     }
 
     impl<'a> SessionSshkeyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 ssh_key_name: Err("ssh_key_name was not initialized".to_string()),
             }
         }
@@ -31475,34 +31475,34 @@ pub mod builder {
         ///Sends a `GET` request to `/session/me/sshkeys/{ssh_key_name}`
         pub async fn send(self) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 ssh_key_name,
             } = self;
             let ssh_key_name = ssh_key_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/session/me/sshkeys/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -31512,14 +31512,14 @@ pub mod builder {
     ///[`Client::session_sshkey_delete`]: super::Client::session_sshkey_delete
     #[derive(Debug, Clone)]
     pub struct SessionSshkeyDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         ssh_key_name: Result<types::Name, String>,
     }
 
     impl<'a> SessionSshkeyDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 ssh_key_name: Err("ssh_key_name was not initialized".to_string()),
             }
         }
@@ -31537,34 +31537,34 @@ pub mod builder {
         ///Sends a `DELETE` request to `/session/me/sshkeys/{ssh_key_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 ssh_key_name,
             } = self;
             let ssh_key_name = ssh_key_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/session/me/sshkeys/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -31574,14 +31574,14 @@ pub mod builder {
     ///[`Client::system_image_view_by_id`]: super::Client::system_image_view_by_id
     #[derive(Debug, Clone)]
     pub struct SystemImageViewById<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SystemImageViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -31598,32 +31598,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/by-id/images/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/by-id/images/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -31633,14 +31633,14 @@ pub mod builder {
     ///[`Client::ip_pool_view_by_id`]: super::Client::ip_pool_view_by_id
     #[derive(Debug, Clone)]
     pub struct IpPoolViewById<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> IpPoolViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -31657,32 +31657,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/by-id/ip-pools/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/by-id/ip-pools/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -31692,14 +31692,14 @@ pub mod builder {
     ///[`Client::silo_view_by_id`]: super::Client::silo_view_by_id
     #[derive(Debug, Clone)]
     pub struct SiloViewById<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SiloViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -31716,32 +31716,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/by-id/silos/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/by-id/silos/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -31751,7 +31751,7 @@ pub mod builder {
     ///[`Client::certificate_list`]: super::Client::certificate_list
     #[derive(Debug, Clone)]
     pub struct CertificateList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameSortMode>, String>,
@@ -31760,7 +31760,7 @@ pub mod builder {
     impl<'a> CertificateList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -31804,7 +31804,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::CertificateResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -31812,37 +31812,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/certificates", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/system/certificates", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -31908,14 +31908,14 @@ pub mod builder {
     ///[`Client::certificate_create`]: super::Client::certificate_create
     #[derive(Debug, Clone)]
     pub struct CertificateCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::CertificateCreate, String>,
     }
 
     impl<'a> CertificateCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::CertificateCreate::default()),
             }
         }
@@ -31943,31 +31943,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/certificates`
         pub async fn send(self) -> Result<ResponseValue<types::Certificate>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::CertificateCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/certificates", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/system/certificates", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -31977,14 +31977,14 @@ pub mod builder {
     ///[`Client::certificate_view`]: super::Client::certificate_view
     #[derive(Debug, Clone)]
     pub struct CertificateView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         certificate: Result<types::NameOrId, String>,
     }
 
     impl<'a> CertificateView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 certificate: Err("certificate was not initialized".to_string()),
             }
         }
@@ -32002,34 +32002,34 @@ pub mod builder {
         ///Sends a `GET` request to `/system/certificates/{certificate}`
         pub async fn send(self) -> Result<ResponseValue<types::Certificate>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 certificate,
             } = self;
             let certificate = certificate.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/certificates/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&certificate.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -32039,14 +32039,14 @@ pub mod builder {
     ///[`Client::certificate_delete`]: super::Client::certificate_delete
     #[derive(Debug, Clone)]
     pub struct CertificateDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         certificate: Result<types::NameOrId, String>,
     }
 
     impl<'a> CertificateDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 certificate: Err("certificate was not initialized".to_string()),
             }
         }
@@ -32064,34 +32064,34 @@ pub mod builder {
         ///Sends a `DELETE` request to `/system/certificates/{certificate}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 certificate,
             } = self;
             let certificate = certificate.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/certificates/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&certificate.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -32101,7 +32101,7 @@ pub mod builder {
     ///[`Client::physical_disk_list`]: super::Client::physical_disk_list
     #[derive(Debug, Clone)]
     pub struct PhysicalDiskList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -32110,7 +32110,7 @@ pub mod builder {
     impl<'a> PhysicalDiskList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -32154,7 +32154,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::PhysicalDiskResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -32162,37 +32162,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/hardware/disks", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/system/hardware/disks", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -32258,7 +32258,7 @@ pub mod builder {
     ///[`Client::rack_list`]: super::Client::rack_list
     #[derive(Debug, Clone)]
     pub struct RackList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -32267,7 +32267,7 @@ pub mod builder {
     impl<'a> RackList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -32311,7 +32311,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::RackResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -32319,37 +32319,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/hardware/racks", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/system/hardware/racks", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -32415,14 +32415,14 @@ pub mod builder {
     ///[`Client::rack_view`]: super::Client::rack_view
     #[derive(Debug, Clone)]
     pub struct RackView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         rack_id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> RackView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 rack_id: Err("rack_id was not initialized".to_string()),
             }
         }
@@ -32439,32 +32439,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/hardware/racks/{rack_id}`
         pub async fn send(self) -> Result<ResponseValue<types::Rack>, Error<types::Error>> {
-            let Self { _client, rack_id } = self;
+            let Self { client, rack_id } = self;
             let rack_id = rack_id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/hardware/racks/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&rack_id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -32474,7 +32474,7 @@ pub mod builder {
     ///[`Client::sled_list`]: super::Client::sled_list
     #[derive(Debug, Clone)]
     pub struct SledList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -32483,7 +32483,7 @@ pub mod builder {
     impl<'a> SledList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -32527,7 +32527,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SledResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -32535,37 +32535,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/hardware/sleds", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/system/hardware/sleds", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -32631,14 +32631,14 @@ pub mod builder {
     ///[`Client::sled_view`]: super::Client::sled_view
     #[derive(Debug, Clone)]
     pub struct SledView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         sled_id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SledView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 sled_id: Err("sled_id was not initialized".to_string()),
             }
         }
@@ -32655,32 +32655,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/hardware/sleds/{sled_id}`
         pub async fn send(self) -> Result<ResponseValue<types::Sled>, Error<types::Error>> {
-            let Self { _client, sled_id } = self;
+            let Self { client, sled_id } = self;
             let sled_id = sled_id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/hardware/sleds/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&sled_id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -32690,7 +32690,7 @@ pub mod builder {
     ///[`Client::sled_physical_disk_list`]: super::Client::sled_physical_disk_list
     #[derive(Debug, Clone)]
     pub struct SledPhysicalDiskList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         sled_id: Result<uuid::Uuid, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -32700,7 +32700,7 @@ pub mod builder {
     impl<'a> SledPhysicalDiskList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 sled_id: Err("sled_id was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -32755,7 +32755,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::PhysicalDiskResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 sled_id,
                 limit,
                 page_token,
@@ -32765,41 +32765,41 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/hardware/sleds/{}/disks",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&sled_id.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -32865,7 +32865,7 @@ pub mod builder {
     ///[`Client::system_image_list`]: super::Client::system_image_list
     #[derive(Debug, Clone)]
     pub struct SystemImageList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameSortMode>, String>,
@@ -32874,7 +32874,7 @@ pub mod builder {
     impl<'a> SystemImageList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -32918,7 +32918,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::GlobalImageResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -32926,37 +32926,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/images", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/system/images", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -33022,14 +33022,14 @@ pub mod builder {
     ///[`Client::system_image_create`]: super::Client::system_image_create
     #[derive(Debug, Clone)]
     pub struct SystemImageCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::GlobalImageCreate, String>,
     }
 
     impl<'a> SystemImageCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::GlobalImageCreate::default()),
             }
         }
@@ -33057,31 +33057,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/images`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::GlobalImageCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/images", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/system/images", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -33091,14 +33091,14 @@ pub mod builder {
     ///[`Client::system_image_view`]: super::Client::system_image_view
     #[derive(Debug, Clone)]
     pub struct SystemImageView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         image_name: Result<types::Name, String>,
     }
 
     impl<'a> SystemImageView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 image_name: Err("image_name was not initialized".to_string()),
             }
         }
@@ -33115,35 +33115,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/images/{image_name}`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-            let Self {
-                _client,
-                image_name,
-            } = self;
+            let Self { client, image_name } = self;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/images/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&image_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -33153,14 +33150,14 @@ pub mod builder {
     ///[`Client::system_image_delete`]: super::Client::system_image_delete
     #[derive(Debug, Clone)]
     pub struct SystemImageDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         image_name: Result<types::Name, String>,
     }
 
     impl<'a> SystemImageDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 image_name: Err("image_name was not initialized".to_string()),
             }
         }
@@ -33177,35 +33174,32 @@ pub mod builder {
 
         ///Sends a `DELETE` request to `/system/images/{image_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self {
-                _client,
-                image_name,
-            } = self;
+            let Self { client, image_name } = self;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/images/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&image_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -33215,7 +33209,7 @@ pub mod builder {
     ///[`Client::ip_pool_list`]: super::Client::ip_pool_list
     #[derive(Debug, Clone)]
     pub struct IpPoolList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameOrIdSortMode>, String>,
@@ -33224,7 +33218,7 @@ pub mod builder {
     impl<'a> IpPoolList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -33268,7 +33262,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::IpPoolResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -33276,37 +33270,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/ip-pools", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/system/ip-pools", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -33372,14 +33366,14 @@ pub mod builder {
     ///[`Client::ip_pool_create`]: super::Client::ip_pool_create
     #[derive(Debug, Clone)]
     pub struct IpPoolCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::IpPoolCreate, String>,
     }
 
     impl<'a> IpPoolCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::IpPoolCreate::default()),
             }
         }
@@ -33405,31 +33399,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/ip-pools`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::IpPoolCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/ip-pools", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/system/ip-pools", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -33439,14 +33433,14 @@ pub mod builder {
     ///[`Client::ip_pool_view`]: super::Client::ip_pool_view
     #[derive(Debug, Clone)]
     pub struct IpPoolView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         pool_name: Result<types::Name, String>,
     }
 
     impl<'a> IpPoolView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
             }
         }
@@ -33463,32 +33457,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/ip-pools/{pool_name}`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-            let Self { _client, pool_name } = self;
+            let Self { client, pool_name } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/ip-pools/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -33498,7 +33492,7 @@ pub mod builder {
     ///[`Client::ip_pool_update`]: super::Client::ip_pool_update
     #[derive(Debug, Clone)]
     pub struct IpPoolUpdate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         pool_name: Result<types::Name, String>,
         body: Result<types::builder::IpPoolUpdate, String>,
     }
@@ -33506,7 +33500,7 @@ pub mod builder {
     impl<'a> IpPoolUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 body: Ok(types::builder::IpPoolUpdate::default()),
             }
@@ -33544,7 +33538,7 @@ pub mod builder {
         ///Sends a `PUT` request to `/system/ip-pools/{pool_name}`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 pool_name,
                 body,
             } = self;
@@ -33552,31 +33546,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::IpPoolUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/ip-pools/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -33586,14 +33580,14 @@ pub mod builder {
     ///[`Client::ip_pool_delete`]: super::Client::ip_pool_delete
     #[derive(Debug, Clone)]
     pub struct IpPoolDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         pool_name: Result<types::Name, String>,
     }
 
     impl<'a> IpPoolDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
             }
         }
@@ -33610,32 +33604,32 @@ pub mod builder {
 
         ///Sends a `DELETE` request to `/system/ip-pools/{pool_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { _client, pool_name } = self;
+            let Self { client, pool_name } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/ip-pools/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -33645,7 +33639,7 @@ pub mod builder {
     ///[`Client::ip_pool_range_list`]: super::Client::ip_pool_range_list
     #[derive(Debug, Clone)]
     pub struct IpPoolRangeList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         pool_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -33654,7 +33648,7 @@ pub mod builder {
     impl<'a> IpPoolRangeList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -33697,7 +33691,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 pool_name,
                 limit,
                 page_token,
@@ -33705,38 +33699,38 @@ pub mod builder {
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/ip-pools/{}/ranges",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(2usize);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -33801,7 +33795,7 @@ pub mod builder {
     ///[`Client::ip_pool_range_add`]: super::Client::ip_pool_range_add
     #[derive(Debug, Clone)]
     pub struct IpPoolRangeAdd<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         pool_name: Result<types::Name, String>,
         body: Result<types::IpRange, String>,
     }
@@ -33809,7 +33803,7 @@ pub mod builder {
     impl<'a> IpPoolRangeAdd<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
@@ -33838,37 +33832,37 @@ pub mod builder {
         ///Sends a `POST` request to `/system/ip-pools/{pool_name}/ranges/add`
         pub async fn send(self) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 pool_name,
                 body,
             } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/ip-pools/{}/ranges/add",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -33878,7 +33872,7 @@ pub mod builder {
     ///[`Client::ip_pool_range_remove`]: super::Client::ip_pool_range_remove
     #[derive(Debug, Clone)]
     pub struct IpPoolRangeRemove<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         pool_name: Result<types::Name, String>,
         body: Result<types::IpRange, String>,
     }
@@ -33886,7 +33880,7 @@ pub mod builder {
     impl<'a> IpPoolRangeRemove<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
@@ -33916,37 +33910,37 @@ pub mod builder {
         /// `/system/ip-pools/{pool_name}/ranges/remove`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 pool_name,
                 body,
             } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/ip-pools/{}/ranges/remove",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -33956,37 +33950,37 @@ pub mod builder {
     ///[`Client::ip_pool_service_view`]: super::Client::ip_pool_service_view
     #[derive(Debug, Clone)]
     pub struct IpPoolServiceView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> IpPoolServiceView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `GET` request to `/system/ip-pools-service`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-            let Self { _client } = self;
-            let _url = format!("{}/system/ip-pools-service", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/system/ip-pools-service", client.baseurl,);
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -33996,7 +33990,7 @@ pub mod builder {
     ///[`Client::ip_pool_service_range_list`]: super::Client::ip_pool_service_range_list
     #[derive(Debug, Clone)]
     pub struct IpPoolServiceRangeList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
     }
@@ -34004,7 +33998,7 @@ pub mod builder {
     impl<'a> IpPoolServiceRangeList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
             }
@@ -34036,40 +34030,40 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/ip-pools-service/ranges", _client.baseurl,);
-            let mut _query = Vec::with_capacity(2usize);
+            let url = format!("{}/system/ip-pools-service/ranges", client.baseurl,);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -34134,14 +34128,14 @@ pub mod builder {
     ///[`Client::ip_pool_service_range_add`]: super::Client::ip_pool_service_range_add
     #[derive(Debug, Clone)]
     pub struct IpPoolServiceRangeAdd<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::IpRange, String>,
     }
 
     impl<'a> IpPoolServiceRangeAdd<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -34158,29 +34152,29 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/ip-pools-service/ranges/add`
         pub async fn send(self) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/ip-pools-service/ranges/add", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/system/ip-pools-service/ranges/add", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -34190,14 +34184,14 @@ pub mod builder {
     ///[`Client::ip_pool_service_range_remove`]: super::Client::ip_pool_service_range_remove
     #[derive(Debug, Clone)]
     pub struct IpPoolServiceRangeRemove<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::IpRange, String>,
     }
 
     impl<'a> IpPoolServiceRangeRemove<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -34214,29 +34208,29 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/ip-pools-service/ranges/remove`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/ip-pools-service/ranges/remove", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/system/ip-pools-service/ranges/remove", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -34246,7 +34240,7 @@ pub mod builder {
     ///[`Client::system_metric`]: super::Client::system_metric
     #[derive(Debug, Clone)]
     pub struct SystemMetric<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         metric_name: Result<types::SystemMetricName, String>,
         end_time: Result<Option<chrono::DateTime<chrono::offset::Utc>>, String>,
         id: Result<uuid::Uuid, String>,
@@ -34258,7 +34252,7 @@ pub mod builder {
     impl<'a> SystemMetric<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 metric_name: Err("metric_name was not initialized".to_string()),
                 end_time: Ok(None),
                 id: Err("id was not initialized".to_string()),
@@ -34337,7 +34331,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::MeasurementResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 metric_name,
                 end_time,
                 id,
@@ -34351,45 +34345,45 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let start_time = start_time.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/metrics/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&metric_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(5usize);
+            let mut query = Vec::with_capacity(5usize);
             if let Some(v) = &end_time {
-                _query.push(("end_time", v.to_string()));
+                query.push(("end_time", v.to_string()));
             }
-            _query.push(("id", id.to_string()));
+            query.push(("id", id.to_string()));
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &start_time {
-                _query.push(("start_time", v.to_string()));
+                query.push(("start_time", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -34399,39 +34393,39 @@ pub mod builder {
     ///[`Client::system_policy_view`]: super::Client::system_policy_view
     #[derive(Debug, Clone)]
     pub struct SystemPolicyView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> SystemPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `GET` request to `/system/policy`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
-            let Self { _client } = self;
-            let _url = format!("{}/system/policy", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/system/policy", client.baseurl,);
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -34441,14 +34435,14 @@ pub mod builder {
     ///[`Client::system_policy_update`]: super::Client::system_policy_update
     #[derive(Debug, Clone)]
     pub struct SystemPolicyUpdate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::FleetRolePolicy, String>,
     }
 
     impl<'a> SystemPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::FleetRolePolicy::default()),
             }
         }
@@ -34476,31 +34470,31 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::FleetRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/policy", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/system/policy", client.baseurl,);
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -34510,7 +34504,7 @@ pub mod builder {
     ///[`Client::saga_list`]: super::Client::saga_list
     #[derive(Debug, Clone)]
     pub struct SagaList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -34519,7 +34513,7 @@ pub mod builder {
     impl<'a> SagaList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -34563,7 +34557,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SagaResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -34571,37 +34565,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/sagas", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/system/sagas", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -34667,14 +34661,14 @@ pub mod builder {
     ///[`Client::saga_view`]: super::Client::saga_view
     #[derive(Debug, Clone)]
     pub struct SagaView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         saga_id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SagaView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 saga_id: Err("saga_id was not initialized".to_string()),
             }
         }
@@ -34691,32 +34685,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/sagas/{saga_id}`
         pub async fn send(self) -> Result<ResponseValue<types::Saga>, Error<types::Error>> {
-            let Self { _client, saga_id } = self;
+            let Self { client, saga_id } = self;
             let saga_id = saga_id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/sagas/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&saga_id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -34726,7 +34720,7 @@ pub mod builder {
     ///[`Client::silo_list`]: super::Client::silo_list
     #[derive(Debug, Clone)]
     pub struct SiloList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameOrIdSortMode>, String>,
@@ -34735,7 +34729,7 @@ pub mod builder {
     impl<'a> SiloList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -34779,7 +34773,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SiloResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -34787,37 +34781,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/silos", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/system/silos", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -34883,14 +34877,14 @@ pub mod builder {
     ///[`Client::silo_create`]: super::Client::silo_create
     #[derive(Debug, Clone)]
     pub struct SiloCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::SiloCreate, String>,
     }
 
     impl<'a> SiloCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::SiloCreate::default()),
             }
         }
@@ -34916,31 +34910,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/silos`
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SiloCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/silos", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/system/silos", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -34950,14 +34944,14 @@ pub mod builder {
     ///[`Client::silo_view`]: super::Client::silo_view
     #[derive(Debug, Clone)]
     pub struct SiloView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
     }
 
     impl<'a> SiloView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
@@ -34974,32 +34968,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/silos/{silo_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-            let Self { _client, silo_name } = self;
+            let Self { client, silo_name } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/silos/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -35009,14 +35003,14 @@ pub mod builder {
     ///[`Client::silo_delete`]: super::Client::silo_delete
     #[derive(Debug, Clone)]
     pub struct SiloDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
     }
 
     impl<'a> SiloDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
@@ -35033,32 +35027,32 @@ pub mod builder {
 
         ///Sends a `DELETE` request to `/system/silos/{silo_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { _client, silo_name } = self;
+            let Self { client, silo_name } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/silos/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -35068,7 +35062,7 @@ pub mod builder {
     ///[`Client::silo_identity_provider_list`]: super::Client::silo_identity_provider_list
     #[derive(Debug, Clone)]
     pub struct SiloIdentityProviderList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -35078,7 +35072,7 @@ pub mod builder {
     impl<'a> SiloIdentityProviderList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -35135,7 +35129,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::IdentityProviderResultsPage>, Error<types::Error>>
         {
             let Self {
-                _client,
+                client,
                 silo_name,
                 limit,
                 page_token,
@@ -35145,41 +35139,41 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/silos/{}/identity-providers",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -35246,7 +35240,7 @@ pub mod builder {
     ///[`Client::local_idp_user_create`]: super::Client::local_idp_user_create
     #[derive(Debug, Clone)]
     pub struct LocalIdpUserCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         body: Result<types::builder::UserCreate, String>,
     }
@@ -35254,7 +35248,7 @@ pub mod builder {
     impl<'a> LocalIdpUserCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(types::builder::UserCreate::default()),
             }
@@ -35293,7 +35287,7 @@ pub mod builder {
         /// `/system/silos/{silo_name}/identity-providers/local/users`
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 silo_name,
                 body,
             } = self;
@@ -35301,31 +35295,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::UserCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/silos/{}/identity-providers/local/users",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -35335,7 +35329,7 @@ pub mod builder {
     ///[`Client::local_idp_user_delete`]: super::Client::local_idp_user_delete
     #[derive(Debug, Clone)]
     pub struct LocalIdpUserDelete<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         user_id: Result<uuid::Uuid, String>,
     }
@@ -35343,7 +35337,7 @@ pub mod builder {
     impl<'a> LocalIdpUserDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 user_id: Err("user_id was not initialized".to_string()),
             }
@@ -35373,37 +35367,37 @@ pub mod builder {
         /// `/system/silos/{silo_name}/identity-providers/local/users/{user_id}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 silo_name,
                 user_id,
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let user_id = user_id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/silos/{}/identity-providers/local/users/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -35413,7 +35407,7 @@ pub mod builder {
     ///[`Client::local_idp_user_set_password`]: super::Client::local_idp_user_set_password
     #[derive(Debug, Clone)]
     pub struct LocalIdpUserSetPassword<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         user_id: Result<uuid::Uuid, String>,
         body: Result<types::UserPassword, String>,
@@ -35422,7 +35416,7 @@ pub mod builder {
     impl<'a> LocalIdpUserSetPassword<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 user_id: Err("user_id was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
@@ -35464,7 +35458,7 @@ pub mod builder {
         /// set-password`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 silo_name,
                 user_id,
                 body,
@@ -35472,32 +35466,32 @@ pub mod builder {
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let user_id = user_id.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/silos/{}/identity-providers/local/users/{}/set-password",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -35507,7 +35501,7 @@ pub mod builder {
     ///[`Client::saml_identity_provider_create`]: super::Client::saml_identity_provider_create
     #[derive(Debug, Clone)]
     pub struct SamlIdentityProviderCreate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         body: Result<types::builder::SamlIdentityProviderCreate, String>,
     }
@@ -35515,7 +35509,7 @@ pub mod builder {
     impl<'a> SamlIdentityProviderCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(types::builder::SamlIdentityProviderCreate::default()),
             }
@@ -35557,7 +35551,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SamlIdentityProvider>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 silo_name,
                 body,
             } = self;
@@ -35565,31 +35559,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::SamlIdentityProviderCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/silos/{}/identity-providers/saml",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -35599,7 +35593,7 @@ pub mod builder {
     ///[`Client::saml_identity_provider_view`]: super::Client::saml_identity_provider_view
     #[derive(Debug, Clone)]
     pub struct SamlIdentityProviderView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         provider_name: Result<types::Name, String>,
     }
@@ -35607,7 +35601,7 @@ pub mod builder {
     impl<'a> SamlIdentityProviderView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 provider_name: Err("provider_name was not initialized".to_string()),
             }
@@ -35639,37 +35633,37 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SamlIdentityProvider>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 silo_name,
                 provider_name,
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let provider_name = provider_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/silos/{}/identity-providers/saml/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -35679,14 +35673,14 @@ pub mod builder {
     ///[`Client::silo_policy_view`]: super::Client::silo_policy_view
     #[derive(Debug, Clone)]
     pub struct SiloPolicyView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
     }
 
     impl<'a> SiloPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
@@ -35705,32 +35699,32 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-            let Self { _client, silo_name } = self;
+            let Self { client, silo_name } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/silos/{}/policy",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -35740,7 +35734,7 @@ pub mod builder {
     ///[`Client::silo_policy_update`]: super::Client::silo_policy_update
     #[derive(Debug, Clone)]
     pub struct SiloPolicyUpdate<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         body: Result<types::builder::SiloRolePolicy, String>,
     }
@@ -35748,7 +35742,7 @@ pub mod builder {
     impl<'a> SiloPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(types::builder::SiloRolePolicy::default()),
             }
@@ -35788,7 +35782,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 silo_name,
                 body,
             } = self;
@@ -35796,31 +35790,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::SiloRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/silos/{}/policy",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -35830,7 +35824,7 @@ pub mod builder {
     ///[`Client::silo_users_list`]: super::Client::silo_users_list
     #[derive(Debug, Clone)]
     pub struct SiloUsersList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -35840,7 +35834,7 @@ pub mod builder {
     impl<'a> SiloUsersList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -35895,7 +35889,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 silo_name,
                 limit,
                 page_token,
@@ -35905,41 +35899,41 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/silos/{}/users/all",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut _query = Vec::with_capacity(3usize);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -36005,7 +35999,7 @@ pub mod builder {
     ///[`Client::silo_user_view`]: super::Client::silo_user_view
     #[derive(Debug, Clone)]
     pub struct SiloUserView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         user_id: Result<uuid::Uuid, String>,
     }
@@ -36013,7 +36007,7 @@ pub mod builder {
     impl<'a> SiloUserView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 user_id: Err("user_id was not initialized".to_string()),
             }
@@ -36043,37 +36037,37 @@ pub mod builder {
         /// `/system/silos/{silo_name}/users/id/{user_id}`
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 silo_name,
                 user_id,
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let user_id = user_id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/silos/{}/users/id/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -36083,7 +36077,7 @@ pub mod builder {
     ///[`Client::system_user_list`]: super::Client::system_user_list
     #[derive(Debug, Clone)]
     pub struct SystemUserList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameSortMode>, String>,
@@ -36092,7 +36086,7 @@ pub mod builder {
     impl<'a> SystemUserList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -36136,7 +36130,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::UserBuiltinResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -36144,37 +36138,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/system/user", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/system/user", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -36240,14 +36234,14 @@ pub mod builder {
     ///[`Client::system_user_view`]: super::Client::system_user_view
     #[derive(Debug, Clone)]
     pub struct SystemUserView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         user_name: Result<types::Name, String>,
     }
 
     impl<'a> SystemUserView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 user_name: Err("user_name was not initialized".to_string()),
             }
         }
@@ -36264,32 +36258,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/user/{user_name}`
         pub async fn send(self) -> Result<ResponseValue<types::UserBuiltin>, Error<types::Error>> {
-            let Self { _client, user_name } = self;
+            let Self { client, user_name } = self;
             let user_name = user_name.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/system/user/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&user_name.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -36299,7 +36293,7 @@ pub mod builder {
     ///[`Client::timeseries_schema_get`]: super::Client::timeseries_schema_get
     #[derive(Debug, Clone)]
     pub struct TimeseriesSchemaGet<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
     }
@@ -36307,7 +36301,7 @@ pub mod builder {
     impl<'a> TimeseriesSchemaGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
             }
@@ -36340,40 +36334,40 @@ pub mod builder {
         ) -> Result<ResponseValue<types::TimeseriesSchemaResultsPage>, Error<types::Error>>
         {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/timeseries/schema", _client.baseurl,);
-            let mut _query = Vec::with_capacity(2usize);
+            let url = format!("{}/timeseries/schema", client.baseurl,);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -36438,7 +36432,7 @@ pub mod builder {
     ///[`Client::user_list`]: super::Client::user_list
     #[derive(Debug, Clone)]
     pub struct UserList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -36447,7 +36441,7 @@ pub mod builder {
     impl<'a> UserList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -36491,7 +36485,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -36499,37 +36493,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/users", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/users", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -36595,7 +36589,7 @@ pub mod builder {
     ///[`Client::disk_list_v1`]: super::Client::disk_list_v1
     #[derive(Debug, Clone)]
     pub struct DiskListV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         organization: Result<Option<types::NameOrId>, String>,
         page_token: Result<Option<String>, String>,
@@ -36606,7 +36600,7 @@ pub mod builder {
     impl<'a> DiskListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 organization: Ok(None),
                 page_token: Ok(None),
@@ -36674,7 +36668,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 organization,
                 page_token,
@@ -36686,43 +36680,43 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/disks", _client.baseurl,);
-            let mut _query = Vec::with_capacity(5usize);
+            let url = format!("{}/v1/disks", client.baseurl,);
+            let mut query = Vec::with_capacity(5usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -36790,7 +36784,7 @@ pub mod builder {
     ///[`Client::disk_create_v1`]: super::Client::disk_create_v1
     #[derive(Debug, Clone)]
     pub struct DiskCreateV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<types::NameOrId, String>,
         body: Result<types::builder::DiskCreate, String>,
@@ -36799,7 +36793,7 @@ pub mod builder {
     impl<'a> DiskCreateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization: Ok(None),
                 project: Err("project was not initialized".to_string()),
                 body: Ok(types::builder::DiskCreate::default()),
@@ -36849,7 +36843,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/disks`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization,
                 project,
                 body,
@@ -36859,33 +36853,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/disks", _client.baseurl,);
-            let mut _query = Vec::with_capacity(2usize);
+            let url = format!("{}/v1/disks", client.baseurl,);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
-            _query.push(("project", project.to_string()));
-            let _request = _client
+            query.push(("project", project.to_string()));
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -36895,7 +36889,7 @@ pub mod builder {
     ///[`Client::disk_view_v1`]: super::Client::disk_view_v1
     #[derive(Debug, Clone)]
     pub struct DiskViewV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         disk: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -36904,7 +36898,7 @@ pub mod builder {
     impl<'a> DiskViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 disk: Err("disk was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -36946,7 +36940,7 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/disks/{disk}`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 disk,
                 organization,
                 project,
@@ -36954,38 +36948,38 @@ pub mod builder {
             let disk = disk.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/disks/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&disk.to_string()),
             );
-            let mut _query = Vec::with_capacity(2usize);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -36995,7 +36989,7 @@ pub mod builder {
     ///[`Client::disk_delete_v1`]: super::Client::disk_delete_v1
     #[derive(Debug, Clone)]
     pub struct DiskDeleteV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         disk: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -37004,7 +36998,7 @@ pub mod builder {
     impl<'a> DiskDeleteV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 disk: Err("disk was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -37046,7 +37040,7 @@ pub mod builder {
         ///Sends a `DELETE` request to `/v1/disks/{disk}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 disk,
                 organization,
                 project,
@@ -37054,38 +37048,38 @@ pub mod builder {
             let disk = disk.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/disks/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&disk.to_string()),
             );
-            let mut _query = Vec::with_capacity(2usize);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -37095,7 +37089,7 @@ pub mod builder {
     ///[`Client::instance_list_v1`]: super::Client::instance_list_v1
     #[derive(Debug, Clone)]
     pub struct InstanceListV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         organization: Result<Option<types::NameOrId>, String>,
         page_token: Result<Option<String>, String>,
@@ -37106,7 +37100,7 @@ pub mod builder {
     impl<'a> InstanceListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 organization: Ok(None),
                 page_token: Ok(None),
@@ -37174,7 +37168,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 organization,
                 page_token,
@@ -37186,43 +37180,43 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/instances", _client.baseurl,);
-            let mut _query = Vec::with_capacity(5usize);
+            let url = format!("{}/v1/instances", client.baseurl,);
+            let mut query = Vec::with_capacity(5usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -37290,7 +37284,7 @@ pub mod builder {
     ///[`Client::instance_create_v1`]: super::Client::instance_create_v1
     #[derive(Debug, Clone)]
     pub struct InstanceCreateV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<types::NameOrId, String>,
         body: Result<types::builder::InstanceCreate, String>,
@@ -37299,7 +37293,7 @@ pub mod builder {
     impl<'a> InstanceCreateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization: Ok(None),
                 project: Err("project was not initialized".to_string()),
                 body: Ok(types::builder::InstanceCreate::default()),
@@ -37349,7 +37343,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization,
                 project,
                 body,
@@ -37359,33 +37353,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/instances", _client.baseurl,);
-            let mut _query = Vec::with_capacity(2usize);
+            let url = format!("{}/v1/instances", client.baseurl,);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
-            _query.push(("project", project.to_string()));
-            let _request = _client
+            query.push(("project", project.to_string()));
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -37395,7 +37389,7 @@ pub mod builder {
     ///[`Client::instance_view_v1`]: super::Client::instance_view_v1
     #[derive(Debug, Clone)]
     pub struct InstanceViewV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -37404,7 +37398,7 @@ pub mod builder {
     impl<'a> InstanceViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -37446,7 +37440,7 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/instances/{instance}`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 instance,
                 organization,
                 project,
@@ -37454,38 +37448,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/instances/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut _query = Vec::with_capacity(2usize);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -37495,7 +37489,7 @@ pub mod builder {
     ///[`Client::instance_delete_v1`]: super::Client::instance_delete_v1
     #[derive(Debug, Clone)]
     pub struct InstanceDeleteV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -37504,7 +37498,7 @@ pub mod builder {
     impl<'a> InstanceDeleteV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -37546,7 +37540,7 @@ pub mod builder {
         ///Sends a `DELETE` request to `/v1/instances/{instance}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 instance,
                 organization,
                 project,
@@ -37554,38 +37548,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/instances/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut _query = Vec::with_capacity(2usize);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -37595,7 +37589,7 @@ pub mod builder {
     ///[`Client::instance_disk_list_v1`]: super::Client::instance_disk_list_v1
     #[derive(Debug, Clone)]
     pub struct InstanceDiskListV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         organization: Result<Option<types::NameOrId>, String>,
@@ -37607,7 +37601,7 @@ pub mod builder {
     impl<'a> InstanceDiskListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 instance: Err("instance was not initialized".to_string()),
                 limit: Ok(None),
                 organization: Ok(None),
@@ -37686,7 +37680,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 instance,
                 limit,
                 organization,
@@ -37700,47 +37694,47 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/instances/{}/disks",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut _query = Vec::with_capacity(5usize);
+            let mut query = Vec::with_capacity(5usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -37808,7 +37802,7 @@ pub mod builder {
     ///[`Client::instance_disk_attach_v1`]: super::Client::instance_disk_attach_v1
     #[derive(Debug, Clone)]
     pub struct InstanceDiskAttachV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -37818,7 +37812,7 @@ pub mod builder {
     impl<'a> InstanceDiskAttachV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -37880,7 +37874,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/disks/attach`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 instance,
                 organization,
                 project,
@@ -37892,39 +37886,39 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskPath>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/instances/{}/disks/attach",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut _query = Vec::with_capacity(2usize);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                202u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                202u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -37934,7 +37928,7 @@ pub mod builder {
     ///[`Client::instance_disk_detach_v1`]: super::Client::instance_disk_detach_v1
     #[derive(Debug, Clone)]
     pub struct InstanceDiskDetachV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -37944,7 +37938,7 @@ pub mod builder {
     impl<'a> InstanceDiskDetachV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38006,7 +38000,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/disks/detach`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 instance,
                 organization,
                 project,
@@ -38018,39 +38012,39 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskPath>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/instances/{}/disks/detach",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut _query = Vec::with_capacity(2usize);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                202u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                202u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -38060,7 +38054,7 @@ pub mod builder {
     ///[`Client::instance_migrate_v1`]: super::Client::instance_migrate_v1
     #[derive(Debug, Clone)]
     pub struct InstanceMigrateV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38070,7 +38064,7 @@ pub mod builder {
     impl<'a> InstanceMigrateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38132,7 +38126,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/migrate`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 instance,
                 organization,
                 project,
@@ -38144,39 +38138,39 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceMigrate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/instances/{}/migrate",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut _query = Vec::with_capacity(2usize);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -38186,7 +38180,7 @@ pub mod builder {
     ///[`Client::instance_reboot_v1`]: super::Client::instance_reboot_v1
     #[derive(Debug, Clone)]
     pub struct InstanceRebootV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38195,7 +38189,7 @@ pub mod builder {
     impl<'a> InstanceRebootV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38237,7 +38231,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/reboot`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 instance,
                 organization,
                 project,
@@ -38245,38 +38239,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/instances/{}/reboot",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut _query = Vec::with_capacity(2usize);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                202u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                202u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -38286,7 +38280,7 @@ pub mod builder {
     ///[`Client::instance_serial_console_v1`]: super::Client::instance_serial_console_v1
     #[derive(Debug, Clone)]
     pub struct InstanceSerialConsoleV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         from_start: Result<Option<u64>, String>,
         max_bytes: Result<Option<u64>, String>,
@@ -38298,7 +38292,7 @@ pub mod builder {
     impl<'a> InstanceSerialConsoleV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 instance: Err("instance was not initialized".to_string()),
                 from_start: Ok(None),
                 max_bytes: Ok(None),
@@ -38378,7 +38372,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceSerialConsoleData>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 instance,
                 from_start,
                 max_bytes,
@@ -38392,47 +38386,47 @@ pub mod builder {
             let most_recent = most_recent.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/instances/{}/serial-console",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut _query = Vec::with_capacity(5usize);
+            let mut query = Vec::with_capacity(5usize);
             if let Some(v) = &from_start {
-                _query.push(("from_start", v.to_string()));
+                query.push(("from_start", v.to_string()));
             }
             if let Some(v) = &max_bytes {
-                _query.push(("max_bytes", v.to_string()));
+                query.push(("max_bytes", v.to_string()));
             }
             if let Some(v) = &most_recent {
-                _query.push(("most_recent", v.to_string()));
+                query.push(("most_recent", v.to_string()));
             }
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -38442,7 +38436,7 @@ pub mod builder {
     ///[`Client::instance_serial_console_stream_v1`]: super::Client::instance_serial_console_stream_v1
     #[derive(Debug, Clone)]
     pub struct InstanceSerialConsoleStreamV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38451,7 +38445,7 @@ pub mod builder {
     impl<'a> InstanceSerialConsoleStreamV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38496,7 +38490,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
             let Self {
-                _client,
+                client,
                 instance,
                 organization,
                 project,
@@ -38504,22 +38498,22 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/instances/{}/serial-console/stream",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut _query = Vec::with_capacity(2usize);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
-                .query(&_query)
+                .get(url)
+                .query(&query)
                 .header(reqwest::header::CONNECTION, "Upgrade")
                 .header(reqwest::header::UPGRADE, "websocket")
                 .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -38531,12 +38525,12 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                101u16 => ResponseValue::upgrade(_response).await,
-                200..=299 => ResponseValue::upgrade(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                101u16 => ResponseValue::upgrade(response).await,
+                200..=299 => ResponseValue::upgrade(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -38546,7 +38540,7 @@ pub mod builder {
     ///[`Client::instance_start_v1`]: super::Client::instance_start_v1
     #[derive(Debug, Clone)]
     pub struct InstanceStartV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38555,7 +38549,7 @@ pub mod builder {
     impl<'a> InstanceStartV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38597,7 +38591,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/start`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 instance,
                 organization,
                 project,
@@ -38605,38 +38599,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/instances/{}/start",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut _query = Vec::with_capacity(2usize);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                202u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                202u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -38646,7 +38640,7 @@ pub mod builder {
     ///[`Client::instance_stop_v1`]: super::Client::instance_stop_v1
     #[derive(Debug, Clone)]
     pub struct InstanceStopV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38655,7 +38649,7 @@ pub mod builder {
     impl<'a> InstanceStopV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38697,7 +38691,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/stop`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 instance,
                 organization,
                 project,
@@ -38705,38 +38699,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/instances/{}/stop",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut _query = Vec::with_capacity(2usize);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                _query.push(("project", v.to_string()));
+                query.push(("project", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                202u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                202u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -38746,7 +38740,7 @@ pub mod builder {
     ///[`Client::organization_list_v1`]: super::Client::organization_list_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationListV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameOrIdSortMode>, String>,
@@ -38755,7 +38749,7 @@ pub mod builder {
     impl<'a> OrganizationListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -38799,7 +38793,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -38807,37 +38801,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/organizations", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/v1/organizations", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -38903,14 +38897,14 @@ pub mod builder {
     ///[`Client::organization_create_v1`]: super::Client::organization_create_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationCreateV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::OrganizationCreate, String>,
     }
 
     impl<'a> OrganizationCreateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::OrganizationCreate::default()),
             }
         }
@@ -38938,31 +38932,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/organizations`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/organizations", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/v1/organizations", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -38972,14 +38966,14 @@ pub mod builder {
     ///[`Client::organization_view_v1`]: super::Client::organization_view_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationViewV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
     }
 
     impl<'a> OrganizationViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization: Err("organization was not initialized".to_string()),
             }
         }
@@ -38997,34 +38991,34 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/organizations/{organization}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization,
             } = self;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/organizations/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -39034,7 +39028,7 @@ pub mod builder {
     ///[`Client::organization_update_v1`]: super::Client::organization_update_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationUpdateV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
         body: Result<types::builder::OrganizationUpdate, String>,
     }
@@ -39042,7 +39036,7 @@ pub mod builder {
     impl<'a> OrganizationUpdateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization: Err("organization was not initialized".to_string()),
                 body: Ok(types::builder::OrganizationUpdate::default()),
             }
@@ -39082,7 +39076,7 @@ pub mod builder {
         ///Sends a `PUT` request to `/v1/organizations/{organization}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization,
                 body,
             } = self;
@@ -39090,31 +39084,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/organizations/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -39124,14 +39118,14 @@ pub mod builder {
     ///[`Client::organization_delete_v1`]: super::Client::organization_delete_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationDeleteV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
     }
 
     impl<'a> OrganizationDeleteV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization: Err("organization was not initialized".to_string()),
             }
         }
@@ -39149,34 +39143,34 @@ pub mod builder {
         ///Sends a `DELETE` request to `/v1/organizations/{organization}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization,
             } = self;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/organizations/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -39186,14 +39180,14 @@ pub mod builder {
     ///[`Client::organization_policy_view_v1`]: super::Client::organization_policy_view_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationPolicyViewV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
     }
 
     impl<'a> OrganizationPolicyViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization: Err("organization was not initialized".to_string()),
             }
         }
@@ -39213,34 +39207,34 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization,
             } = self;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/organizations/{}/policy",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -39250,7 +39244,7 @@ pub mod builder {
     ///[`Client::organization_policy_update_v1`]: super::Client::organization_policy_update_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationPolicyUpdateV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
         body: Result<types::builder::OrganizationRolePolicy, String>,
     }
@@ -39258,7 +39252,7 @@ pub mod builder {
     impl<'a> OrganizationPolicyUpdateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization: Err("organization was not initialized".to_string()),
                 body: Ok(types::builder::OrganizationRolePolicy::default()),
             }
@@ -39300,7 +39294,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization,
                 body,
             } = self;
@@ -39308,31 +39302,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/organizations/{}/policy",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -39342,7 +39336,7 @@ pub mod builder {
     ///[`Client::project_list_v1`]: super::Client::project_list_v1
     #[derive(Debug, Clone)]
     pub struct ProjectListV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         organization: Result<Option<types::NameOrId>, String>,
         page_token: Result<Option<String>, String>,
@@ -39352,7 +39346,7 @@ pub mod builder {
     impl<'a> ProjectListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 organization: Ok(None),
                 page_token: Ok(None),
@@ -39408,7 +39402,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 organization,
                 page_token,
@@ -39418,40 +39412,40 @@ pub mod builder {
             let organization = organization.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/projects", _client.baseurl,);
-            let mut _query = Vec::with_capacity(4usize);
+            let url = format!("{}/v1/projects", client.baseurl,);
+            let mut query = Vec::with_capacity(4usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -39518,7 +39512,7 @@ pub mod builder {
     ///[`Client::project_create_v1`]: super::Client::project_create_v1
     #[derive(Debug, Clone)]
     pub struct ProjectCreateV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
         body: Result<types::builder::ProjectCreate, String>,
     }
@@ -39526,7 +39520,7 @@ pub mod builder {
     impl<'a> ProjectCreateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 organization: Err("organization was not initialized".to_string()),
                 body: Ok(types::builder::ProjectCreate::default()),
             }
@@ -39564,7 +39558,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/projects`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 organization,
                 body,
             } = self;
@@ -39572,30 +39566,30 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/projects", _client.baseurl,);
-            let mut _query = Vec::with_capacity(1usize);
-            _query.push(("organization", organization.to_string()));
-            let _request = _client
+            let url = format!("{}/v1/projects", client.baseurl,);
+            let mut query = Vec::with_capacity(1usize);
+            query.push(("organization", organization.to_string()));
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -39605,7 +39599,7 @@ pub mod builder {
     ///[`Client::project_view_v1`]: super::Client::project_view_v1
     #[derive(Debug, Clone)]
     pub struct ProjectViewV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
     }
@@ -39613,7 +39607,7 @@ pub mod builder {
     impl<'a> ProjectViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
             }
@@ -39643,41 +39637,41 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/projects/{project}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 project,
                 organization,
             } = self;
             let project = project.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/projects/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut _query = Vec::with_capacity(1usize);
+            let mut query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -39687,7 +39681,7 @@ pub mod builder {
     ///[`Client::project_update_v1`]: super::Client::project_update_v1
     #[derive(Debug, Clone)]
     pub struct ProjectUpdateV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         body: Result<types::builder::ProjectUpdate, String>,
@@ -39696,7 +39690,7 @@ pub mod builder {
     impl<'a> ProjectUpdateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
                 body: Ok(types::builder::ProjectUpdate::default()),
@@ -39746,7 +39740,7 @@ pub mod builder {
         ///Sends a `PUT` request to `/v1/projects/{project}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 project,
                 organization,
                 body,
@@ -39756,36 +39750,36 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/projects/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut _query = Vec::with_capacity(1usize);
+            let mut query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -39795,7 +39789,7 @@ pub mod builder {
     ///[`Client::project_delete_v1`]: super::Client::project_delete_v1
     #[derive(Debug, Clone)]
     pub struct ProjectDeleteV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
     }
@@ -39803,7 +39797,7 @@ pub mod builder {
     impl<'a> ProjectDeleteV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
             }
@@ -39833,41 +39827,41 @@ pub mod builder {
         ///Sends a `DELETE` request to `/v1/projects/{project}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 project,
                 organization,
             } = self;
             let project = project.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/projects/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut _query = Vec::with_capacity(1usize);
+            let mut query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .delete(_url)
+                .delete(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -39877,7 +39871,7 @@ pub mod builder {
     ///[`Client::project_policy_view_v1`]: super::Client::project_policy_view_v1
     #[derive(Debug, Clone)]
     pub struct ProjectPolicyViewV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
     }
@@ -39885,7 +39879,7 @@ pub mod builder {
     impl<'a> ProjectPolicyViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
             }
@@ -39917,41 +39911,41 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 project,
                 organization,
             } = self;
             let project = project.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/projects/{}/policy",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut _query = Vec::with_capacity(1usize);
+            let mut query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -39961,7 +39955,7 @@ pub mod builder {
     ///[`Client::project_policy_update_v1`]: super::Client::project_policy_update_v1
     #[derive(Debug, Clone)]
     pub struct ProjectPolicyUpdateV1<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         body: Result<types::builder::ProjectRolePolicy, String>,
@@ -39970,7 +39964,7 @@ pub mod builder {
     impl<'a> ProjectPolicyUpdateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
                 body: Ok(types::builder::ProjectRolePolicy::default()),
@@ -40024,7 +40018,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 project,
                 organization,
                 body,
@@ -40034,36 +40028,36 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/projects/{}/policy",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut _query = Vec::with_capacity(1usize);
+            let mut query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                _query.push(("organization", v.to_string()));
+                query.push(("organization", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -40073,7 +40067,7 @@ pub mod builder {
     ///[`Client::system_component_version_list`]: super::Client::system_component_version_list
     #[derive(Debug, Clone)]
     pub struct SystemComponentVersionList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -40082,7 +40076,7 @@ pub mod builder {
     impl<'a> SystemComponentVersionList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -40127,7 +40121,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::UpdateableComponentResultsPage>, Error<types::Error>>
         {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -40135,37 +40129,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/system/update/components", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/v1/system/update/components", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -40232,7 +40226,7 @@ pub mod builder {
     ///[`Client::update_deployments_list`]: super::Client::update_deployments_list
     #[derive(Debug, Clone)]
     pub struct UpdateDeploymentsList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -40241,7 +40235,7 @@ pub mod builder {
     impl<'a> UpdateDeploymentsList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -40286,7 +40280,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::UpdateDeploymentResultsPage>, Error<types::Error>>
         {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -40294,37 +40288,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/system/update/deployments", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/v1/system/update/deployments", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -40390,14 +40384,14 @@ pub mod builder {
     ///[`Client::update_deployment_view`]: super::Client::update_deployment_view
     #[derive(Debug, Clone)]
     pub struct UpdateDeploymentView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> UpdateDeploymentView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -40416,32 +40410,32 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
-            let Self { _client, id } = self;
+            let Self { client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/system/update/deployments/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -40451,37 +40445,37 @@ pub mod builder {
     ///[`Client::system_update_refresh`]: super::Client::system_update_refresh
     #[derive(Debug, Clone)]
     pub struct SystemUpdateRefresh<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> SystemUpdateRefresh<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `POST` request to `/v1/system/update/refresh`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { _client } = self;
-            let _url = format!("{}/v1/system/update/refresh", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/v1/system/update/refresh", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -40491,14 +40485,14 @@ pub mod builder {
     ///[`Client::system_update_start`]: super::Client::system_update_start
     #[derive(Debug, Clone)]
     pub struct SystemUpdateStart<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::SystemUpdateStart, String>,
     }
 
     impl<'a> SystemUpdateStart<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::SystemUpdateStart::default()),
             }
         }
@@ -40528,31 +40522,31 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SystemUpdateStart>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/system/update/start", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/v1/system/update/start", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                202u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                202u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -40562,37 +40556,37 @@ pub mod builder {
     ///[`Client::system_update_stop`]: super::Client::system_update_stop
     #[derive(Debug, Clone)]
     pub struct SystemUpdateStop<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> SystemUpdateStop<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `POST` request to `/v1/system/update/stop`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { _client } = self;
-            let _url = format!("{}/v1/system/update/stop", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/v1/system/update/stop", client.baseurl,);
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -40602,7 +40596,7 @@ pub mod builder {
     ///[`Client::system_update_list`]: super::Client::system_update_list
     #[derive(Debug, Clone)]
     pub struct SystemUpdateList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -40611,7 +40605,7 @@ pub mod builder {
     impl<'a> SystemUpdateList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -40655,7 +40649,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SystemUpdateResultsPage>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 limit,
                 page_token,
                 sort_by,
@@ -40663,37 +40657,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/v1/system/update/updates", _client.baseurl,);
-            let mut _query = Vec::with_capacity(3usize);
+            let url = format!("{}/v1/system/update/updates", client.baseurl,);
+            let mut query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                _query.push(("limit", v.to_string()));
+                query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                _query.push(("page_token", v.to_string()));
+                query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                _query.push(("sort_by", v.to_string()));
+                query.push(("sort_by", v.to_string()));
             }
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&_query)
+                .query(&query)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
 
@@ -40759,14 +40753,14 @@ pub mod builder {
     ///[`Client::system_update_view`]: super::Client::system_update_view
     #[derive(Debug, Clone)]
     pub struct SystemUpdateView<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         version: Result<types::SemverVersion, String>,
     }
 
     impl<'a> SystemUpdateView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 version: Err("version was not initialized".to_string()),
             }
         }
@@ -40783,32 +40777,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/v1/system/update/updates/{version}`
         pub async fn send(self) -> Result<ResponseValue<types::SystemUpdate>, Error<types::Error>> {
-            let Self { _client, version } = self;
+            let Self { client, version } = self;
             let version = version.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/system/update/updates/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&version.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -40818,14 +40812,14 @@ pub mod builder {
     ///[`Client::system_update_components_list`]: super::Client::system_update_components_list
     #[derive(Debug, Clone)]
     pub struct SystemUpdateComponentsList<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         version: Result<types::SemverVersion, String>,
     }
 
     impl<'a> SystemUpdateComponentsList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 version: Err("version was not initialized".to_string()),
             }
         }
@@ -40845,32 +40839,32 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::ComponentUpdateResultsPage>, Error<types::Error>> {
-            let Self { _client, version } = self;
+            let Self { client, version } = self;
             let version = version.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/v1/system/update/updates/{}/components",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&version.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -40880,39 +40874,39 @@ pub mod builder {
     ///[`Client::system_version`]: super::Client::system_version
     #[derive(Debug, Clone)]
     pub struct SystemVersion<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> SystemVersion<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `GET` request to `/v1/system/update/version`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SystemVersion>, Error<types::Error>> {
-            let Self { _client } = self;
-            let _url = format!("{}/v1/system/update/version", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/v1/system/update/version", client.baseurl,);
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/nexus-builder.out
+++ b/progenitor-impl/tests/output/nexus-builder.out
@@ -20827,14 +20827,14 @@ pub mod builder {
     ///[`Client::disk_view_by_id`]: super::Client::disk_view_by_id
     #[derive(Debug, Clone)]
     pub struct DiskViewById<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> DiskViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -20851,38 +20851,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/disks/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/by-id/disks/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -20892,14 +20886,14 @@ pub mod builder {
     ///[`Client::image_view_by_id`]: super::Client::image_view_by_id
     #[derive(Debug, Clone)]
     pub struct ImageViewById<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> ImageViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -20916,38 +20910,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/images/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/by-id/images/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -20957,14 +20945,14 @@ pub mod builder {
     ///[`Client::instance_view_by_id`]: super::Client::instance_view_by_id
     #[derive(Debug, Clone)]
     pub struct InstanceViewById<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> InstanceViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -20981,38 +20969,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/instances/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/by-id/instances/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -21022,14 +21004,14 @@ pub mod builder {
     ///[`Client::instance_network_interface_view_by_id`]: super::Client::instance_network_interface_view_by_id
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceViewById<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> InstanceNetworkInterfaceViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21048,38 +21030,32 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/by-id/network-interfaces/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -21089,14 +21065,14 @@ pub mod builder {
     ///[`Client::organization_view_by_id`]: super::Client::organization_view_by_id
     #[derive(Debug, Clone)]
     pub struct OrganizationViewById<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> OrganizationViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21113,38 +21089,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/organizations/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/by-id/organizations/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -21154,14 +21124,14 @@ pub mod builder {
     ///[`Client::project_view_by_id`]: super::Client::project_view_by_id
     #[derive(Debug, Clone)]
     pub struct ProjectViewById<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> ProjectViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21178,38 +21148,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/projects/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/by-id/projects/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -21219,14 +21183,14 @@ pub mod builder {
     ///[`Client::snapshot_view_by_id`]: super::Client::snapshot_view_by_id
     #[derive(Debug, Clone)]
     pub struct SnapshotViewById<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SnapshotViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21243,38 +21207,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/snapshots/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/by-id/snapshots/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -21284,14 +21242,14 @@ pub mod builder {
     ///[`Client::vpc_router_route_view_by_id`]: super::Client::vpc_router_route_view_by_id
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteViewById<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcRouterRouteViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21308,38 +21266,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/vpc-router-routes/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/by-id/vpc-router-routes/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -21349,14 +21301,14 @@ pub mod builder {
     ///[`Client::vpc_router_view_by_id`]: super::Client::vpc_router_view_by_id
     #[derive(Debug, Clone)]
     pub struct VpcRouterViewById<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcRouterViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21373,38 +21325,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/vpc-routers/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/by-id/vpc-routers/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -21414,14 +21360,14 @@ pub mod builder {
     ///[`Client::vpc_subnet_view_by_id`]: super::Client::vpc_subnet_view_by_id
     #[derive(Debug, Clone)]
     pub struct VpcSubnetViewById<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcSubnetViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21438,38 +21384,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/vpc-subnets/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/by-id/vpc-subnets/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -21479,14 +21419,14 @@ pub mod builder {
     ///[`Client::vpc_view_by_id`]: super::Client::vpc_view_by_id
     #[derive(Debug, Clone)]
     pub struct VpcViewById<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> VpcViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -21503,38 +21443,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/by-id/vpcs/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/by-id/vpcs/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -21544,14 +21478,14 @@ pub mod builder {
     ///[`Client::device_auth_request`]: super::Client::device_auth_request
     #[derive(Debug, Clone)]
     pub struct DeviceAuthRequest<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::DeviceAuthRequest, String>,
     }
 
     impl<'a> DeviceAuthRequest<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::DeviceAuthRequest::default()),
             }
         }
@@ -21579,29 +21513,17 @@ pub mod builder {
 
         ///Sends a `POST` request to `/device/auth`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::DeviceAuthRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/device/auth", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
-                .client
-                .post(__progenitor_url)
-                .form_urlencoded(&body)?
-                .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
-                _ => Err(Error::ErrorResponse(ResponseValue::stream(
-                    __progenitor_response,
-                ))),
+            let _url = format!("{}/device/auth", _client.baseurl,);
+            let _request = _client.client.post(_url).form_urlencoded(&body)?.build()?;
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(_response)),
+                _ => Err(Error::ErrorResponse(ResponseValue::stream(_response))),
             }
         }
     }
@@ -21611,14 +21533,14 @@ pub mod builder {
     ///[`Client::device_auth_confirm`]: super::Client::device_auth_confirm
     #[derive(Debug, Clone)]
     pub struct DeviceAuthConfirm<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::DeviceAuthVerify, String>,
     }
 
     impl<'a> DeviceAuthConfirm<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::DeviceAuthVerify::default()),
             }
         }
@@ -21646,37 +21568,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/device/confirm`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::DeviceAuthVerify>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/device/confirm", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/device/confirm", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -21686,14 +21602,14 @@ pub mod builder {
     ///[`Client::device_access_token`]: super::Client::device_access_token
     #[derive(Debug, Clone)]
     pub struct DeviceAccessToken<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::DeviceAccessTokenRequest, String>,
     }
 
     impl<'a> DeviceAccessToken<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::DeviceAccessTokenRequest::default()),
             }
         }
@@ -21720,29 +21636,17 @@ pub mod builder {
 
         ///Sends a `POST` request to `/device/token`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::DeviceAccessTokenRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/device/token", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
-                .client
-                .post(__progenitor_url)
-                .form_urlencoded(&body)?
-                .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
-                _ => Err(Error::ErrorResponse(ResponseValue::stream(
-                    __progenitor_response,
-                ))),
+            let _url = format!("{}/device/token", _client.baseurl,);
+            let _request = _client.client.post(_url).form_urlencoded(&body)?.build()?;
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(_response)),
+                _ => Err(Error::ErrorResponse(ResponseValue::stream(_response))),
             }
         }
     }
@@ -21752,7 +21656,7 @@ pub mod builder {
     ///[`Client::group_list`]: super::Client::group_list
     #[derive(Debug, Clone)]
     pub struct GroupList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -21761,7 +21665,7 @@ pub mod builder {
     impl<'a> GroupList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -21805,7 +21709,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -21813,40 +21717,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/groups", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/groups", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -21912,14 +21813,14 @@ pub mod builder {
     ///[`Client::login_spoof`]: super::Client::login_spoof
     #[derive(Debug, Clone)]
     pub struct LoginSpoof<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::SpoofLoginBody, String>,
     }
 
     impl<'a> LoginSpoof<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::SpoofLoginBody::default()),
             }
         }
@@ -21945,37 +21846,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/login`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SpoofLoginBody>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/login", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/login", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -21985,7 +21880,7 @@ pub mod builder {
     ///[`Client::login_local`]: super::Client::login_local
     #[derive(Debug, Clone)]
     pub struct LoginLocal<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         body: Result<types::builder::UsernamePasswordCredentials, String>,
     }
@@ -21993,7 +21888,7 @@ pub mod builder {
     impl<'a> LoginLocal<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(types::builder::UsernamePasswordCredentials::default()),
             }
@@ -22032,7 +21927,7 @@ pub mod builder {
         ///Sends a `POST` request to `/login/{silo_name}/local`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 silo_name,
                 body,
             } = self;
@@ -22040,30 +21935,23 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::UsernamePasswordCredentials>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/login/{}/local",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
-                .client
-                .post(__progenitor_url)
-                .json(&body)
-                .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
+            let _request = _client.client.post(_url).json(&body).build()?;
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -22073,7 +21961,7 @@ pub mod builder {
     ///[`Client::login_saml_begin`]: super::Client::login_saml_begin
     #[derive(Debug, Clone)]
     pub struct LoginSamlBegin<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         provider_name: Result<types::Name, String>,
     }
@@ -22081,7 +21969,7 @@ pub mod builder {
     impl<'a> LoginSamlBegin<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 provider_name: Err("provider_name was not initialized".to_string()),
             }
@@ -22110,33 +21998,30 @@ pub mod builder {
         ///Sends a `GET` request to `/login/{silo_name}/saml/{provider_name}`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 silo_name,
                 provider_name,
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let provider_name = provider_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/login/{}/saml/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client.client.get(__progenitor_url).build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
+            let _request = _client.client.get(_url).build()?;
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -22146,7 +22031,7 @@ pub mod builder {
     ///[`Client::login_saml`]: super::Client::login_saml
     #[derive(Debug)]
     pub struct LoginSaml<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         provider_name: Result<types::Name, String>,
         body: Result<reqwest::Body, String>,
@@ -22155,7 +22040,7 @@ pub mod builder {
     impl<'a> LoginSaml<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 provider_name: Err("provider_name was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
@@ -22195,7 +22080,7 @@ pub mod builder {
         ///Sends a `POST` request to `/login/{silo_name}/saml/{provider_name}`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 silo_name,
                 provider_name,
                 body,
@@ -22203,35 +22088,32 @@ pub mod builder {
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let provider_name = provider_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/login/{}/saml/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::CONTENT_TYPE,
                     reqwest::header::HeaderValue::from_static("application/octet-stream"),
                 )
                 .body(body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -22241,44 +22123,37 @@ pub mod builder {
     ///[`Client::logout`]: super::Client::logout
     #[derive(Debug, Clone)]
     pub struct Logout<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> Logout<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `POST` request to `/logout`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url = format!("{}/logout", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/logout", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -22288,7 +22163,7 @@ pub mod builder {
     ///[`Client::organization_list`]: super::Client::organization_list
     #[derive(Debug, Clone)]
     pub struct OrganizationList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameOrIdSortMode>, String>,
@@ -22297,7 +22172,7 @@ pub mod builder {
     impl<'a> OrganizationList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -22341,7 +22216,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -22349,40 +22224,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/organizations", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/organizations", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -22448,14 +22320,14 @@ pub mod builder {
     ///[`Client::organization_create`]: super::Client::organization_create
     #[derive(Debug, Clone)]
     pub struct OrganizationCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::OrganizationCreate, String>,
     }
 
     impl<'a> OrganizationCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::OrganizationCreate::default()),
             }
         }
@@ -22483,37 +22355,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/organizations`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/organizations", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/organizations", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -22523,14 +22389,14 @@ pub mod builder {
     ///[`Client::organization_view`]: super::Client::organization_view
     #[derive(Debug, Clone)]
     pub struct OrganizationView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
     }
 
     impl<'a> OrganizationView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
@@ -22548,37 +22414,34 @@ pub mod builder {
         ///Sends a `GET` request to `/organizations/{organization_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -22588,7 +22451,7 @@ pub mod builder {
     ///[`Client::organization_update`]: super::Client::organization_update
     #[derive(Debug, Clone)]
     pub struct OrganizationUpdate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         body: Result<types::builder::OrganizationUpdate, String>,
     }
@@ -22596,7 +22459,7 @@ pub mod builder {
     impl<'a> OrganizationUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 body: Ok(types::builder::OrganizationUpdate::default()),
             }
@@ -22636,7 +22499,7 @@ pub mod builder {
         ///Sends a `PUT` request to `/organizations/{organization_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 body,
             } = self;
@@ -22644,34 +22507,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -22681,14 +22541,14 @@ pub mod builder {
     ///[`Client::organization_delete`]: super::Client::organization_delete
     #[derive(Debug, Clone)]
     pub struct OrganizationDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
     }
 
     impl<'a> OrganizationDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
@@ -22706,37 +22566,34 @@ pub mod builder {
         ///Sends a `DELETE` request to `/organizations/{organization_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -22746,14 +22603,14 @@ pub mod builder {
     ///[`Client::organization_policy_view`]: super::Client::organization_policy_view
     #[derive(Debug, Clone)]
     pub struct OrganizationPolicyView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
     }
 
     impl<'a> OrganizationPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
             }
         }
@@ -22773,37 +22630,34 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/policy",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -22813,7 +22667,7 @@ pub mod builder {
     ///[`Client::organization_policy_update`]: super::Client::organization_policy_update
     #[derive(Debug, Clone)]
     pub struct OrganizationPolicyUpdate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         body: Result<types::builder::OrganizationRolePolicy, String>,
     }
@@ -22821,7 +22675,7 @@ pub mod builder {
     impl<'a> OrganizationPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 body: Ok(types::builder::OrganizationRolePolicy::default()),
             }
@@ -22863,7 +22717,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 body,
             } = self;
@@ -22871,34 +22725,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/policy",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -22908,7 +22759,7 @@ pub mod builder {
     ///[`Client::project_list`]: super::Client::project_list
     #[derive(Debug, Clone)]
     pub struct ProjectList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -22918,7 +22769,7 @@ pub mod builder {
     impl<'a> ProjectList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -22974,7 +22825,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 limit,
                 page_token,
@@ -22984,44 +22835,41 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -23088,7 +22936,7 @@ pub mod builder {
     ///[`Client::project_create`]: super::Client::project_create
     #[derive(Debug, Clone)]
     pub struct ProjectCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         body: Result<types::builder::ProjectCreate, String>,
     }
@@ -23096,7 +22944,7 @@ pub mod builder {
     impl<'a> ProjectCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 body: Ok(types::builder::ProjectCreate::default()),
             }
@@ -23135,7 +22983,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 body,
             } = self;
@@ -23143,34 +22991,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -23180,7 +23025,7 @@ pub mod builder {
     ///[`Client::project_view`]: super::Client::project_view
     #[derive(Debug, Clone)]
     pub struct ProjectView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
     }
@@ -23188,7 +23033,7 @@ pub mod builder {
     impl<'a> ProjectView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
             }
@@ -23218,40 +23063,37 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -23261,7 +23103,7 @@ pub mod builder {
     ///[`Client::project_update`]: super::Client::project_update
     #[derive(Debug, Clone)]
     pub struct ProjectUpdate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::ProjectUpdate, String>,
@@ -23270,7 +23112,7 @@ pub mod builder {
     impl<'a> ProjectUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::ProjectUpdate::default()),
@@ -23320,7 +23162,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 body,
@@ -23330,35 +23172,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -23368,7 +23207,7 @@ pub mod builder {
     ///[`Client::project_delete`]: super::Client::project_delete
     #[derive(Debug, Clone)]
     pub struct ProjectDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
     }
@@ -23376,7 +23215,7 @@ pub mod builder {
     impl<'a> ProjectDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
             }
@@ -23406,40 +23245,37 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -23449,7 +23285,7 @@ pub mod builder {
     ///[`Client::disk_list`]: super::Client::disk_list
     #[derive(Debug, Clone)]
     pub struct DiskList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -23460,7 +23296,7 @@ pub mod builder {
     impl<'a> DiskList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -23527,7 +23363,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 limit,
@@ -23539,45 +23375,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/disks",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -23644,7 +23477,7 @@ pub mod builder {
     ///[`Client::disk_create`]: super::Client::disk_create
     #[derive(Debug, Clone)]
     pub struct DiskCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::DiskCreate, String>,
@@ -23653,7 +23486,7 @@ pub mod builder {
     impl<'a> DiskCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::DiskCreate::default()),
@@ -23703,7 +23536,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}/disks`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 body,
@@ -23713,35 +23546,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/disks",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -23751,7 +23581,7 @@ pub mod builder {
     ///[`Client::disk_view`]: super::Client::disk_view
     #[derive(Debug, Clone)]
     pub struct DiskView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         disk_name: Result<types::Name, String>,
@@ -23760,7 +23590,7 @@ pub mod builder {
     impl<'a> DiskView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 disk_name: Err("disk_name was not initialized".to_string()),
@@ -23802,7 +23632,7 @@ pub mod builder {
         /// {disk_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 disk_name,
@@ -23810,35 +23640,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let disk_name = disk_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/disks/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -23848,7 +23675,7 @@ pub mod builder {
     ///[`Client::disk_delete`]: super::Client::disk_delete
     #[derive(Debug, Clone)]
     pub struct DiskDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         disk_name: Result<types::Name, String>,
@@ -23857,7 +23684,7 @@ pub mod builder {
     impl<'a> DiskDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 disk_name: Err("disk_name was not initialized".to_string()),
@@ -23899,7 +23726,7 @@ pub mod builder {
         /// {disk_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 disk_name,
@@ -23907,35 +23734,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let disk_name = disk_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/disks/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -23945,7 +23769,7 @@ pub mod builder {
     ///[`Client::disk_metrics_list`]: super::Client::disk_metrics_list
     #[derive(Debug, Clone)]
     pub struct DiskMetricsList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         disk_name: Result<types::Name, String>,
@@ -23959,7 +23783,7 @@ pub mod builder {
     impl<'a> DiskMetricsList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 disk_name: Err("disk_name was not initialized".to_string()),
@@ -24062,7 +23886,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::MeasurementResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 disk_name,
@@ -24080,50 +23904,47 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let start_time = start_time.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/disks/{}/metrics/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&disk_name.to_string()),
                 encode_path(&metric_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(4usize);
+            let mut _query = Vec::with_capacity(4usize);
             if let Some(v) = &end_time {
-                __progenitor_query.push(("end_time", v.to_string()));
+                _query.push(("end_time", v.to_string()));
             }
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &start_time {
-                __progenitor_query.push(("start_time", v.to_string()));
+                _query.push(("start_time", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -24192,7 +24013,7 @@ pub mod builder {
     ///[`Client::image_list`]: super::Client::image_list
     #[derive(Debug, Clone)]
     pub struct ImageList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -24203,7 +24024,7 @@ pub mod builder {
     impl<'a> ImageList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -24270,7 +24091,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ImageResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 limit,
@@ -24282,45 +24103,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/images",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -24387,7 +24205,7 @@ pub mod builder {
     ///[`Client::image_create`]: super::Client::image_create
     #[derive(Debug, Clone)]
     pub struct ImageCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::ImageCreate, String>,
@@ -24396,7 +24214,7 @@ pub mod builder {
     impl<'a> ImageCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::ImageCreate::default()),
@@ -24446,7 +24264,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}/images`
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 body,
@@ -24456,35 +24274,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ImageCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/images",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -24494,7 +24309,7 @@ pub mod builder {
     ///[`Client::image_view`]: super::Client::image_view
     #[derive(Debug, Clone)]
     pub struct ImageView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         image_name: Result<types::Name, String>,
@@ -24503,7 +24318,7 @@ pub mod builder {
     impl<'a> ImageView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 image_name: Err("image_name was not initialized".to_string()),
@@ -24545,7 +24360,7 @@ pub mod builder {
         /// {image_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 image_name,
@@ -24553,35 +24368,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/images/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -24591,7 +24403,7 @@ pub mod builder {
     ///[`Client::image_delete`]: super::Client::image_delete
     #[derive(Debug, Clone)]
     pub struct ImageDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         image_name: Result<types::Name, String>,
@@ -24600,7 +24412,7 @@ pub mod builder {
     impl<'a> ImageDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 image_name: Err("image_name was not initialized".to_string()),
@@ -24642,7 +24454,7 @@ pub mod builder {
         /// {image_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 image_name,
@@ -24650,35 +24462,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/images/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&image_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -24688,7 +24497,7 @@ pub mod builder {
     ///[`Client::instance_list`]: super::Client::instance_list
     #[derive(Debug, Clone)]
     pub struct InstanceList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -24699,7 +24508,7 @@ pub mod builder {
     impl<'a> InstanceList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -24767,7 +24576,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 limit,
@@ -24779,45 +24588,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -24885,7 +24691,7 @@ pub mod builder {
     ///[`Client::instance_create`]: super::Client::instance_create
     #[derive(Debug, Clone)]
     pub struct InstanceCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::InstanceCreate, String>,
@@ -24894,7 +24700,7 @@ pub mod builder {
     impl<'a> InstanceCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::InstanceCreate::default()),
@@ -24945,7 +24751,7 @@ pub mod builder {
         /// instances`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 body,
@@ -24955,35 +24761,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -24993,7 +24796,7 @@ pub mod builder {
     ///[`Client::instance_view`]: super::Client::instance_view
     #[derive(Debug, Clone)]
     pub struct InstanceView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25002,7 +24805,7 @@ pub mod builder {
     impl<'a> InstanceView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25044,7 +24847,7 @@ pub mod builder {
         /// instances/{instance_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25052,35 +24855,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -25090,7 +24890,7 @@ pub mod builder {
     ///[`Client::instance_delete`]: super::Client::instance_delete
     #[derive(Debug, Clone)]
     pub struct InstanceDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25099,7 +24899,7 @@ pub mod builder {
     impl<'a> InstanceDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25141,7 +24941,7 @@ pub mod builder {
         /// instances/{instance_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25149,35 +24949,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -25187,7 +24984,7 @@ pub mod builder {
     ///[`Client::instance_disk_list`]: super::Client::instance_disk_list
     #[derive(Debug, Clone)]
     pub struct InstanceDiskList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25199,7 +24996,7 @@ pub mod builder {
     impl<'a> InstanceDiskList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25278,7 +25075,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25292,46 +25089,43 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -25399,7 +25193,7 @@ pub mod builder {
     ///[`Client::instance_disk_attach`]: super::Client::instance_disk_attach
     #[derive(Debug, Clone)]
     pub struct InstanceDiskAttach<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25409,7 +25203,7 @@ pub mod builder {
     impl<'a> InstanceDiskAttach<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25471,7 +25265,7 @@ pub mod builder {
         /// instances/{instance_name}/disks/attach`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25483,36 +25277,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskIdentifier>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks/attach",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                202u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                202u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -25522,7 +25313,7 @@ pub mod builder {
     ///[`Client::instance_disk_detach`]: super::Client::instance_disk_detach
     #[derive(Debug, Clone)]
     pub struct InstanceDiskDetach<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25532,7 +25323,7 @@ pub mod builder {
     impl<'a> InstanceDiskDetach<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25594,7 +25385,7 @@ pub mod builder {
         /// instances/{instance_name}/disks/detach`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25606,36 +25397,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskIdentifier>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/disks/detach",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                202u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                202u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -25645,7 +25433,7 @@ pub mod builder {
     ///[`Client::instance_external_ip_list`]: super::Client::instance_external_ip_list
     #[derive(Debug, Clone)]
     pub struct InstanceExternalIpList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25654,7 +25442,7 @@ pub mod builder {
     impl<'a> InstanceExternalIpList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25698,7 +25486,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ExternalIpResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25706,35 +25494,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/external-ips",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -25744,7 +25529,7 @@ pub mod builder {
     ///[`Client::instance_migrate`]: super::Client::instance_migrate
     #[derive(Debug, Clone)]
     pub struct InstanceMigrate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25754,7 +25539,7 @@ pub mod builder {
     impl<'a> InstanceMigrate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25816,7 +25601,7 @@ pub mod builder {
         /// instances/{instance_name}/migrate`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25828,36 +25613,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceMigrate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/migrate",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -25867,7 +25649,7 @@ pub mod builder {
     ///[`Client::instance_network_interface_list`]: super::Client::instance_network_interface_list
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -25879,7 +25661,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -25959,7 +25741,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::NetworkInterfaceResultsPage>, Error<types::Error>>
         {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -25973,46 +25755,43 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -26080,7 +25859,7 @@ pub mod builder {
     ///[`Client::instance_network_interface_create`]: super::Client::instance_network_interface_create
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26090,7 +25869,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26156,7 +25935,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26168,36 +25947,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::NetworkInterfaceCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -26207,7 +25983,7 @@ pub mod builder {
     ///[`Client::instance_network_interface_view`]: super::Client::instance_network_interface_view
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26217,7 +25993,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26272,7 +26048,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26282,36 +26058,33 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let interface_name = interface_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -26321,7 +26094,7 @@ pub mod builder {
     ///[`Client::instance_network_interface_update`]: super::Client::instance_network_interface_update
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceUpdate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26332,7 +26105,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26409,7 +26182,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26423,37 +26196,34 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::NetworkInterfaceUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -26463,7 +26233,7 @@ pub mod builder {
     ///[`Client::instance_network_interface_delete`]: super::Client::instance_network_interface_delete
     #[derive(Debug, Clone)]
     pub struct InstanceNetworkInterfaceDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26473,7 +26243,7 @@ pub mod builder {
     impl<'a> InstanceNetworkInterfaceDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26526,7 +26296,7 @@ pub mod builder {
         /// instances/{instance_name}/network-interfaces/{interface_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26536,36 +26306,33 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
             let interface_name = interface_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
                 encode_path(&interface_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -26575,7 +26342,7 @@ pub mod builder {
     ///[`Client::instance_reboot`]: super::Client::instance_reboot
     #[derive(Debug, Clone)]
     pub struct InstanceReboot<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26584,7 +26351,7 @@ pub mod builder {
     impl<'a> InstanceReboot<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26626,7 +26393,7 @@ pub mod builder {
         /// instances/{instance_name}/reboot`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26634,35 +26401,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/reboot",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                202u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                202u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -26672,7 +26436,7 @@ pub mod builder {
     ///[`Client::instance_serial_console`]: super::Client::instance_serial_console
     #[derive(Debug, Clone)]
     pub struct InstanceSerialConsole<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26684,7 +26448,7 @@ pub mod builder {
     impl<'a> InstanceSerialConsole<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26764,7 +26528,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceSerialConsoleData>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26778,46 +26542,43 @@ pub mod builder {
             let from_start = from_start.map_err(Error::InvalidRequest)?;
             let max_bytes = max_bytes.map_err(Error::InvalidRequest)?;
             let most_recent = most_recent.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/serial-console",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &from_start {
-                __progenitor_query.push(("from_start", v.to_string()));
+                _query.push(("from_start", v.to_string()));
             }
             if let Some(v) = &max_bytes {
-                __progenitor_query.push(("max_bytes", v.to_string()));
+                _query.push(("max_bytes", v.to_string()));
             }
             if let Some(v) = &most_recent {
-                __progenitor_query.push(("most_recent", v.to_string()));
+                _query.push(("most_recent", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -26827,7 +26588,7 @@ pub mod builder {
     ///[`Client::instance_serial_console_stream`]: super::Client::instance_serial_console_stream
     #[derive(Debug, Clone)]
     pub struct InstanceSerialConsoleStream<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26836,7 +26597,7 @@ pub mod builder {
     impl<'a> InstanceSerialConsoleStream<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26880,7 +26641,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26888,16 +26649,16 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/serial-console/stream",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(reqwest::header::CONNECTION, "Upgrade")
                 .header(reqwest::header::UPGRADE, "websocket")
                 .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -26909,15 +26670,12 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                101u16 => ResponseValue::upgrade(__progenitor_response).await,
-                200..=299 => ResponseValue::upgrade(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                101u16 => ResponseValue::upgrade(_response).await,
+                200..=299 => ResponseValue::upgrade(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -26927,7 +26685,7 @@ pub mod builder {
     ///[`Client::instance_start`]: super::Client::instance_start
     #[derive(Debug, Clone)]
     pub struct InstanceStart<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -26936,7 +26694,7 @@ pub mod builder {
     impl<'a> InstanceStart<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -26978,7 +26736,7 @@ pub mod builder {
         /// instances/{instance_name}/start`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -26986,35 +26744,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/start",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                202u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                202u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -27024,7 +26779,7 @@ pub mod builder {
     ///[`Client::instance_stop`]: super::Client::instance_stop
     #[derive(Debug, Clone)]
     pub struct InstanceStop<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         instance_name: Result<types::Name, String>,
@@ -27033,7 +26788,7 @@ pub mod builder {
     impl<'a> InstanceStop<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 instance_name: Err("instance_name was not initialized".to_string()),
@@ -27075,7 +26830,7 @@ pub mod builder {
         /// instances/{instance_name}/stop`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 instance_name,
@@ -27083,35 +26838,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let instance_name = instance_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/instances/{}/stop",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&instance_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                202u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                202u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -27121,7 +26873,7 @@ pub mod builder {
     ///[`Client::project_policy_view`]: super::Client::project_policy_view
     #[derive(Debug, Clone)]
     pub struct ProjectPolicyView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
     }
@@ -27129,7 +26881,7 @@ pub mod builder {
     impl<'a> ProjectPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
             }
@@ -27161,40 +26913,37 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
             } = self;
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/policy",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -27204,7 +26953,7 @@ pub mod builder {
     ///[`Client::project_policy_update`]: super::Client::project_policy_update
     #[derive(Debug, Clone)]
     pub struct ProjectPolicyUpdate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::ProjectRolePolicy, String>,
@@ -27213,7 +26962,7 @@ pub mod builder {
     impl<'a> ProjectPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::ProjectRolePolicy::default()),
@@ -27267,7 +27016,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 body,
@@ -27277,35 +27026,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/policy",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -27315,7 +27061,7 @@ pub mod builder {
     ///[`Client::snapshot_list`]: super::Client::snapshot_list
     #[derive(Debug, Clone)]
     pub struct SnapshotList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -27326,7 +27072,7 @@ pub mod builder {
     impl<'a> SnapshotList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -27394,7 +27140,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SnapshotResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 limit,
@@ -27406,45 +27152,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/snapshots",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -27512,7 +27255,7 @@ pub mod builder {
     ///[`Client::snapshot_create`]: super::Client::snapshot_create
     #[derive(Debug, Clone)]
     pub struct SnapshotCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::SnapshotCreate, String>,
@@ -27521,7 +27264,7 @@ pub mod builder {
     impl<'a> SnapshotCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::SnapshotCreate::default()),
@@ -27572,7 +27315,7 @@ pub mod builder {
         /// snapshots`
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 body,
@@ -27582,35 +27325,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::SnapshotCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/snapshots",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -27620,7 +27360,7 @@ pub mod builder {
     ///[`Client::snapshot_view`]: super::Client::snapshot_view
     #[derive(Debug, Clone)]
     pub struct SnapshotView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         snapshot_name: Result<types::Name, String>,
@@ -27629,7 +27369,7 @@ pub mod builder {
     impl<'a> SnapshotView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 snapshot_name: Err("snapshot_name was not initialized".to_string()),
@@ -27671,7 +27411,7 @@ pub mod builder {
         /// snapshots/{snapshot_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 snapshot_name,
@@ -27679,35 +27419,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let snapshot_name = snapshot_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/snapshots/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -27717,7 +27454,7 @@ pub mod builder {
     ///[`Client::snapshot_delete`]: super::Client::snapshot_delete
     #[derive(Debug, Clone)]
     pub struct SnapshotDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         snapshot_name: Result<types::Name, String>,
@@ -27726,7 +27463,7 @@ pub mod builder {
     impl<'a> SnapshotDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 snapshot_name: Err("snapshot_name was not initialized".to_string()),
@@ -27768,7 +27505,7 @@ pub mod builder {
         /// snapshots/{snapshot_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 snapshot_name,
@@ -27776,35 +27513,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let snapshot_name = snapshot_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/snapshots/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&snapshot_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -27814,7 +27548,7 @@ pub mod builder {
     ///[`Client::vpc_list`]: super::Client::vpc_list
     #[derive(Debug, Clone)]
     pub struct VpcList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
@@ -27825,7 +27559,7 @@ pub mod builder {
     impl<'a> VpcList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 limit: Ok(None),
@@ -27892,7 +27626,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 limit,
@@ -27904,45 +27638,42 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -28009,7 +27740,7 @@ pub mod builder {
     ///[`Client::vpc_create`]: super::Client::vpc_create
     #[derive(Debug, Clone)]
     pub struct VpcCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         body: Result<types::builder::VpcCreate, String>,
@@ -28018,7 +27749,7 @@ pub mod builder {
     impl<'a> VpcCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 body: Ok(types::builder::VpcCreate::default()),
@@ -28068,7 +27799,7 @@ pub mod builder {
         /// `/organizations/{organization_name}/projects/{project_name}/vpcs`
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 body,
@@ -28078,35 +27809,32 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -28116,7 +27844,7 @@ pub mod builder {
     ///[`Client::vpc_view`]: super::Client::vpc_view
     #[derive(Debug, Clone)]
     pub struct VpcView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28125,7 +27853,7 @@ pub mod builder {
     impl<'a> VpcView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28167,7 +27895,7 @@ pub mod builder {
         /// {vpc_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28175,35 +27903,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -28213,7 +27938,7 @@ pub mod builder {
     ///[`Client::vpc_update`]: super::Client::vpc_update
     #[derive(Debug, Clone)]
     pub struct VpcUpdate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28223,7 +27948,7 @@ pub mod builder {
     impl<'a> VpcUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28285,7 +28010,7 @@ pub mod builder {
         /// {vpc_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28297,36 +28022,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -28336,7 +28058,7 @@ pub mod builder {
     ///[`Client::vpc_delete`]: super::Client::vpc_delete
     #[derive(Debug, Clone)]
     pub struct VpcDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28345,7 +28067,7 @@ pub mod builder {
     impl<'a> VpcDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28387,7 +28109,7 @@ pub mod builder {
         /// {vpc_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28395,35 +28117,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -28433,7 +28152,7 @@ pub mod builder {
     ///[`Client::vpc_firewall_rules_view`]: super::Client::vpc_firewall_rules_view
     #[derive(Debug, Clone)]
     pub struct VpcFirewallRulesView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28442,7 +28161,7 @@ pub mod builder {
     impl<'a> VpcFirewallRulesView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28486,7 +28205,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcFirewallRules>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28494,35 +28213,32 @@ pub mod builder {
             let organization_name = organization_name.map_err(Error::InvalidRequest)?;
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -28532,7 +28248,7 @@ pub mod builder {
     ///[`Client::vpc_firewall_rules_update`]: super::Client::vpc_firewall_rules_update
     #[derive(Debug, Clone)]
     pub struct VpcFirewallRulesUpdate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28542,7 +28258,7 @@ pub mod builder {
     impl<'a> VpcFirewallRulesUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28607,7 +28323,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcFirewallRules>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28619,36 +28335,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcFirewallRuleUpdateParams>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -28658,7 +28371,7 @@ pub mod builder {
     ///[`Client::vpc_router_list`]: super::Client::vpc_router_list
     #[derive(Debug, Clone)]
     pub struct VpcRouterList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28670,7 +28383,7 @@ pub mod builder {
     impl<'a> VpcRouterList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28749,7 +28462,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcRouterResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28763,46 +28476,43 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -28870,7 +28580,7 @@ pub mod builder {
     ///[`Client::vpc_router_create`]: super::Client::vpc_router_create
     #[derive(Debug, Clone)]
     pub struct VpcRouterCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -28880,7 +28590,7 @@ pub mod builder {
     impl<'a> VpcRouterCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -28942,7 +28652,7 @@ pub mod builder {
         /// {vpc_name}/routers`
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -28954,36 +28664,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcRouterCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -28993,7 +28700,7 @@ pub mod builder {
     ///[`Client::vpc_router_view`]: super::Client::vpc_router_view
     #[derive(Debug, Clone)]
     pub struct VpcRouterView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29003,7 +28710,7 @@ pub mod builder {
     impl<'a> VpcRouterView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29056,7 +28763,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29066,36 +28773,33 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -29105,7 +28809,7 @@ pub mod builder {
     ///[`Client::vpc_router_update`]: super::Client::vpc_router_update
     #[derive(Debug, Clone)]
     pub struct VpcRouterUpdate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29116,7 +28820,7 @@ pub mod builder {
     impl<'a> VpcRouterUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29189,7 +28893,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29203,37 +28907,34 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcRouterUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -29243,7 +28944,7 @@ pub mod builder {
     ///[`Client::vpc_router_delete`]: super::Client::vpc_router_delete
     #[derive(Debug, Clone)]
     pub struct VpcRouterDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29253,7 +28954,7 @@ pub mod builder {
     impl<'a> VpcRouterDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29306,7 +29007,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29316,36 +29017,33 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -29355,7 +29053,7 @@ pub mod builder {
     ///[`Client::vpc_router_route_list`]: super::Client::vpc_router_route_list
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29368,7 +29066,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29458,7 +29156,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::RouterRouteResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29474,47 +29172,44 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -29582,7 +29277,7 @@ pub mod builder {
     ///[`Client::vpc_router_route_create`]: super::Client::vpc_router_route_create
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29593,7 +29288,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29668,7 +29363,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}/routes`
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29682,37 +29377,34 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::RouterRouteCreateParams>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -29722,7 +29414,7 @@ pub mod builder {
     ///[`Client::vpc_router_route_view`]: super::Client::vpc_router_route_view
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29733,7 +29425,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29797,7 +29489,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}/routes/{route_name}`
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29809,37 +29501,34 @@ pub mod builder {
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
             let route_name = route_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -29849,7 +29538,7 @@ pub mod builder {
     ///[`Client::vpc_router_route_update`]: super::Client::vpc_router_route_update
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteUpdate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -29861,7 +29550,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -29947,7 +29636,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}/routes/{route_name}`
         pub async fn send(self) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -29963,38 +29652,35 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::RouterRouteUpdateParams>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -30004,7 +29690,7 @@ pub mod builder {
     ///[`Client::vpc_router_route_delete`]: super::Client::vpc_router_route_delete
     #[derive(Debug, Clone)]
     pub struct VpcRouterRouteDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30015,7 +29701,7 @@ pub mod builder {
     impl<'a> VpcRouterRouteDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30079,7 +29765,7 @@ pub mod builder {
         /// {vpc_name}/routers/{router_name}/routes/{route_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30091,37 +29777,34 @@ pub mod builder {
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let router_name = router_name.map_err(Error::InvalidRequest)?;
             let route_name = route_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&router_name.to_string()),
                 encode_path(&route_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -30131,7 +29814,7 @@ pub mod builder {
     ///[`Client::vpc_subnet_list`]: super::Client::vpc_subnet_list
     #[derive(Debug, Clone)]
     pub struct VpcSubnetList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30143,7 +29826,7 @@ pub mod builder {
     impl<'a> VpcSubnetList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30222,7 +29905,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::VpcSubnetResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30236,46 +29919,43 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -30343,7 +30023,7 @@ pub mod builder {
     ///[`Client::vpc_subnet_create`]: super::Client::vpc_subnet_create
     #[derive(Debug, Clone)]
     pub struct VpcSubnetCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30353,7 +30033,7 @@ pub mod builder {
     impl<'a> VpcSubnetCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30415,7 +30095,7 @@ pub mod builder {
         /// {vpc_name}/subnets`
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30427,36 +30107,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcSubnetCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -30466,7 +30143,7 @@ pub mod builder {
     ///[`Client::vpc_subnet_view`]: super::Client::vpc_subnet_view
     #[derive(Debug, Clone)]
     pub struct VpcSubnetView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30476,7 +30153,7 @@ pub mod builder {
     impl<'a> VpcSubnetView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30529,7 +30206,7 @@ pub mod builder {
         /// {vpc_name}/subnets/{subnet_name}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30539,36 +30216,33 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -30578,7 +30252,7 @@ pub mod builder {
     ///[`Client::vpc_subnet_update`]: super::Client::vpc_subnet_update
     #[derive(Debug, Clone)]
     pub struct VpcSubnetUpdate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30589,7 +30263,7 @@ pub mod builder {
     impl<'a> VpcSubnetUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30662,7 +30336,7 @@ pub mod builder {
         /// {vpc_name}/subnets/{subnet_name}`
         pub async fn send(self) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30676,37 +30350,34 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::VpcSubnetUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -30716,7 +30387,7 @@ pub mod builder {
     ///[`Client::vpc_subnet_delete`]: super::Client::vpc_subnet_delete
     #[derive(Debug, Clone)]
     pub struct VpcSubnetDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30726,7 +30397,7 @@ pub mod builder {
     impl<'a> VpcSubnetDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30779,7 +30450,7 @@ pub mod builder {
         /// {vpc_name}/subnets/{subnet_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30789,36 +30460,33 @@ pub mod builder {
             let project_name = project_name.map_err(Error::InvalidRequest)?;
             let vpc_name = vpc_name.map_err(Error::InvalidRequest)?;
             let subnet_name = subnet_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -30828,7 +30496,7 @@ pub mod builder {
     ///[`Client::vpc_subnet_list_network_interfaces`]: super::Client::vpc_subnet_list_network_interfaces
     #[derive(Debug, Clone)]
     pub struct VpcSubnetListNetworkInterfaces<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization_name: Result<types::Name, String>,
         project_name: Result<types::Name, String>,
         vpc_name: Result<types::Name, String>,
@@ -30841,7 +30509,7 @@ pub mod builder {
     impl<'a> VpcSubnetListNetworkInterfaces<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization_name: Err("organization_name was not initialized".to_string()),
                 project_name: Err("project_name was not initialized".to_string()),
                 vpc_name: Err("vpc_name was not initialized".to_string()),
@@ -30932,7 +30600,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::NetworkInterfaceResultsPage>, Error<types::Error>>
         {
             let Self {
-                __progenitor_client,
+                _client,
                 organization_name,
                 project_name,
                 vpc_name,
@@ -30948,47 +30616,44 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}/network-interfaces",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization_name.to_string()),
                 encode_path(&project_name.to_string()),
                 encode_path(&vpc_name.to_string()),
                 encode_path(&subnet_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -31056,46 +30721,39 @@ pub mod builder {
     ///[`Client::policy_view`]: super::Client::policy_view
     #[derive(Debug, Clone)]
     pub struct PolicyView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> PolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `GET` request to `/policy`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url = format!("{}/policy", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/policy", _client.baseurl,);
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -31105,14 +30763,14 @@ pub mod builder {
     ///[`Client::policy_update`]: super::Client::policy_update
     #[derive(Debug, Clone)]
     pub struct PolicyUpdate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::SiloRolePolicy, String>,
     }
 
     impl<'a> PolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::SiloRolePolicy::default()),
             }
         }
@@ -31140,37 +30798,31 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SiloRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/policy", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/policy", _client.baseurl,);
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -31180,7 +30832,7 @@ pub mod builder {
     ///[`Client::role_list`]: super::Client::role_list
     #[derive(Debug, Clone)]
     pub struct RoleList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
     }
@@ -31188,7 +30840,7 @@ pub mod builder {
     impl<'a> RoleList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
             }
@@ -31220,43 +30872,40 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::RoleResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/roles", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let _url = format!("{}/roles", _client.baseurl,);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -31321,14 +30970,14 @@ pub mod builder {
     ///[`Client::role_view`]: super::Client::role_view
     #[derive(Debug, Clone)]
     pub struct RoleView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         role_name: Result<String, String>,
     }
 
     impl<'a> RoleView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 role_name: Err("role_name was not initialized".to_string()),
             }
         }
@@ -31345,38 +30994,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/roles/{role_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Role>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                role_name,
-            } = self;
+            let Self { _client, role_name } = self;
             let role_name = role_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/roles/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&role_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -31386,44 +31029,37 @@ pub mod builder {
     ///[`Client::session_me`]: super::Client::session_me
     #[derive(Debug, Clone)]
     pub struct SessionMe<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> SessionMe<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `GET` request to `/session/me`
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url = format!("{}/session/me", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/session/me", _client.baseurl,);
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -31433,7 +31069,7 @@ pub mod builder {
     ///[`Client::session_me_groups`]: super::Client::session_me_groups
     #[derive(Debug, Clone)]
     pub struct SessionMeGroups<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -31442,7 +31078,7 @@ pub mod builder {
     impl<'a> SessionMeGroups<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -31486,7 +31122,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -31494,40 +31130,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/session/me/groups", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/session/me/groups", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -31593,7 +31226,7 @@ pub mod builder {
     ///[`Client::session_sshkey_list`]: super::Client::session_sshkey_list
     #[derive(Debug, Clone)]
     pub struct SessionSshkeyList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameSortMode>, String>,
@@ -31602,7 +31235,7 @@ pub mod builder {
     impl<'a> SessionSshkeyList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -31646,7 +31279,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SshKeyResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -31654,40 +31287,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/session/me/sshkeys", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/session/me/sshkeys", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -31753,14 +31383,14 @@ pub mod builder {
     ///[`Client::session_sshkey_create`]: super::Client::session_sshkey_create
     #[derive(Debug, Clone)]
     pub struct SessionSshkeyCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::SshKeyCreate, String>,
     }
 
     impl<'a> SessionSshkeyCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::SshKeyCreate::default()),
             }
         }
@@ -31786,37 +31416,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/session/me/sshkeys`
         pub async fn send(self) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SshKeyCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/session/me/sshkeys", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/session/me/sshkeys", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -31826,14 +31450,14 @@ pub mod builder {
     ///[`Client::session_sshkey_view`]: super::Client::session_sshkey_view
     #[derive(Debug, Clone)]
     pub struct SessionSshkeyView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         ssh_key_name: Result<types::Name, String>,
     }
 
     impl<'a> SessionSshkeyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 ssh_key_name: Err("ssh_key_name was not initialized".to_string()),
             }
         }
@@ -31851,37 +31475,34 @@ pub mod builder {
         ///Sends a `GET` request to `/session/me/sshkeys/{ssh_key_name}`
         pub async fn send(self) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 ssh_key_name,
             } = self;
             let ssh_key_name = ssh_key_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/session/me/sshkeys/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -31891,14 +31512,14 @@ pub mod builder {
     ///[`Client::session_sshkey_delete`]: super::Client::session_sshkey_delete
     #[derive(Debug, Clone)]
     pub struct SessionSshkeyDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         ssh_key_name: Result<types::Name, String>,
     }
 
     impl<'a> SessionSshkeyDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 ssh_key_name: Err("ssh_key_name was not initialized".to_string()),
             }
         }
@@ -31916,37 +31537,34 @@ pub mod builder {
         ///Sends a `DELETE` request to `/session/me/sshkeys/{ssh_key_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 ssh_key_name,
             } = self;
             let ssh_key_name = ssh_key_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/session/me/sshkeys/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&ssh_key_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -31956,14 +31574,14 @@ pub mod builder {
     ///[`Client::system_image_view_by_id`]: super::Client::system_image_view_by_id
     #[derive(Debug, Clone)]
     pub struct SystemImageViewById<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SystemImageViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -31980,38 +31598,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/by-id/images/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/by-id/images/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -32021,14 +31633,14 @@ pub mod builder {
     ///[`Client::ip_pool_view_by_id`]: super::Client::ip_pool_view_by_id
     #[derive(Debug, Clone)]
     pub struct IpPoolViewById<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> IpPoolViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -32045,38 +31657,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/by-id/ip-pools/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/by-id/ip-pools/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -32086,14 +31692,14 @@ pub mod builder {
     ///[`Client::silo_view_by_id`]: super::Client::silo_view_by_id
     #[derive(Debug, Clone)]
     pub struct SiloViewById<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SiloViewById<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -32110,38 +31716,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/by-id/silos/{id}`
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/by-id/silos/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -32151,7 +31751,7 @@ pub mod builder {
     ///[`Client::certificate_list`]: super::Client::certificate_list
     #[derive(Debug, Clone)]
     pub struct CertificateList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameSortMode>, String>,
@@ -32160,7 +31760,7 @@ pub mod builder {
     impl<'a> CertificateList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -32204,7 +31804,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::CertificateResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -32212,40 +31812,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/certificates", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/system/certificates", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -32311,14 +31908,14 @@ pub mod builder {
     ///[`Client::certificate_create`]: super::Client::certificate_create
     #[derive(Debug, Clone)]
     pub struct CertificateCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::CertificateCreate, String>,
     }
 
     impl<'a> CertificateCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::CertificateCreate::default()),
             }
         }
@@ -32346,37 +31943,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/certificates`
         pub async fn send(self) -> Result<ResponseValue<types::Certificate>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::CertificateCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/certificates", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/system/certificates", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -32386,14 +31977,14 @@ pub mod builder {
     ///[`Client::certificate_view`]: super::Client::certificate_view
     #[derive(Debug, Clone)]
     pub struct CertificateView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         certificate: Result<types::NameOrId, String>,
     }
 
     impl<'a> CertificateView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 certificate: Err("certificate was not initialized".to_string()),
             }
         }
@@ -32411,37 +32002,34 @@ pub mod builder {
         ///Sends a `GET` request to `/system/certificates/{certificate}`
         pub async fn send(self) -> Result<ResponseValue<types::Certificate>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 certificate,
             } = self;
             let certificate = certificate.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/certificates/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&certificate.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -32451,14 +32039,14 @@ pub mod builder {
     ///[`Client::certificate_delete`]: super::Client::certificate_delete
     #[derive(Debug, Clone)]
     pub struct CertificateDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         certificate: Result<types::NameOrId, String>,
     }
 
     impl<'a> CertificateDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 certificate: Err("certificate was not initialized".to_string()),
             }
         }
@@ -32476,37 +32064,34 @@ pub mod builder {
         ///Sends a `DELETE` request to `/system/certificates/{certificate}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 certificate,
             } = self;
             let certificate = certificate.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/certificates/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&certificate.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -32516,7 +32101,7 @@ pub mod builder {
     ///[`Client::physical_disk_list`]: super::Client::physical_disk_list
     #[derive(Debug, Clone)]
     pub struct PhysicalDiskList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -32525,7 +32110,7 @@ pub mod builder {
     impl<'a> PhysicalDiskList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -32569,7 +32154,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::PhysicalDiskResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -32577,41 +32162,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url =
-                format!("{}/system/hardware/disks", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/system/hardware/disks", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -32677,7 +32258,7 @@ pub mod builder {
     ///[`Client::rack_list`]: super::Client::rack_list
     #[derive(Debug, Clone)]
     pub struct RackList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -32686,7 +32267,7 @@ pub mod builder {
     impl<'a> RackList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -32730,7 +32311,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::RackResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -32738,41 +32319,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url =
-                format!("{}/system/hardware/racks", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/system/hardware/racks", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -32838,14 +32415,14 @@ pub mod builder {
     ///[`Client::rack_view`]: super::Client::rack_view
     #[derive(Debug, Clone)]
     pub struct RackView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         rack_id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> RackView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 rack_id: Err("rack_id was not initialized".to_string()),
             }
         }
@@ -32862,38 +32439,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/hardware/racks/{rack_id}`
         pub async fn send(self) -> Result<ResponseValue<types::Rack>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                rack_id,
-            } = self;
+            let Self { _client, rack_id } = self;
             let rack_id = rack_id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/hardware/racks/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&rack_id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -32903,7 +32474,7 @@ pub mod builder {
     ///[`Client::sled_list`]: super::Client::sled_list
     #[derive(Debug, Clone)]
     pub struct SledList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -32912,7 +32483,7 @@ pub mod builder {
     impl<'a> SledList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -32956,7 +32527,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SledResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -32964,41 +32535,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url =
-                format!("{}/system/hardware/sleds", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/system/hardware/sleds", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -33064,14 +32631,14 @@ pub mod builder {
     ///[`Client::sled_view`]: super::Client::sled_view
     #[derive(Debug, Clone)]
     pub struct SledView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         sled_id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SledView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 sled_id: Err("sled_id was not initialized".to_string()),
             }
         }
@@ -33088,38 +32655,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/hardware/sleds/{sled_id}`
         pub async fn send(self) -> Result<ResponseValue<types::Sled>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                sled_id,
-            } = self;
+            let Self { _client, sled_id } = self;
             let sled_id = sled_id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/hardware/sleds/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&sled_id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -33129,7 +32690,7 @@ pub mod builder {
     ///[`Client::sled_physical_disk_list`]: super::Client::sled_physical_disk_list
     #[derive(Debug, Clone)]
     pub struct SledPhysicalDiskList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         sled_id: Result<uuid::Uuid, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -33139,7 +32700,7 @@ pub mod builder {
     impl<'a> SledPhysicalDiskList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 sled_id: Err("sled_id was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -33194,7 +32755,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::PhysicalDiskResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 sled_id,
                 limit,
                 page_token,
@@ -33204,44 +32765,41 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/hardware/sleds/{}/disks",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&sled_id.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -33307,7 +32865,7 @@ pub mod builder {
     ///[`Client::system_image_list`]: super::Client::system_image_list
     #[derive(Debug, Clone)]
     pub struct SystemImageList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameSortMode>, String>,
@@ -33316,7 +32874,7 @@ pub mod builder {
     impl<'a> SystemImageList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -33360,7 +32918,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::GlobalImageResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -33368,40 +32926,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/images", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/system/images", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -33467,14 +33022,14 @@ pub mod builder {
     ///[`Client::system_image_create`]: super::Client::system_image_create
     #[derive(Debug, Clone)]
     pub struct SystemImageCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::GlobalImageCreate, String>,
     }
 
     impl<'a> SystemImageCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::GlobalImageCreate::default()),
             }
         }
@@ -33502,37 +33057,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/images`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::GlobalImageCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/images", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/system/images", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -33542,14 +33091,14 @@ pub mod builder {
     ///[`Client::system_image_view`]: super::Client::system_image_view
     #[derive(Debug, Clone)]
     pub struct SystemImageView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         image_name: Result<types::Name, String>,
     }
 
     impl<'a> SystemImageView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 image_name: Err("image_name was not initialized".to_string()),
             }
         }
@@ -33567,37 +33116,34 @@ pub mod builder {
         ///Sends a `GET` request to `/system/images/{image_name}`
         pub async fn send(self) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 image_name,
             } = self;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/images/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&image_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -33607,14 +33153,14 @@ pub mod builder {
     ///[`Client::system_image_delete`]: super::Client::system_image_delete
     #[derive(Debug, Clone)]
     pub struct SystemImageDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         image_name: Result<types::Name, String>,
     }
 
     impl<'a> SystemImageDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 image_name: Err("image_name was not initialized".to_string()),
             }
         }
@@ -33632,37 +33178,34 @@ pub mod builder {
         ///Sends a `DELETE` request to `/system/images/{image_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 image_name,
             } = self;
             let image_name = image_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/images/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&image_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -33672,7 +33215,7 @@ pub mod builder {
     ///[`Client::ip_pool_list`]: super::Client::ip_pool_list
     #[derive(Debug, Clone)]
     pub struct IpPoolList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameOrIdSortMode>, String>,
@@ -33681,7 +33224,7 @@ pub mod builder {
     impl<'a> IpPoolList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -33725,7 +33268,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::IpPoolResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -33733,40 +33276,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/ip-pools", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/system/ip-pools", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -33832,14 +33372,14 @@ pub mod builder {
     ///[`Client::ip_pool_create`]: super::Client::ip_pool_create
     #[derive(Debug, Clone)]
     pub struct IpPoolCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::IpPoolCreate, String>,
     }
 
     impl<'a> IpPoolCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::IpPoolCreate::default()),
             }
         }
@@ -33865,37 +33405,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/ip-pools`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::IpPoolCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/ip-pools", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/system/ip-pools", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -33905,14 +33439,14 @@ pub mod builder {
     ///[`Client::ip_pool_view`]: super::Client::ip_pool_view
     #[derive(Debug, Clone)]
     pub struct IpPoolView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         pool_name: Result<types::Name, String>,
     }
 
     impl<'a> IpPoolView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
             }
         }
@@ -33929,38 +33463,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/ip-pools/{pool_name}`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                pool_name,
-            } = self;
+            let Self { _client, pool_name } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/ip-pools/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -33970,7 +33498,7 @@ pub mod builder {
     ///[`Client::ip_pool_update`]: super::Client::ip_pool_update
     #[derive(Debug, Clone)]
     pub struct IpPoolUpdate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         pool_name: Result<types::Name, String>,
         body: Result<types::builder::IpPoolUpdate, String>,
     }
@@ -33978,7 +33506,7 @@ pub mod builder {
     impl<'a> IpPoolUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 body: Ok(types::builder::IpPoolUpdate::default()),
             }
@@ -34016,7 +33544,7 @@ pub mod builder {
         ///Sends a `PUT` request to `/system/ip-pools/{pool_name}`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 pool_name,
                 body,
             } = self;
@@ -34024,34 +33552,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::IpPoolUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/ip-pools/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -34061,14 +33586,14 @@ pub mod builder {
     ///[`Client::ip_pool_delete`]: super::Client::ip_pool_delete
     #[derive(Debug, Clone)]
     pub struct IpPoolDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         pool_name: Result<types::Name, String>,
     }
 
     impl<'a> IpPoolDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
             }
         }
@@ -34085,38 +33610,32 @@ pub mod builder {
 
         ///Sends a `DELETE` request to `/system/ip-pools/{pool_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                pool_name,
-            } = self;
+            let Self { _client, pool_name } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/ip-pools/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -34126,7 +33645,7 @@ pub mod builder {
     ///[`Client::ip_pool_range_list`]: super::Client::ip_pool_range_list
     #[derive(Debug, Clone)]
     pub struct IpPoolRangeList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         pool_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -34135,7 +33654,7 @@ pub mod builder {
     impl<'a> IpPoolRangeList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -34178,7 +33697,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 pool_name,
                 limit,
                 page_token,
@@ -34186,41 +33705,38 @@ pub mod builder {
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/ip-pools/{}/ranges",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -34285,7 +33801,7 @@ pub mod builder {
     ///[`Client::ip_pool_range_add`]: super::Client::ip_pool_range_add
     #[derive(Debug, Clone)]
     pub struct IpPoolRangeAdd<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         pool_name: Result<types::Name, String>,
         body: Result<types::IpRange, String>,
     }
@@ -34293,7 +33809,7 @@ pub mod builder {
     impl<'a> IpPoolRangeAdd<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
@@ -34322,40 +33838,37 @@ pub mod builder {
         ///Sends a `POST` request to `/system/ip-pools/{pool_name}/ranges/add`
         pub async fn send(self) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 pool_name,
                 body,
             } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/ip-pools/{}/ranges/add",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -34365,7 +33878,7 @@ pub mod builder {
     ///[`Client::ip_pool_range_remove`]: super::Client::ip_pool_range_remove
     #[derive(Debug, Clone)]
     pub struct IpPoolRangeRemove<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         pool_name: Result<types::Name, String>,
         body: Result<types::IpRange, String>,
     }
@@ -34373,7 +33886,7 @@ pub mod builder {
     impl<'a> IpPoolRangeRemove<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 pool_name: Err("pool_name was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
             }
@@ -34403,40 +33916,37 @@ pub mod builder {
         /// `/system/ip-pools/{pool_name}/ranges/remove`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 pool_name,
                 body,
             } = self;
             let pool_name = pool_name.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/ip-pools/{}/ranges/remove",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&pool_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -34446,45 +33956,37 @@ pub mod builder {
     ///[`Client::ip_pool_service_view`]: super::Client::ip_pool_service_view
     #[derive(Debug, Clone)]
     pub struct IpPoolServiceView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> IpPoolServiceView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `GET` request to `/system/ip-pools-service`
         pub async fn send(self) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url =
-                format!("{}/system/ip-pools-service", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/system/ip-pools-service", _client.baseurl,);
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -34494,7 +33996,7 @@ pub mod builder {
     ///[`Client::ip_pool_service_range_list`]: super::Client::ip_pool_service_range_list
     #[derive(Debug, Clone)]
     pub struct IpPoolServiceRangeList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
     }
@@ -34502,7 +34004,7 @@ pub mod builder {
     impl<'a> IpPoolServiceRangeList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
             }
@@ -34534,46 +34036,40 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
-                "{}/system/ip-pools-service/ranges",
-                __progenitor_client.baseurl,
-            );
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let _url = format!("{}/system/ip-pools-service/ranges", _client.baseurl,);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -34638,14 +34134,14 @@ pub mod builder {
     ///[`Client::ip_pool_service_range_add`]: super::Client::ip_pool_service_range_add
     #[derive(Debug, Clone)]
     pub struct IpPoolServiceRangeAdd<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::IpRange, String>,
     }
 
     impl<'a> IpPoolServiceRangeAdd<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -34662,38 +34158,29 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/ip-pools-service/ranges/add`
         pub async fn send(self) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
-                "{}/system/ip-pools-service/ranges/add",
-                __progenitor_client.baseurl,
-            );
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/system/ip-pools-service/ranges/add", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -34703,14 +34190,14 @@ pub mod builder {
     ///[`Client::ip_pool_service_range_remove`]: super::Client::ip_pool_service_range_remove
     #[derive(Debug, Clone)]
     pub struct IpPoolServiceRangeRemove<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::IpRange, String>,
     }
 
     impl<'a> IpPoolServiceRangeRemove<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -34727,38 +34214,29 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/ip-pools-service/ranges/remove`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
-                "{}/system/ip-pools-service/ranges/remove",
-                __progenitor_client.baseurl,
-            );
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/system/ip-pools-service/ranges/remove", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -34768,7 +34246,7 @@ pub mod builder {
     ///[`Client::system_metric`]: super::Client::system_metric
     #[derive(Debug, Clone)]
     pub struct SystemMetric<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         metric_name: Result<types::SystemMetricName, String>,
         end_time: Result<Option<chrono::DateTime<chrono::offset::Utc>>, String>,
         id: Result<uuid::Uuid, String>,
@@ -34780,7 +34258,7 @@ pub mod builder {
     impl<'a> SystemMetric<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 metric_name: Err("metric_name was not initialized".to_string()),
                 end_time: Ok(None),
                 id: Err("id was not initialized".to_string()),
@@ -34859,7 +34337,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::MeasurementResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 metric_name,
                 end_time,
                 id,
@@ -34873,48 +34351,45 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let start_time = start_time.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/metrics/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&metric_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(5usize);
+            let mut _query = Vec::with_capacity(5usize);
             if let Some(v) = &end_time {
-                __progenitor_query.push(("end_time", v.to_string()));
+                _query.push(("end_time", v.to_string()));
             }
-            __progenitor_query.push(("id", id.to_string()));
+            _query.push(("id", id.to_string()));
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &start_time {
-                __progenitor_query.push(("start_time", v.to_string()));
+                _query.push(("start_time", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -34924,46 +34399,39 @@ pub mod builder {
     ///[`Client::system_policy_view`]: super::Client::system_policy_view
     #[derive(Debug, Clone)]
     pub struct SystemPolicyView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> SystemPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `GET` request to `/system/policy`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url = format!("{}/system/policy", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/system/policy", _client.baseurl,);
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -34973,14 +34441,14 @@ pub mod builder {
     ///[`Client::system_policy_update`]: super::Client::system_policy_update
     #[derive(Debug, Clone)]
     pub struct SystemPolicyUpdate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::FleetRolePolicy, String>,
     }
 
     impl<'a> SystemPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::FleetRolePolicy::default()),
             }
         }
@@ -35008,37 +34476,31 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::FleetRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/policy", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/system/policy", _client.baseurl,);
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -35048,7 +34510,7 @@ pub mod builder {
     ///[`Client::saga_list`]: super::Client::saga_list
     #[derive(Debug, Clone)]
     pub struct SagaList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -35057,7 +34519,7 @@ pub mod builder {
     impl<'a> SagaList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -35101,7 +34563,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SagaResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -35109,40 +34571,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/sagas", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/system/sagas", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -35208,14 +34667,14 @@ pub mod builder {
     ///[`Client::saga_view`]: super::Client::saga_view
     #[derive(Debug, Clone)]
     pub struct SagaView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         saga_id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> SagaView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 saga_id: Err("saga_id was not initialized".to_string()),
             }
         }
@@ -35232,38 +34691,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/sagas/{saga_id}`
         pub async fn send(self) -> Result<ResponseValue<types::Saga>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                saga_id,
-            } = self;
+            let Self { _client, saga_id } = self;
             let saga_id = saga_id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/sagas/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&saga_id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -35273,7 +34726,7 @@ pub mod builder {
     ///[`Client::silo_list`]: super::Client::silo_list
     #[derive(Debug, Clone)]
     pub struct SiloList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameOrIdSortMode>, String>,
@@ -35282,7 +34735,7 @@ pub mod builder {
     impl<'a> SiloList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -35326,7 +34779,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SiloResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -35334,40 +34787,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/silos", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/system/silos", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -35433,14 +34883,14 @@ pub mod builder {
     ///[`Client::silo_create`]: super::Client::silo_create
     #[derive(Debug, Clone)]
     pub struct SiloCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::SiloCreate, String>,
     }
 
     impl<'a> SiloCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::SiloCreate::default()),
             }
         }
@@ -35466,37 +34916,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/system/silos`
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SiloCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/silos", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/system/silos", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -35506,14 +34950,14 @@ pub mod builder {
     ///[`Client::silo_view`]: super::Client::silo_view
     #[derive(Debug, Clone)]
     pub struct SiloView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
     }
 
     impl<'a> SiloView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
@@ -35530,38 +34974,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/silos/{silo_name}`
         pub async fn send(self) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                silo_name,
-            } = self;
+            let Self { _client, silo_name } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/silos/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -35571,14 +35009,14 @@ pub mod builder {
     ///[`Client::silo_delete`]: super::Client::silo_delete
     #[derive(Debug, Clone)]
     pub struct SiloDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
     }
 
     impl<'a> SiloDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
@@ -35595,38 +35033,32 @@ pub mod builder {
 
         ///Sends a `DELETE` request to `/system/silos/{silo_name}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                silo_name,
-            } = self;
+            let Self { _client, silo_name } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/silos/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -35636,7 +35068,7 @@ pub mod builder {
     ///[`Client::silo_identity_provider_list`]: super::Client::silo_identity_provider_list
     #[derive(Debug, Clone)]
     pub struct SiloIdentityProviderList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -35646,7 +35078,7 @@ pub mod builder {
     impl<'a> SiloIdentityProviderList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -35703,7 +35135,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::IdentityProviderResultsPage>, Error<types::Error>>
         {
             let Self {
-                __progenitor_client,
+                _client,
                 silo_name,
                 limit,
                 page_token,
@@ -35713,44 +35145,41 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/silos/{}/identity-providers",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -35817,7 +35246,7 @@ pub mod builder {
     ///[`Client::local_idp_user_create`]: super::Client::local_idp_user_create
     #[derive(Debug, Clone)]
     pub struct LocalIdpUserCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         body: Result<types::builder::UserCreate, String>,
     }
@@ -35825,7 +35254,7 @@ pub mod builder {
     impl<'a> LocalIdpUserCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(types::builder::UserCreate::default()),
             }
@@ -35864,7 +35293,7 @@ pub mod builder {
         /// `/system/silos/{silo_name}/identity-providers/local/users`
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 silo_name,
                 body,
             } = self;
@@ -35872,34 +35301,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::UserCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/silos/{}/identity-providers/local/users",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -35909,7 +35335,7 @@ pub mod builder {
     ///[`Client::local_idp_user_delete`]: super::Client::local_idp_user_delete
     #[derive(Debug, Clone)]
     pub struct LocalIdpUserDelete<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         user_id: Result<uuid::Uuid, String>,
     }
@@ -35917,7 +35343,7 @@ pub mod builder {
     impl<'a> LocalIdpUserDelete<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 user_id: Err("user_id was not initialized".to_string()),
             }
@@ -35947,40 +35373,37 @@ pub mod builder {
         /// `/system/silos/{silo_name}/identity-providers/local/users/{user_id}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 silo_name,
                 user_id,
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let user_id = user_id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/silos/{}/identity-providers/local/users/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -35990,7 +35413,7 @@ pub mod builder {
     ///[`Client::local_idp_user_set_password`]: super::Client::local_idp_user_set_password
     #[derive(Debug, Clone)]
     pub struct LocalIdpUserSetPassword<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         user_id: Result<uuid::Uuid, String>,
         body: Result<types::UserPassword, String>,
@@ -35999,7 +35422,7 @@ pub mod builder {
     impl<'a> LocalIdpUserSetPassword<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 user_id: Err("user_id was not initialized".to_string()),
                 body: Err("body was not initialized".to_string()),
@@ -36041,7 +35464,7 @@ pub mod builder {
         /// set-password`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 silo_name,
                 user_id,
                 body,
@@ -36049,35 +35472,32 @@ pub mod builder {
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let user_id = user_id.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/silos/{}/identity-providers/local/users/{}/set-password",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -36087,7 +35507,7 @@ pub mod builder {
     ///[`Client::saml_identity_provider_create`]: super::Client::saml_identity_provider_create
     #[derive(Debug, Clone)]
     pub struct SamlIdentityProviderCreate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         body: Result<types::builder::SamlIdentityProviderCreate, String>,
     }
@@ -36095,7 +35515,7 @@ pub mod builder {
     impl<'a> SamlIdentityProviderCreate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(types::builder::SamlIdentityProviderCreate::default()),
             }
@@ -36137,7 +35557,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SamlIdentityProvider>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 silo_name,
                 body,
             } = self;
@@ -36145,34 +35565,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::SamlIdentityProviderCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/silos/{}/identity-providers/saml",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -36182,7 +35599,7 @@ pub mod builder {
     ///[`Client::saml_identity_provider_view`]: super::Client::saml_identity_provider_view
     #[derive(Debug, Clone)]
     pub struct SamlIdentityProviderView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         provider_name: Result<types::Name, String>,
     }
@@ -36190,7 +35607,7 @@ pub mod builder {
     impl<'a> SamlIdentityProviderView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 provider_name: Err("provider_name was not initialized".to_string()),
             }
@@ -36222,40 +35639,37 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SamlIdentityProvider>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 silo_name,
                 provider_name,
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let provider_name = provider_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/silos/{}/identity-providers/saml/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&provider_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -36265,14 +35679,14 @@ pub mod builder {
     ///[`Client::silo_policy_view`]: super::Client::silo_policy_view
     #[derive(Debug, Clone)]
     pub struct SiloPolicyView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
     }
 
     impl<'a> SiloPolicyView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
             }
         }
@@ -36291,38 +35705,32 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                silo_name,
-            } = self;
+            let Self { _client, silo_name } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/silos/{}/policy",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -36332,7 +35740,7 @@ pub mod builder {
     ///[`Client::silo_policy_update`]: super::Client::silo_policy_update
     #[derive(Debug, Clone)]
     pub struct SiloPolicyUpdate<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         body: Result<types::builder::SiloRolePolicy, String>,
     }
@@ -36340,7 +35748,7 @@ pub mod builder {
     impl<'a> SiloPolicyUpdate<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 body: Ok(types::builder::SiloRolePolicy::default()),
             }
@@ -36380,7 +35788,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 silo_name,
                 body,
             } = self;
@@ -36388,34 +35796,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::SiloRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/silos/{}/policy",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -36425,7 +35830,7 @@ pub mod builder {
     ///[`Client::silo_users_list`]: super::Client::silo_users_list
     #[derive(Debug, Clone)]
     pub struct SiloUsersList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
@@ -36435,7 +35840,7 @@ pub mod builder {
     impl<'a> SiloUsersList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 limit: Ok(None),
                 page_token: Ok(None),
@@ -36490,7 +35895,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 silo_name,
                 limit,
                 page_token,
@@ -36500,44 +35905,41 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/silos/{}/users/all",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -36603,7 +36005,7 @@ pub mod builder {
     ///[`Client::silo_user_view`]: super::Client::silo_user_view
     #[derive(Debug, Clone)]
     pub struct SiloUserView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         silo_name: Result<types::Name, String>,
         user_id: Result<uuid::Uuid, String>,
     }
@@ -36611,7 +36013,7 @@ pub mod builder {
     impl<'a> SiloUserView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 silo_name: Err("silo_name was not initialized".to_string()),
                 user_id: Err("user_id was not initialized".to_string()),
             }
@@ -36641,40 +36043,37 @@ pub mod builder {
         /// `/system/silos/{silo_name}/users/id/{user_id}`
         pub async fn send(self) -> Result<ResponseValue<types::User>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 silo_name,
                 user_id,
             } = self;
             let silo_name = silo_name.map_err(Error::InvalidRequest)?;
             let user_id = user_id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/silos/{}/users/id/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&silo_name.to_string()),
                 encode_path(&user_id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -36684,7 +36083,7 @@ pub mod builder {
     ///[`Client::system_user_list`]: super::Client::system_user_list
     #[derive(Debug, Clone)]
     pub struct SystemUserList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameSortMode>, String>,
@@ -36693,7 +36092,7 @@ pub mod builder {
     impl<'a> SystemUserList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -36737,7 +36136,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::UserBuiltinResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -36745,40 +36144,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/system/user", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/system/user", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -36844,14 +36240,14 @@ pub mod builder {
     ///[`Client::system_user_view`]: super::Client::system_user_view
     #[derive(Debug, Clone)]
     pub struct SystemUserView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         user_name: Result<types::Name, String>,
     }
 
     impl<'a> SystemUserView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 user_name: Err("user_name was not initialized".to_string()),
             }
         }
@@ -36868,38 +36264,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/system/user/{user_name}`
         pub async fn send(self) -> Result<ResponseValue<types::UserBuiltin>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                user_name,
-            } = self;
+            let Self { _client, user_name } = self;
             let user_name = user_name.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/system/user/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&user_name.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -36909,7 +36299,7 @@ pub mod builder {
     ///[`Client::timeseries_schema_get`]: super::Client::timeseries_schema_get
     #[derive(Debug, Clone)]
     pub struct TimeseriesSchemaGet<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
     }
@@ -36917,7 +36307,7 @@ pub mod builder {
     impl<'a> TimeseriesSchemaGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
             }
@@ -36950,43 +36340,40 @@ pub mod builder {
         ) -> Result<ResponseValue<types::TimeseriesSchemaResultsPage>, Error<types::Error>>
         {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
             } = self;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/timeseries/schema", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let _url = format!("{}/timeseries/schema", _client.baseurl,);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -37051,7 +36438,7 @@ pub mod builder {
     ///[`Client::user_list`]: super::Client::user_list
     #[derive(Debug, Clone)]
     pub struct UserList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -37060,7 +36447,7 @@ pub mod builder {
     impl<'a> UserList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -37104,7 +36491,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -37112,40 +36499,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/users", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/users", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -37211,7 +36595,7 @@ pub mod builder {
     ///[`Client::disk_list_v1`]: super::Client::disk_list_v1
     #[derive(Debug, Clone)]
     pub struct DiskListV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         organization: Result<Option<types::NameOrId>, String>,
         page_token: Result<Option<String>, String>,
@@ -37222,7 +36606,7 @@ pub mod builder {
     impl<'a> DiskListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 organization: Ok(None),
                 page_token: Ok(None),
@@ -37290,7 +36674,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 organization,
                 page_token,
@@ -37302,46 +36686,43 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/disks", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(5usize);
+            let _url = format!("{}/v1/disks", _client.baseurl,);
+            let mut _query = Vec::with_capacity(5usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -37409,7 +36790,7 @@ pub mod builder {
     ///[`Client::disk_create_v1`]: super::Client::disk_create_v1
     #[derive(Debug, Clone)]
     pub struct DiskCreateV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<types::NameOrId, String>,
         body: Result<types::builder::DiskCreate, String>,
@@ -37418,7 +36799,7 @@ pub mod builder {
     impl<'a> DiskCreateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization: Ok(None),
                 project: Err("project was not initialized".to_string()),
                 body: Ok(types::builder::DiskCreate::default()),
@@ -37468,7 +36849,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/disks`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization,
                 project,
                 body,
@@ -37478,36 +36859,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/disks", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let _url = format!("{}/v1/disks", _client.baseurl,);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
-            __progenitor_query.push(("project", project.to_string()));
-            let __progenitor_request = __progenitor_client
+            _query.push(("project", project.to_string()));
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -37517,7 +36895,7 @@ pub mod builder {
     ///[`Client::disk_view_v1`]: super::Client::disk_view_v1
     #[derive(Debug, Clone)]
     pub struct DiskViewV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         disk: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -37526,7 +36904,7 @@ pub mod builder {
     impl<'a> DiskViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 disk: Err("disk was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -37568,7 +36946,7 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/disks/{disk}`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 disk,
                 organization,
                 project,
@@ -37576,41 +36954,38 @@ pub mod builder {
             let disk = disk.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/disks/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&disk.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -37620,7 +36995,7 @@ pub mod builder {
     ///[`Client::disk_delete_v1`]: super::Client::disk_delete_v1
     #[derive(Debug, Clone)]
     pub struct DiskDeleteV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         disk: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -37629,7 +37004,7 @@ pub mod builder {
     impl<'a> DiskDeleteV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 disk: Err("disk was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -37671,7 +37046,7 @@ pub mod builder {
         ///Sends a `DELETE` request to `/v1/disks/{disk}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 disk,
                 organization,
                 project,
@@ -37679,41 +37054,38 @@ pub mod builder {
             let disk = disk.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/disks/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&disk.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -37723,7 +37095,7 @@ pub mod builder {
     ///[`Client::instance_list_v1`]: super::Client::instance_list_v1
     #[derive(Debug, Clone)]
     pub struct InstanceListV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         organization: Result<Option<types::NameOrId>, String>,
         page_token: Result<Option<String>, String>,
@@ -37734,7 +37106,7 @@ pub mod builder {
     impl<'a> InstanceListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 organization: Ok(None),
                 page_token: Ok(None),
@@ -37802,7 +37174,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 organization,
                 page_token,
@@ -37814,46 +37186,43 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/instances", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(5usize);
+            let _url = format!("{}/v1/instances", _client.baseurl,);
+            let mut _query = Vec::with_capacity(5usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -37921,7 +37290,7 @@ pub mod builder {
     ///[`Client::instance_create_v1`]: super::Client::instance_create_v1
     #[derive(Debug, Clone)]
     pub struct InstanceCreateV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<types::NameOrId, String>,
         body: Result<types::builder::InstanceCreate, String>,
@@ -37930,7 +37299,7 @@ pub mod builder {
     impl<'a> InstanceCreateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization: Ok(None),
                 project: Err("project was not initialized".to_string()),
                 body: Ok(types::builder::InstanceCreate::default()),
@@ -37980,7 +37349,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization,
                 project,
                 body,
@@ -37990,36 +37359,33 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/instances", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let _url = format!("{}/v1/instances", _client.baseurl,);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
-            __progenitor_query.push(("project", project.to_string()));
-            let __progenitor_request = __progenitor_client
+            _query.push(("project", project.to_string()));
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -38029,7 +37395,7 @@ pub mod builder {
     ///[`Client::instance_view_v1`]: super::Client::instance_view_v1
     #[derive(Debug, Clone)]
     pub struct InstanceViewV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38038,7 +37404,7 @@ pub mod builder {
     impl<'a> InstanceViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38080,7 +37446,7 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/instances/{instance}`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 instance,
                 organization,
                 project,
@@ -38088,41 +37454,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/instances/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -38132,7 +37495,7 @@ pub mod builder {
     ///[`Client::instance_delete_v1`]: super::Client::instance_delete_v1
     #[derive(Debug, Clone)]
     pub struct InstanceDeleteV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38141,7 +37504,7 @@ pub mod builder {
     impl<'a> InstanceDeleteV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38183,7 +37546,7 @@ pub mod builder {
         ///Sends a `DELETE` request to `/v1/instances/{instance}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 instance,
                 organization,
                 project,
@@ -38191,41 +37554,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/instances/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -38235,7 +37595,7 @@ pub mod builder {
     ///[`Client::instance_disk_list_v1`]: super::Client::instance_disk_list_v1
     #[derive(Debug, Clone)]
     pub struct InstanceDiskListV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         organization: Result<Option<types::NameOrId>, String>,
@@ -38247,7 +37607,7 @@ pub mod builder {
     impl<'a> InstanceDiskListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 instance: Err("instance was not initialized".to_string()),
                 limit: Ok(None),
                 organization: Ok(None),
@@ -38326,7 +37686,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 instance,
                 limit,
                 organization,
@@ -38340,50 +37700,47 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/instances/{}/disks",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(5usize);
+            let mut _query = Vec::with_capacity(5usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -38451,7 +37808,7 @@ pub mod builder {
     ///[`Client::instance_disk_attach_v1`]: super::Client::instance_disk_attach_v1
     #[derive(Debug, Clone)]
     pub struct InstanceDiskAttachV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38461,7 +37818,7 @@ pub mod builder {
     impl<'a> InstanceDiskAttachV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38523,7 +37880,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/disks/attach`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 instance,
                 organization,
                 project,
@@ -38535,42 +37892,39 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskPath>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/instances/{}/disks/attach",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                202u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                202u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -38580,7 +37934,7 @@ pub mod builder {
     ///[`Client::instance_disk_detach_v1`]: super::Client::instance_disk_detach_v1
     #[derive(Debug, Clone)]
     pub struct InstanceDiskDetachV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38590,7 +37944,7 @@ pub mod builder {
     impl<'a> InstanceDiskDetachV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38652,7 +38006,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/disks/detach`
         pub async fn send(self) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 instance,
                 organization,
                 project,
@@ -38664,42 +38018,39 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::DiskPath>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/instances/{}/disks/detach",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                202u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                202u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -38709,7 +38060,7 @@ pub mod builder {
     ///[`Client::instance_migrate_v1`]: super::Client::instance_migrate_v1
     #[derive(Debug, Clone)]
     pub struct InstanceMigrateV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38719,7 +38070,7 @@ pub mod builder {
     impl<'a> InstanceMigrateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38781,7 +38132,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/migrate`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 instance,
                 organization,
                 project,
@@ -38793,42 +38144,39 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceMigrate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/instances/{}/migrate",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -38838,7 +38186,7 @@ pub mod builder {
     ///[`Client::instance_reboot_v1`]: super::Client::instance_reboot_v1
     #[derive(Debug, Clone)]
     pub struct InstanceRebootV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -38847,7 +38195,7 @@ pub mod builder {
     impl<'a> InstanceRebootV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -38889,7 +38237,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/reboot`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 instance,
                 organization,
                 project,
@@ -38897,41 +38245,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/instances/{}/reboot",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                202u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                202u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -38941,7 +38286,7 @@ pub mod builder {
     ///[`Client::instance_serial_console_v1`]: super::Client::instance_serial_console_v1
     #[derive(Debug, Clone)]
     pub struct InstanceSerialConsoleV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         from_start: Result<Option<u64>, String>,
         max_bytes: Result<Option<u64>, String>,
@@ -38953,7 +38298,7 @@ pub mod builder {
     impl<'a> InstanceSerialConsoleV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 instance: Err("instance was not initialized".to_string()),
                 from_start: Ok(None),
                 max_bytes: Ok(None),
@@ -39033,7 +38378,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceSerialConsoleData>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 instance,
                 from_start,
                 max_bytes,
@@ -39047,50 +38392,47 @@ pub mod builder {
             let most_recent = most_recent.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/instances/{}/serial-console",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(5usize);
+            let mut _query = Vec::with_capacity(5usize);
             if let Some(v) = &from_start {
-                __progenitor_query.push(("from_start", v.to_string()));
+                _query.push(("from_start", v.to_string()));
             }
             if let Some(v) = &max_bytes {
-                __progenitor_query.push(("max_bytes", v.to_string()));
+                _query.push(("max_bytes", v.to_string()));
             }
             if let Some(v) = &most_recent {
-                __progenitor_query.push(("most_recent", v.to_string()));
+                _query.push(("most_recent", v.to_string()));
             }
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -39100,7 +38442,7 @@ pub mod builder {
     ///[`Client::instance_serial_console_stream_v1`]: super::Client::instance_serial_console_stream_v1
     #[derive(Debug, Clone)]
     pub struct InstanceSerialConsoleStreamV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -39109,7 +38451,7 @@ pub mod builder {
     impl<'a> InstanceSerialConsoleStreamV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -39154,7 +38496,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
             let Self {
-                __progenitor_client,
+                _client,
                 instance,
                 organization,
                 project,
@@ -39162,22 +38504,22 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/instances/{}/serial-console/stream",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
-                .query(&__progenitor_query)
+                .get(_url)
+                .query(&_query)
                 .header(reqwest::header::CONNECTION, "Upgrade")
                 .header(reqwest::header::UPGRADE, "websocket")
                 .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -39189,15 +38531,12 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                101u16 => ResponseValue::upgrade(__progenitor_response).await,
-                200..=299 => ResponseValue::upgrade(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                101u16 => ResponseValue::upgrade(_response).await,
+                200..=299 => ResponseValue::upgrade(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -39207,7 +38546,7 @@ pub mod builder {
     ///[`Client::instance_start_v1`]: super::Client::instance_start_v1
     #[derive(Debug, Clone)]
     pub struct InstanceStartV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -39216,7 +38555,7 @@ pub mod builder {
     impl<'a> InstanceStartV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -39258,7 +38597,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/start`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 instance,
                 organization,
                 project,
@@ -39266,41 +38605,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/instances/{}/start",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                202u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                202u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -39310,7 +38646,7 @@ pub mod builder {
     ///[`Client::instance_stop_v1`]: super::Client::instance_stop_v1
     #[derive(Debug, Clone)]
     pub struct InstanceStopV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         instance: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         project: Result<Option<types::NameOrId>, String>,
@@ -39319,7 +38655,7 @@ pub mod builder {
     impl<'a> InstanceStopV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 instance: Err("instance was not initialized".to_string()),
                 organization: Ok(None),
                 project: Ok(None),
@@ -39361,7 +38697,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/instances/{instance}/stop`
         pub async fn send(self) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 instance,
                 organization,
                 project,
@@ -39369,41 +38705,38 @@ pub mod builder {
             let instance = instance.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
             let project = project.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/instances/{}/stop",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&instance.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &project {
-                __progenitor_query.push(("project", v.to_string()));
+                _query.push(("project", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                202u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                202u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -39413,7 +38746,7 @@ pub mod builder {
     ///[`Client::organization_list_v1`]: super::Client::organization_list_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationListV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::NameOrIdSortMode>, String>,
@@ -39422,7 +38755,7 @@ pub mod builder {
     impl<'a> OrganizationListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -39466,7 +38799,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -39474,40 +38807,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/organizations", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/v1/organizations", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -39573,14 +38903,14 @@ pub mod builder {
     ///[`Client::organization_create_v1`]: super::Client::organization_create_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationCreateV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::OrganizationCreate, String>,
     }
 
     impl<'a> OrganizationCreateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::OrganizationCreate::default()),
             }
         }
@@ -39608,37 +38938,31 @@ pub mod builder {
 
         ///Sends a `POST` request to `/v1/organizations`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/organizations", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/v1/organizations", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -39648,14 +38972,14 @@ pub mod builder {
     ///[`Client::organization_view_v1`]: super::Client::organization_view_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationViewV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
     }
 
     impl<'a> OrganizationViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization: Err("organization was not initialized".to_string()),
             }
         }
@@ -39673,37 +38997,34 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/organizations/{organization}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization,
             } = self;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/organizations/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -39713,7 +39034,7 @@ pub mod builder {
     ///[`Client::organization_update_v1`]: super::Client::organization_update_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationUpdateV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
         body: Result<types::builder::OrganizationUpdate, String>,
     }
@@ -39721,7 +39042,7 @@ pub mod builder {
     impl<'a> OrganizationUpdateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization: Err("organization was not initialized".to_string()),
                 body: Ok(types::builder::OrganizationUpdate::default()),
             }
@@ -39761,7 +39082,7 @@ pub mod builder {
         ///Sends a `PUT` request to `/v1/organizations/{organization}`
         pub async fn send(self) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization,
                 body,
             } = self;
@@ -39769,34 +39090,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/organizations/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -39806,14 +39124,14 @@ pub mod builder {
     ///[`Client::organization_delete_v1`]: super::Client::organization_delete_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationDeleteV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
     }
 
     impl<'a> OrganizationDeleteV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization: Err("organization was not initialized".to_string()),
             }
         }
@@ -39831,37 +39149,34 @@ pub mod builder {
         ///Sends a `DELETE` request to `/v1/organizations/{organization}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization,
             } = self;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/organizations/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -39871,14 +39186,14 @@ pub mod builder {
     ///[`Client::organization_policy_view_v1`]: super::Client::organization_policy_view_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationPolicyViewV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
     }
 
     impl<'a> OrganizationPolicyViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization: Err("organization was not initialized".to_string()),
             }
         }
@@ -39898,37 +39213,34 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization,
             } = self;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/organizations/{}/policy",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -39938,7 +39250,7 @@ pub mod builder {
     ///[`Client::organization_policy_update_v1`]: super::Client::organization_policy_update_v1
     #[derive(Debug, Clone)]
     pub struct OrganizationPolicyUpdateV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
         body: Result<types::builder::OrganizationRolePolicy, String>,
     }
@@ -39946,7 +39258,7 @@ pub mod builder {
     impl<'a> OrganizationPolicyUpdateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization: Err("organization was not initialized".to_string()),
                 body: Ok(types::builder::OrganizationRolePolicy::default()),
             }
@@ -39988,7 +39300,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization,
                 body,
             } = self;
@@ -39996,34 +39308,31 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::OrganizationRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/organizations/{}/policy",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&organization.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -40033,7 +39342,7 @@ pub mod builder {
     ///[`Client::project_list_v1`]: super::Client::project_list_v1
     #[derive(Debug, Clone)]
     pub struct ProjectListV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         organization: Result<Option<types::NameOrId>, String>,
         page_token: Result<Option<String>, String>,
@@ -40043,7 +39352,7 @@ pub mod builder {
     impl<'a> ProjectListV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 organization: Ok(None),
                 page_token: Ok(None),
@@ -40099,7 +39408,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 organization,
                 page_token,
@@ -40109,43 +39418,40 @@ pub mod builder {
             let organization = organization.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/projects", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(4usize);
+            let _url = format!("{}/v1/projects", _client.baseurl,);
+            let mut _query = Vec::with_capacity(4usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -40212,7 +39518,7 @@ pub mod builder {
     ///[`Client::project_create_v1`]: super::Client::project_create_v1
     #[derive(Debug, Clone)]
     pub struct ProjectCreateV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         organization: Result<types::NameOrId, String>,
         body: Result<types::builder::ProjectCreate, String>,
     }
@@ -40220,7 +39526,7 @@ pub mod builder {
     impl<'a> ProjectCreateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 organization: Err("organization was not initialized".to_string()),
                 body: Ok(types::builder::ProjectCreate::default()),
             }
@@ -40258,7 +39564,7 @@ pub mod builder {
         ///Sends a `POST` request to `/v1/projects`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 organization,
                 body,
             } = self;
@@ -40266,33 +39572,30 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectCreate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/v1/projects", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(1usize);
-            __progenitor_query.push(("organization", organization.to_string()));
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/v1/projects", _client.baseurl,);
+            let mut _query = Vec::with_capacity(1usize);
+            _query.push(("organization", organization.to_string()));
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -40302,7 +39605,7 @@ pub mod builder {
     ///[`Client::project_view_v1`]: super::Client::project_view_v1
     #[derive(Debug, Clone)]
     pub struct ProjectViewV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
     }
@@ -40310,7 +39613,7 @@ pub mod builder {
     impl<'a> ProjectViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
             }
@@ -40340,44 +39643,41 @@ pub mod builder {
         ///Sends a `GET` request to `/v1/projects/{project}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 project,
                 organization,
             } = self;
             let project = project.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/projects/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(1usize);
+            let mut _query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -40387,7 +39687,7 @@ pub mod builder {
     ///[`Client::project_update_v1`]: super::Client::project_update_v1
     #[derive(Debug, Clone)]
     pub struct ProjectUpdateV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         body: Result<types::builder::ProjectUpdate, String>,
@@ -40396,7 +39696,7 @@ pub mod builder {
     impl<'a> ProjectUpdateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
                 body: Ok(types::builder::ProjectUpdate::default()),
@@ -40446,7 +39746,7 @@ pub mod builder {
         ///Sends a `PUT` request to `/v1/projects/{project}`
         pub async fn send(self) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 project,
                 organization,
                 body,
@@ -40456,39 +39756,36 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectUpdate>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/projects/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(1usize);
+            let mut _query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -40498,7 +39795,7 @@ pub mod builder {
     ///[`Client::project_delete_v1`]: super::Client::project_delete_v1
     #[derive(Debug, Clone)]
     pub struct ProjectDeleteV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
     }
@@ -40506,7 +39803,7 @@ pub mod builder {
     impl<'a> ProjectDeleteV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
             }
@@ -40536,44 +39833,41 @@ pub mod builder {
         ///Sends a `DELETE` request to `/v1/projects/{project}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 project,
                 organization,
             } = self;
             let project = project.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/projects/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(1usize);
+            let mut _query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .delete(__progenitor_url)
+                .delete(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -40583,7 +39877,7 @@ pub mod builder {
     ///[`Client::project_policy_view_v1`]: super::Client::project_policy_view_v1
     #[derive(Debug, Clone)]
     pub struct ProjectPolicyViewV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
     }
@@ -40591,7 +39885,7 @@ pub mod builder {
     impl<'a> ProjectPolicyViewV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
             }
@@ -40623,44 +39917,41 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 project,
                 organization,
             } = self;
             let project = project.map_err(Error::InvalidRequest)?;
             let organization = organization.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/projects/{}/policy",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(1usize);
+            let mut _query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -40670,7 +39961,7 @@ pub mod builder {
     ///[`Client::project_policy_update_v1`]: super::Client::project_policy_update_v1
     #[derive(Debug, Clone)]
     pub struct ProjectPolicyUpdateV1<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         project: Result<types::NameOrId, String>,
         organization: Result<Option<types::NameOrId>, String>,
         body: Result<types::builder::ProjectRolePolicy, String>,
@@ -40679,7 +39970,7 @@ pub mod builder {
     impl<'a> ProjectPolicyUpdateV1<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 project: Err("project was not initialized".to_string()),
                 organization: Ok(None),
                 body: Ok(types::builder::ProjectRolePolicy::default()),
@@ -40733,7 +40024,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 project,
                 organization,
                 body,
@@ -40743,39 +40034,36 @@ pub mod builder {
             let body = body
                 .and_then(std::convert::TryInto::<types::ProjectRolePolicy>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/projects/{}/policy",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&project.to_string()),
             );
-            let mut __progenitor_query = Vec::with_capacity(1usize);
+            let mut _query = Vec::with_capacity(1usize);
             if let Some(v) = &organization {
-                __progenitor_query.push(("organization", v.to_string()));
+                _query.push(("organization", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -40785,7 +40073,7 @@ pub mod builder {
     ///[`Client::system_component_version_list`]: super::Client::system_component_version_list
     #[derive(Debug, Clone)]
     pub struct SystemComponentVersionList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -40794,7 +40082,7 @@ pub mod builder {
     impl<'a> SystemComponentVersionList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -40839,7 +40127,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::UpdateableComponentResultsPage>, Error<types::Error>>
         {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -40847,43 +40135,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
-                "{}/v1/system/update/components",
-                __progenitor_client.baseurl,
-            );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/v1/system/update/components", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -40950,7 +40232,7 @@ pub mod builder {
     ///[`Client::update_deployments_list`]: super::Client::update_deployments_list
     #[derive(Debug, Clone)]
     pub struct UpdateDeploymentsList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -40959,7 +40241,7 @@ pub mod builder {
     impl<'a> UpdateDeploymentsList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -41004,7 +40286,7 @@ pub mod builder {
         ) -> Result<ResponseValue<types::UpdateDeploymentResultsPage>, Error<types::Error>>
         {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -41012,43 +40294,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
-                "{}/v1/system/update/deployments",
-                __progenitor_client.baseurl,
-            );
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/v1/system/update/deployments", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -41114,14 +40390,14 @@ pub mod builder {
     ///[`Client::update_deployment_view`]: super::Client::update_deployment_view
     #[derive(Debug, Clone)]
     pub struct UpdateDeploymentView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
     }
 
     impl<'a> UpdateDeploymentView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
             }
         }
@@ -41140,38 +40416,32 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                id,
-            } = self;
+            let Self { _client, id } = self;
             let id = id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/system/update/deployments/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -41181,45 +40451,37 @@ pub mod builder {
     ///[`Client::system_update_refresh`]: super::Client::system_update_refresh
     #[derive(Debug, Clone)]
     pub struct SystemUpdateRefresh<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> SystemUpdateRefresh<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `POST` request to `/v1/system/update/refresh`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url =
-                format!("{}/v1/system/update/refresh", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/v1/system/update/refresh", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -41229,14 +40491,14 @@ pub mod builder {
     ///[`Client::system_update_start`]: super::Client::system_update_start
     #[derive(Debug, Clone)]
     pub struct SystemUpdateStart<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::SystemUpdateStart, String>,
     }
 
     impl<'a> SystemUpdateStart<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::SystemUpdateStart::default()),
             }
         }
@@ -41266,38 +40528,31 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::SystemUpdateStart>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url =
-                format!("{}/v1/system/update/start", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/v1/system/update/start", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                202u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                202u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -41307,45 +40562,37 @@ pub mod builder {
     ///[`Client::system_update_stop`]: super::Client::system_update_stop
     #[derive(Debug, Clone)]
     pub struct SystemUpdateStop<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> SystemUpdateStop<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `POST` request to `/v1/system/update/stop`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url =
-                format!("{}/v1/system/update/stop", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/v1/system/update/stop", _client.baseurl,);
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -41355,7 +40602,7 @@ pub mod builder {
     ///[`Client::system_update_list`]: super::Client::system_update_list
     #[derive(Debug, Clone)]
     pub struct SystemUpdateList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         limit: Result<Option<std::num::NonZeroU32>, String>,
         page_token: Result<Option<String>, String>,
         sort_by: Result<Option<types::IdSortMode>, String>,
@@ -41364,7 +40611,7 @@ pub mod builder {
     impl<'a> SystemUpdateList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 limit: Ok(None),
                 page_token: Ok(None),
                 sort_by: Ok(None),
@@ -41408,7 +40655,7 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::SystemUpdateResultsPage>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 limit,
                 page_token,
                 sort_by,
@@ -41416,41 +40663,37 @@ pub mod builder {
             let limit = limit.map_err(Error::InvalidRequest)?;
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
-            let __progenitor_url =
-                format!("{}/v1/system/update/updates", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(3usize);
+            let _url = format!("{}/v1/system/update/updates", _client.baseurl,);
+            let mut _query = Vec::with_capacity(3usize);
             if let Some(v) = &limit {
-                __progenitor_query.push(("limit", v.to_string()));
+                _query.push(("limit", v.to_string()));
             }
             if let Some(v) = &page_token {
-                __progenitor_query.push(("page_token", v.to_string()));
+                _query.push(("page_token", v.to_string()));
             }
             if let Some(v) = &sort_by {
-                __progenitor_query.push(("sort_by", v.to_string()));
+                _query.push(("sort_by", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
-                .query(&__progenitor_query)
+                .query(&_query)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
 
@@ -41516,14 +40759,14 @@ pub mod builder {
     ///[`Client::system_update_view`]: super::Client::system_update_view
     #[derive(Debug, Clone)]
     pub struct SystemUpdateView<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         version: Result<types::SemverVersion, String>,
     }
 
     impl<'a> SystemUpdateView<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 version: Err("version was not initialized".to_string()),
             }
         }
@@ -41540,38 +40783,32 @@ pub mod builder {
 
         ///Sends a `GET` request to `/v1/system/update/updates/{version}`
         pub async fn send(self) -> Result<ResponseValue<types::SystemUpdate>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                version,
-            } = self;
+            let Self { _client, version } = self;
             let version = version.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/system/update/updates/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&version.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -41581,14 +40818,14 @@ pub mod builder {
     ///[`Client::system_update_components_list`]: super::Client::system_update_components_list
     #[derive(Debug, Clone)]
     pub struct SystemUpdateComponentsList<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         version: Result<types::SemverVersion, String>,
     }
 
     impl<'a> SystemUpdateComponentsList<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 version: Err("version was not initialized".to_string()),
             }
         }
@@ -41608,38 +40845,32 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::ComponentUpdateResultsPage>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                version,
-            } = self;
+            let Self { _client, version } = self;
             let version = version.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/v1/system/update/updates/{}/components",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&version.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -41649,47 +40880,39 @@ pub mod builder {
     ///[`Client::system_version`]: super::Client::system_version
     #[derive(Debug, Clone)]
     pub struct SystemVersion<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> SystemVersion<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `GET` request to `/v1/system/update/version`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::SystemVersion>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url =
-                format!("{}/v1/system/update/version", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/v1/system/update/version", _client.baseurl,);
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/nexus-positional.out
+++ b/progenitor-impl/tests/output/nexus-positional.out
@@ -5957,30 +5957,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/by-id/disks/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -5991,30 +5991,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/by-id/images/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -6025,30 +6025,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/by-id/instances/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -6059,30 +6059,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/by-id/network-interfaces/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -6095,30 +6095,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/by-id/organizations/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -6131,30 +6131,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/by-id/projects/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -6165,30 +6165,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/by-id/snapshots/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -6199,30 +6199,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/by-id/vpc-router-routes/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -6233,30 +6233,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/by-id/vpc-routers/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -6267,30 +6267,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/by-id/vpc-subnets/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -6301,30 +6301,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/by-id/vpcs/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -6339,13 +6339,13 @@ impl Client {
         &'a self,
         body: &'a types::DeviceAuthRequest,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-        let _url = format!("{}/device/auth", self.baseurl,);
-        let _request = self.client.post(_url).form_urlencoded(&body)?.build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200..=299 => Ok(ResponseValue::stream(_response)),
-            _ => Err(Error::ErrorResponse(ResponseValue::stream(_response))),
+        let url = format!("{}/device/auth", self.baseurl,);
+        let request = self.client.post(url).form_urlencoded(&body)?.build()?;
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200..=299 => Ok(ResponseValue::stream(response)),
+            _ => Err(Error::ErrorResponse(ResponseValue::stream(response))),
         }
     }
 
@@ -6361,27 +6361,27 @@ impl Client {
         &'a self,
         body: &'a types::DeviceAuthVerify,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!("{}/device/confirm", self.baseurl,);
-        let _request = self
+        let url = format!("{}/device/confirm", self.baseurl,);
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -6395,13 +6395,13 @@ impl Client {
         &'a self,
         body: &'a types::DeviceAccessTokenRequest,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-        let _url = format!("{}/device/token", self.baseurl,);
-        let _request = self.client.post(_url).form_urlencoded(&body)?.build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200..=299 => Ok(ResponseValue::stream(_response)),
-            _ => Err(Error::ErrorResponse(ResponseValue::stream(_response))),
+        let url = format!("{}/device/token", self.baseurl,);
+        let request = self.client.post(url).form_urlencoded(&body)?.build()?;
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200..=299 => Ok(ResponseValue::stream(response)),
+            _ => Err(Error::ErrorResponse(ResponseValue::stream(response))),
         }
     }
 
@@ -6420,40 +6420,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
-        let _url = format!("{}/groups", self.baseurl,);
-        let mut _query = Vec::with_capacity(3usize);
+        let url = format!("{}/groups", self.baseurl,);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -6507,27 +6507,27 @@ impl Client {
         &'a self,
         body: &'a types::SpoofLoginBody,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!("{}/login", self.baseurl,);
-        let _request = self
+        let url = format!("{}/login", self.baseurl,);
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -6539,23 +6539,23 @@ impl Client {
         silo_name: &'a types::Name,
         body: &'a types::UsernamePasswordCredentials,
     ) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/login/{}/local",
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let _request = self.client.post(_url).json(&body).build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200..=299 => Ok(ResponseValue::stream(_response)),
+        let request = self.client.post(url).json(&body).build()?;
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200..=299 => Ok(ResponseValue::stream(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -6570,24 +6570,24 @@ impl Client {
         silo_name: &'a types::Name,
         provider_name: &'a types::Name,
     ) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/login/{}/saml/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
             encode_path(&provider_name.to_string()),
         );
-        let _request = self.client.get(_url).build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200..=299 => Ok(ResponseValue::stream(_response)),
+        let request = self.client.get(url).build()?;
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200..=299 => Ok(ResponseValue::stream(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -6600,57 +6600,57 @@ impl Client {
         provider_name: &'a types::Name,
         body: B,
     ) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/login/{}/saml/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
             encode_path(&provider_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::CONTENT_TYPE,
                 reqwest::header::HeaderValue::from_static("application/octet-stream"),
             )
             .body(body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200..=299 => Ok(ResponseValue::stream(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200..=299 => Ok(ResponseValue::stream(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
     ///Sends a `POST` request to `/logout`
     pub async fn logout<'a>(&'a self) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!("{}/logout", self.baseurl,);
-        let _request = self
+        let url = format!("{}/logout", self.baseurl,);
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -6671,40 +6671,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
-        let _url = format!("{}/organizations", self.baseurl,);
-        let mut _query = Vec::with_capacity(3usize);
+        let url = format!("{}/organizations", self.baseurl,);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -6765,27 +6765,27 @@ impl Client {
         &'a self,
         body: &'a types::OrganizationCreate,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let _url = format!("{}/organizations", self.baseurl,);
-        let _request = self
+        let url = format!("{}/organizations", self.baseurl,);
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -6801,30 +6801,30 @@ impl Client {
         &'a self,
         organization_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -6842,31 +6842,31 @@ impl Client {
         organization_name: &'a types::Name,
         body: &'a types::OrganizationUpdate,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .put(_url)
+            .put(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -6882,30 +6882,30 @@ impl Client {
         &'a self,
         organization_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .delete(_url)
+            .delete(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -6921,30 +6921,30 @@ impl Client {
         &'a self,
         organization_name: &'a types::Name,
     ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/policy",
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -6962,31 +6962,31 @@ impl Client {
         organization_name: &'a types::Name,
         body: &'a types::OrganizationRolePolicy,
     ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/policy",
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .put(_url)
+            .put(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -7009,44 +7009,44 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects",
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let mut _query = Vec::with_capacity(3usize);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -7114,31 +7114,31 @@ impl Client {
         organization_name: &'a types::Name,
         body: &'a types::ProjectCreate,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects",
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -7157,31 +7157,31 @@ impl Client {
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -7202,32 +7202,32 @@ impl Client {
         project_name: &'a types::Name,
         body: &'a types::ProjectUpdate,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .put(_url)
+            .put(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -7246,31 +7246,31 @@ impl Client {
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .delete(_url)
+            .delete(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -7296,45 +7296,45 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/disks",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut _query = Vec::with_capacity(3usize);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -7411,32 +7411,32 @@ impl Client {
         project_name: &'a types::Name,
         body: &'a types::DiskCreate,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/disks",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -7453,32 +7453,32 @@ impl Client {
         project_name: &'a types::Name,
         disk_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/disks/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&disk_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -7493,32 +7493,32 @@ impl Client {
         project_name: &'a types::Name,
         disk_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/disks/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&disk_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .delete(_url)
+            .delete(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -7549,7 +7549,7 @@ impl Client {
         page_token: Option<&'a str>,
         start_time: Option<&'a chrono::DateTime<chrono::offset::Utc>>,
     ) -> Result<ResponseValue<types::MeasurementResultsPage>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/disks/{}/metrics/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -7557,43 +7557,43 @@ impl Client {
             encode_path(&disk_name.to_string()),
             encode_path(&metric_name.to_string()),
         );
-        let mut _query = Vec::with_capacity(4usize);
+        let mut query = Vec::with_capacity(4usize);
         if let Some(v) = &end_time {
-            _query.push(("end_time", v.to_string()));
+            query.push(("end_time", v.to_string()));
         }
 
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &start_time {
-            _query.push(("start_time", v.to_string()));
+            query.push(("start_time", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -7695,45 +7695,45 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::ImageResultsPage>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/images",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut _query = Vec::with_capacity(3usize);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -7813,32 +7813,32 @@ impl Client {
         project_name: &'a types::Name,
         body: &'a types::ImageCreate,
     ) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/images",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -7855,32 +7855,32 @@ impl Client {
         project_name: &'a types::Name,
         image_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/images/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&image_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -7899,32 +7899,32 @@ impl Client {
         project_name: &'a types::Name,
         image_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/images/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&image_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .delete(_url)
+            .delete(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -7948,45 +7948,45 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/instances",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut _query = Vec::with_capacity(3usize);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -8064,32 +8064,32 @@ impl Client {
         project_name: &'a types::Name,
         body: &'a types::InstanceCreate,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/instances",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -8106,32 +8106,32 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -8146,32 +8146,32 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .delete(_url)
+            .delete(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -8200,46 +8200,46 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/disks",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut _query = Vec::with_capacity(3usize);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -8325,33 +8325,33 @@ impl Client {
         instance_name: &'a types::Name,
         body: &'a types::DiskIdentifier,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/disks/attach",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            202u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            202u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -8369,33 +8369,33 @@ impl Client {
         instance_name: &'a types::Name,
         body: &'a types::DiskIdentifier,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/disks/detach",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            202u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            202u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -8410,32 +8410,32 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
     ) -> Result<ResponseValue<types::ExternalIpResultsPage>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/external-ips",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -8453,33 +8453,33 @@ impl Client {
         instance_name: &'a types::Name,
         body: &'a types::InstanceMigrate,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/migrate",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -8506,46 +8506,46 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::NetworkInterfaceResultsPage>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut _query = Vec::with_capacity(3usize);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -8628,33 +8628,33 @@ impl Client {
         instance_name: &'a types::Name,
         body: &'a types::NetworkInterfaceCreate,
     ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -8670,7 +8670,7 @@ impl Client {
         instance_name: &'a types::Name,
         interface_name: &'a types::Name,
     ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -8678,25 +8678,25 @@ impl Client {
             encode_path(&instance_name.to_string()),
             encode_path(&interface_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -8713,7 +8713,7 @@ impl Client {
         interface_name: &'a types::Name,
         body: &'a types::NetworkInterfaceUpdate,
     ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -8721,26 +8721,26 @@ impl Client {
             encode_path(&instance_name.to_string()),
             encode_path(&interface_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .put(_url)
+            .put(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -8761,7 +8761,7 @@ impl Client {
         instance_name: &'a types::Name,
         interface_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -8769,25 +8769,25 @@ impl Client {
             encode_path(&instance_name.to_string()),
             encode_path(&interface_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .delete(_url)
+            .delete(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -8804,32 +8804,32 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/reboot",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            202u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            202u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -8865,46 +8865,46 @@ impl Client {
         max_bytes: Option<u64>,
         most_recent: Option<u64>,
     ) -> Result<ResponseValue<types::InstanceSerialConsoleData>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/serial-console",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut _query = Vec::with_capacity(3usize);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &from_start {
-            _query.push(("from_start", v.to_string()));
+            query.push(("from_start", v.to_string()));
         }
 
         if let Some(v) = &max_bytes {
-            _query.push(("max_bytes", v.to_string()));
+            query.push(("max_bytes", v.to_string()));
         }
 
         if let Some(v) = &most_recent {
-            _query.push(("most_recent", v.to_string()));
+            query.push(("most_recent", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -8921,16 +8921,16 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
     ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/serial-console/stream",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(reqwest::header::CONNECTION, "Upgrade")
             .header(reqwest::header::UPGRADE, "websocket")
             .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -8942,12 +8942,12 @@ impl Client {
                 ),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            101u16 => ResponseValue::upgrade(_response).await,
-            200..=299 => ResponseValue::upgrade(_response).await,
-            _ => Err(Error::UnexpectedResponse(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            101u16 => ResponseValue::upgrade(response).await,
+            200..=299 => ResponseValue::upgrade(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -8964,32 +8964,32 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/start",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            202u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            202u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -9006,32 +9006,32 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/stop",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            202u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            202u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -9050,31 +9050,31 @@ impl Client {
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
     ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/policy",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -9093,32 +9093,32 @@ impl Client {
         project_name: &'a types::Name,
         body: &'a types::ProjectRolePolicy,
     ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/policy",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .put(_url)
+            .put(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -9142,45 +9142,45 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::SnapshotResultsPage>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/snapshots",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut _query = Vec::with_capacity(3usize);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -9258,32 +9258,32 @@ impl Client {
         project_name: &'a types::Name,
         body: &'a types::SnapshotCreate,
     ) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/snapshots",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -9298,32 +9298,32 @@ impl Client {
         project_name: &'a types::Name,
         snapshot_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/snapshots/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&snapshot_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -9338,32 +9338,32 @@ impl Client {
         project_name: &'a types::Name,
         snapshot_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/snapshots/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&snapshot_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .delete(_url)
+            .delete(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -9387,45 +9387,45 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::VpcResultsPage>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/vpcs",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut _query = Vec::with_capacity(3usize);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -9500,32 +9500,32 @@ impl Client {
         project_name: &'a types::Name,
         body: &'a types::VpcCreate,
     ) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/vpcs",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -9540,32 +9540,32 @@ impl Client {
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -9581,33 +9581,33 @@ impl Client {
         vpc_name: &'a types::Name,
         body: &'a types::VpcUpdate,
     ) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .put(_url)
+            .put(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -9622,32 +9622,32 @@ impl Client {
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .delete(_url)
+            .delete(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -9662,32 +9662,32 @@ impl Client {
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
     ) -> Result<ResponseValue<types::VpcFirewallRules>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -9703,33 +9703,33 @@ impl Client {
         vpc_name: &'a types::Name,
         body: &'a types::VpcFirewallRuleUpdateParams,
     ) -> Result<ResponseValue<types::VpcFirewallRules>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .put(_url)
+            .put(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -9756,46 +9756,46 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::VpcRouterResultsPage>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let mut _query = Vec::with_capacity(3usize);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -9878,33 +9878,33 @@ impl Client {
         vpc_name: &'a types::Name,
         body: &'a types::VpcRouterCreate,
     ) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -9920,7 +9920,7 @@ impl Client {
         vpc_name: &'a types::Name,
         router_name: &'a types::Name,
     ) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -9928,25 +9928,25 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -9963,7 +9963,7 @@ impl Client {
         router_name: &'a types::Name,
         body: &'a types::VpcRouterUpdate,
     ) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -9971,26 +9971,26 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .put(_url)
+            .put(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -10006,7 +10006,7 @@ impl Client {
         vpc_name: &'a types::Name,
         router_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10014,25 +10014,25 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .delete(_url)
+            .delete(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -10063,7 +10063,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::RouterRouteResultsPage>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10071,39 +10071,39 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
-        let mut _query = Vec::with_capacity(3usize);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -10194,7 +10194,7 @@ impl Client {
         router_name: &'a types::Name,
         body: &'a types::RouterRouteCreateParams,
     ) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10202,26 +10202,26 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -10238,7 +10238,7 @@ impl Client {
         router_name: &'a types::Name,
         route_name: &'a types::Name,
     ) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10247,25 +10247,25 @@ impl Client {
             encode_path(&router_name.to_string()),
             encode_path(&route_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -10283,7 +10283,7 @@ impl Client {
         route_name: &'a types::Name,
         body: &'a types::RouterRouteUpdateParams,
     ) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10292,26 +10292,26 @@ impl Client {
             encode_path(&router_name.to_string()),
             encode_path(&route_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .put(_url)
+            .put(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -10328,7 +10328,7 @@ impl Client {
         router_name: &'a types::Name,
         route_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10337,25 +10337,25 @@ impl Client {
             encode_path(&router_name.to_string()),
             encode_path(&route_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .delete(_url)
+            .delete(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -10382,46 +10382,46 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::VpcSubnetResultsPage>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let mut _query = Vec::with_capacity(3usize);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -10504,33 +10504,33 @@ impl Client {
         vpc_name: &'a types::Name,
         body: &'a types::VpcSubnetCreate,
     ) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -10546,7 +10546,7 @@ impl Client {
         vpc_name: &'a types::Name,
         subnet_name: &'a types::Name,
     ) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10554,25 +10554,25 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&subnet_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -10589,7 +10589,7 @@ impl Client {
         subnet_name: &'a types::Name,
         body: &'a types::VpcSubnetUpdate,
     ) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10597,26 +10597,26 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&subnet_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .put(_url)
+            .put(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -10632,7 +10632,7 @@ impl Client {
         vpc_name: &'a types::Name,
         subnet_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10640,25 +10640,25 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&subnet_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .delete(_url)
+            .delete(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -10687,7 +10687,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::NetworkInterfaceResultsPage>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}/network-interfaces",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10695,39 +10695,39 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&subnet_name.to_string()),
         );
-        let mut _query = Vec::with_capacity(3usize);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -10809,26 +10809,26 @@ impl Client {
     pub async fn policy_view<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-        let _url = format!("{}/policy", self.baseurl,);
-        let _request = self
+        let url = format!("{}/policy", self.baseurl,);
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -10839,27 +10839,27 @@ impl Client {
         &'a self,
         body: &'a types::SiloRolePolicy,
     ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-        let _url = format!("{}/policy", self.baseurl,);
-        let _request = self
+        let url = format!("{}/policy", self.baseurl,);
+        let request = self
             .client
-            .put(_url)
+            .put(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -10876,36 +10876,36 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::RoleResultsPage>, Error<types::Error>> {
-        let _url = format!("{}/roles", self.baseurl,);
-        let mut _query = Vec::with_capacity(2usize);
+        let url = format!("{}/roles", self.baseurl,);
+        let mut query = Vec::with_capacity(2usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -10962,30 +10962,30 @@ impl Client {
         &'a self,
         role_name: &'a str,
     ) -> Result<ResponseValue<types::Role>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/roles/{}",
             self.baseurl,
             encode_path(&role_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -10995,26 +10995,26 @@ impl Client {
     pub async fn session_me<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::User>, Error<types::Error>> {
-        let _url = format!("{}/session/me", self.baseurl,);
-        let _request = self
+        let url = format!("{}/session/me", self.baseurl,);
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -11033,40 +11033,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
-        let _url = format!("{}/session/me/groups", self.baseurl,);
-        let mut _query = Vec::with_capacity(3usize);
+        let url = format!("{}/session/me/groups", self.baseurl,);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -11132,40 +11132,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::SshKeyResultsPage>, Error<types::Error>> {
-        let _url = format!("{}/session/me/sshkeys", self.baseurl,);
-        let mut _query = Vec::with_capacity(3usize);
+        let url = format!("{}/session/me/sshkeys", self.baseurl,);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -11225,27 +11225,27 @@ impl Client {
         &'a self,
         body: &'a types::SshKeyCreate,
     ) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
-        let _url = format!("{}/session/me/sshkeys", self.baseurl,);
-        let _request = self
+        let url = format!("{}/session/me/sshkeys", self.baseurl,);
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -11259,30 +11259,30 @@ impl Client {
         &'a self,
         ssh_key_name: &'a types::Name,
     ) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/session/me/sshkeys/{}",
             self.baseurl,
             encode_path(&ssh_key_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -11296,30 +11296,30 @@ impl Client {
         &'a self,
         ssh_key_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/session/me/sshkeys/{}",
             self.baseurl,
             encode_path(&ssh_key_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .delete(_url)
+            .delete(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -11330,30 +11330,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/by-id/images/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -11364,30 +11364,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/by-id/ip-pools/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -11398,30 +11398,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/by-id/silos/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -11444,40 +11444,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::CertificateResultsPage>, Error<types::Error>> {
-        let _url = format!("{}/system/certificates", self.baseurl,);
-        let mut _query = Vec::with_capacity(3usize);
+        let url = format!("{}/system/certificates", self.baseurl,);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -11541,27 +11541,27 @@ impl Client {
         &'a self,
         body: &'a types::CertificateCreate,
     ) -> Result<ResponseValue<types::Certificate>, Error<types::Error>> {
-        let _url = format!("{}/system/certificates", self.baseurl,);
-        let _request = self
+        let url = format!("{}/system/certificates", self.baseurl,);
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -11574,30 +11574,30 @@ impl Client {
         &'a self,
         certificate: &'a types::NameOrId,
     ) -> Result<ResponseValue<types::Certificate>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/certificates/{}",
             self.baseurl,
             encode_path(&certificate.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -11610,30 +11610,30 @@ impl Client {
         &'a self,
         certificate: &'a types::NameOrId,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/certificates/{}",
             self.baseurl,
             encode_path(&certificate.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .delete(_url)
+            .delete(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -11652,40 +11652,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::PhysicalDiskResultsPage>, Error<types::Error>> {
-        let _url = format!("{}/system/hardware/disks", self.baseurl,);
-        let mut _query = Vec::with_capacity(3usize);
+        let url = format!("{}/system/hardware/disks", self.baseurl,);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -11750,40 +11750,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::RackResultsPage>, Error<types::Error>> {
-        let _url = format!("{}/system/hardware/racks", self.baseurl,);
-        let mut _query = Vec::with_capacity(3usize);
+        let url = format!("{}/system/hardware/racks", self.baseurl,);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -11842,30 +11842,30 @@ impl Client {
         &'a self,
         rack_id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Rack>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/hardware/racks/{}",
             self.baseurl,
             encode_path(&rack_id.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -11884,40 +11884,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SledResultsPage>, Error<types::Error>> {
-        let _url = format!("{}/system/hardware/sleds", self.baseurl,);
-        let mut _query = Vec::with_capacity(3usize);
+        let url = format!("{}/system/hardware/sleds", self.baseurl,);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -11976,30 +11976,30 @@ impl Client {
         &'a self,
         sled_id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Sled>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/hardware/sleds/{}",
             self.baseurl,
             encode_path(&sled_id.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -12020,44 +12020,44 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::PhysicalDiskResultsPage>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/hardware/sleds/{}/disks",
             self.baseurl,
             encode_path(&sled_id.to_string()),
         );
-        let mut _query = Vec::with_capacity(3usize);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -12129,40 +12129,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::GlobalImageResultsPage>, Error<types::Error>> {
-        let _url = format!("{}/system/images", self.baseurl,);
-        let mut _query = Vec::with_capacity(3usize);
+        let url = format!("{}/system/images", self.baseurl,);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -12226,27 +12226,27 @@ impl Client {
         &'a self,
         body: &'a types::GlobalImageCreate,
     ) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-        let _url = format!("{}/system/images", self.baseurl,);
-        let _request = self
+        let url = format!("{}/system/images", self.baseurl,);
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -12259,30 +12259,30 @@ impl Client {
         &'a self,
         image_name: &'a types::Name,
     ) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/images/{}",
             self.baseurl,
             encode_path(&image_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -12297,30 +12297,30 @@ impl Client {
         &'a self,
         image_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/images/{}",
             self.baseurl,
             encode_path(&image_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .delete(_url)
+            .delete(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -12339,40 +12339,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::IpPoolResultsPage>, Error<types::Error>> {
-        let _url = format!("{}/system/ip-pools", self.baseurl,);
-        let mut _query = Vec::with_capacity(3usize);
+        let url = format!("{}/system/ip-pools", self.baseurl,);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -12428,27 +12428,27 @@ impl Client {
         &'a self,
         body: &'a types::IpPoolCreate,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-        let _url = format!("{}/system/ip-pools", self.baseurl,);
-        let _request = self
+        let url = format!("{}/system/ip-pools", self.baseurl,);
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -12459,30 +12459,30 @@ impl Client {
         &'a self,
         pool_name: &'a types::Name,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/ip-pools/{}",
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -12494,31 +12494,31 @@ impl Client {
         pool_name: &'a types::Name,
         body: &'a types::IpPoolUpdate,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/ip-pools/{}",
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .put(_url)
+            .put(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -12529,30 +12529,30 @@ impl Client {
         &'a self,
         pool_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/ip-pools/{}",
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .delete(_url)
+            .delete(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -12573,40 +12573,40 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/ip-pools/{}/ranges",
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let mut _query = Vec::with_capacity(2usize);
+        let mut query = Vec::with_capacity(2usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -12666,31 +12666,31 @@ impl Client {
         pool_name: &'a types::Name,
         body: &'a types::IpRange,
     ) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/ip-pools/{}/ranges/add",
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -12702,31 +12702,31 @@ impl Client {
         pool_name: &'a types::Name,
         body: &'a types::IpRange,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/ip-pools/{}/ranges/remove",
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -12736,26 +12736,26 @@ impl Client {
     pub async fn ip_pool_service_view<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-        let _url = format!("{}/system/ip-pools-service", self.baseurl,);
-        let _request = self
+        let url = format!("{}/system/ip-pools-service", self.baseurl,);
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -12774,36 +12774,36 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
-        let _url = format!("{}/system/ip-pools-service/ranges", self.baseurl,);
-        let mut _query = Vec::with_capacity(2usize);
+        let url = format!("{}/system/ip-pools-service/ranges", self.baseurl,);
+        let mut query = Vec::with_capacity(2usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -12860,27 +12860,27 @@ impl Client {
         &'a self,
         body: &'a types::IpRange,
     ) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
-        let _url = format!("{}/system/ip-pools-service/ranges/add", self.baseurl,);
-        let _request = self
+        let url = format!("{}/system/ip-pools-service/ranges/add", self.baseurl,);
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -12891,27 +12891,27 @@ impl Client {
         &'a self,
         body: &'a types::IpRange,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!("{}/system/ip-pools-service/ranges/remove", self.baseurl,);
-        let _request = self
+        let url = format!("{}/system/ip-pools-service/ranges/remove", self.baseurl,);
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -12936,49 +12936,49 @@ impl Client {
         page_token: Option<&'a str>,
         start_time: Option<&'a chrono::DateTime<chrono::offset::Utc>>,
     ) -> Result<ResponseValue<types::MeasurementResultsPage>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/metrics/{}",
             self.baseurl,
             encode_path(&metric_name.to_string()),
         );
-        let mut _query = Vec::with_capacity(5usize);
+        let mut query = Vec::with_capacity(5usize);
         if let Some(v) = &end_time {
-            _query.push(("end_time", v.to_string()));
+            query.push(("end_time", v.to_string()));
         }
 
-        _query.push(("id", id.to_string()));
+        query.push(("id", id.to_string()));
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &start_time {
-            _query.push(("start_time", v.to_string()));
+            query.push(("start_time", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -12988,26 +12988,26 @@ impl Client {
     pub async fn system_policy_view<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
-        let _url = format!("{}/system/policy", self.baseurl,);
-        let _request = self
+        let url = format!("{}/system/policy", self.baseurl,);
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -13018,27 +13018,27 @@ impl Client {
         &'a self,
         body: &'a types::FleetRolePolicy,
     ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
-        let _url = format!("{}/system/policy", self.baseurl,);
-        let _request = self
+        let url = format!("{}/system/policy", self.baseurl,);
+        let request = self
             .client
-            .put(_url)
+            .put(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -13057,40 +13057,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SagaResultsPage>, Error<types::Error>> {
-        let _url = format!("{}/system/sagas", self.baseurl,);
-        let mut _query = Vec::with_capacity(3usize);
+        let url = format!("{}/system/sagas", self.baseurl,);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -13146,30 +13146,30 @@ impl Client {
         &'a self,
         saga_id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Saga>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/sagas/{}",
             self.baseurl,
             encode_path(&saga_id.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -13190,40 +13190,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::SiloResultsPage>, Error<types::Error>> {
-        let _url = format!("{}/system/silos", self.baseurl,);
-        let mut _query = Vec::with_capacity(3usize);
+        let url = format!("{}/system/silos", self.baseurl,);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -13281,27 +13281,27 @@ impl Client {
         &'a self,
         body: &'a types::SiloCreate,
     ) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-        let _url = format!("{}/system/silos", self.baseurl,);
-        let _request = self
+        let url = format!("{}/system/silos", self.baseurl,);
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -13317,30 +13317,30 @@ impl Client {
         &'a self,
         silo_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/silos/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -13356,30 +13356,30 @@ impl Client {
         &'a self,
         silo_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/silos/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .delete(_url)
+            .delete(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -13400,44 +13400,44 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::IdentityProviderResultsPage>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/silos/{}/identity-providers",
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let mut _query = Vec::with_capacity(3usize);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -13507,31 +13507,31 @@ impl Client {
         silo_name: &'a types::Name,
         body: &'a types::UserCreate,
     ) -> Result<ResponseValue<types::User>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/silos/{}/identity-providers/local/users",
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -13548,31 +13548,31 @@ impl Client {
         silo_name: &'a types::Name,
         user_id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/silos/{}/identity-providers/local/users/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
             encode_path(&user_id.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .delete(_url)
+            .delete(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -13595,32 +13595,32 @@ impl Client {
         user_id: &'a uuid::Uuid,
         body: &'a types::UserPassword,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/silos/{}/identity-providers/local/users/{}/set-password",
             self.baseurl,
             encode_path(&silo_name.to_string()),
             encode_path(&user_id.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -13637,31 +13637,31 @@ impl Client {
         silo_name: &'a types::Name,
         body: &'a types::SamlIdentityProviderCreate,
     ) -> Result<ResponseValue<types::SamlIdentityProvider>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/silos/{}/identity-providers/saml",
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -13678,31 +13678,31 @@ impl Client {
         silo_name: &'a types::Name,
         provider_name: &'a types::Name,
     ) -> Result<ResponseValue<types::SamlIdentityProvider>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/silos/{}/identity-providers/saml/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
             encode_path(&provider_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -13716,30 +13716,30 @@ impl Client {
         &'a self,
         silo_name: &'a types::Name,
     ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/silos/{}/policy",
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -13755,31 +13755,31 @@ impl Client {
         silo_name: &'a types::Name,
         body: &'a types::SiloRolePolicy,
     ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/silos/{}/policy",
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .put(_url)
+            .put(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -13800,44 +13800,44 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/silos/{}/users/all",
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let mut _query = Vec::with_capacity(3usize);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -13900,31 +13900,31 @@ impl Client {
         silo_name: &'a types::Name,
         user_id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::User>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/silos/{}/users/id/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
             encode_path(&user_id.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -13943,40 +13943,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::UserBuiltinResultsPage>, Error<types::Error>> {
-        let _url = format!("{}/system/user", self.baseurl,);
-        let mut _query = Vec::with_capacity(3usize);
+        let url = format!("{}/system/user", self.baseurl,);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -14036,30 +14036,30 @@ impl Client {
         &'a self,
         user_name: &'a types::Name,
     ) -> Result<ResponseValue<types::UserBuiltin>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/system/user/{}",
             self.baseurl,
             encode_path(&user_name.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -14076,36 +14076,36 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::TimeseriesSchemaResultsPage>, Error<types::Error>> {
-        let _url = format!("{}/timeseries/schema", self.baseurl,);
-        let mut _query = Vec::with_capacity(2usize);
+        let url = format!("{}/timeseries/schema", self.baseurl,);
+        let mut query = Vec::with_capacity(2usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -14168,40 +14168,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
-        let _url = format!("{}/users", self.baseurl,);
-        let mut _query = Vec::with_capacity(3usize);
+        let url = format!("{}/users", self.baseurl,);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -14269,48 +14269,48 @@ impl Client {
         project: Option<&'a types::NameOrId>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
-        let _url = format!("{}/v1/disks", self.baseurl,);
-        let mut _query = Vec::with_capacity(5usize);
+        let url = format!("{}/v1/disks", self.baseurl,);
+        let mut query = Vec::with_capacity(5usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &organization {
-            _query.push(("organization", v.to_string()));
+            query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &project {
-            _query.push(("project", v.to_string()));
+            query.push(("project", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -14372,34 +14372,34 @@ impl Client {
         project: &'a types::NameOrId,
         body: &'a types::DiskCreate,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let _url = format!("{}/v1/disks", self.baseurl,);
-        let mut _query = Vec::with_capacity(2usize);
+        let url = format!("{}/v1/disks", self.baseurl,);
+        let mut query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            _query.push(("organization", v.to_string()));
+            query.push(("organization", v.to_string()));
         }
 
-        _query.push(("project", project.to_string()));
-        let _request = self
+        query.push(("project", project.to_string()));
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -14412,40 +14412,40 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         project: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/disks/{}",
             self.baseurl,
             encode_path(&disk.to_string()),
         );
-        let mut _query = Vec::with_capacity(2usize);
+        let mut query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            _query.push(("organization", v.to_string()));
+            query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            _query.push(("project", v.to_string()));
+            query.push(("project", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -14458,40 +14458,40 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         project: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/disks/{}",
             self.baseurl,
             encode_path(&disk.to_string()),
         );
-        let mut _query = Vec::with_capacity(2usize);
+        let mut query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            _query.push(("organization", v.to_string()));
+            query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            _query.push(("project", v.to_string()));
+            query.push(("project", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .delete(_url)
+            .delete(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -14514,48 +14514,48 @@ impl Client {
         project: Option<&'a types::NameOrId>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
-        let _url = format!("{}/v1/instances", self.baseurl,);
-        let mut _query = Vec::with_capacity(5usize);
+        let url = format!("{}/v1/instances", self.baseurl,);
+        let mut query = Vec::with_capacity(5usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &organization {
-            _query.push(("organization", v.to_string()));
+            query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &project {
-            _query.push(("project", v.to_string()));
+            query.push(("project", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -14618,34 +14618,34 @@ impl Client {
         project: &'a types::NameOrId,
         body: &'a types::InstanceCreate,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let _url = format!("{}/v1/instances", self.baseurl,);
-        let mut _query = Vec::with_capacity(2usize);
+        let url = format!("{}/v1/instances", self.baseurl,);
+        let mut query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            _query.push(("organization", v.to_string()));
+            query.push(("organization", v.to_string()));
         }
 
-        _query.push(("project", project.to_string()));
-        let _request = self
+        query.push(("project", project.to_string()));
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -14658,40 +14658,40 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         project: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/instances/{}",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut _query = Vec::with_capacity(2usize);
+        let mut query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            _query.push(("organization", v.to_string()));
+            query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            _query.push(("project", v.to_string()));
+            query.push(("project", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -14704,40 +14704,40 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         project: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/instances/{}",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut _query = Vec::with_capacity(2usize);
+        let mut query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            _query.push(("organization", v.to_string()));
+            query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            _query.push(("project", v.to_string()));
+            query.push(("project", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .delete(_url)
+            .delete(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -14762,52 +14762,52 @@ impl Client {
         project: Option<&'a types::NameOrId>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/instances/{}/disks",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut _query = Vec::with_capacity(5usize);
+        let mut query = Vec::with_capacity(5usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &organization {
-            _query.push(("organization", v.to_string()));
+            query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &project {
-            _query.push(("project", v.to_string()));
+            query.push(("project", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -14879,41 +14879,41 @@ impl Client {
         project: Option<&'a types::NameOrId>,
         body: &'a types::DiskPath,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/instances/{}/disks/attach",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut _query = Vec::with_capacity(2usize);
+        let mut query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            _query.push(("organization", v.to_string()));
+            query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            _query.push(("project", v.to_string()));
+            query.push(("project", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            202u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            202u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -14927,41 +14927,41 @@ impl Client {
         project: Option<&'a types::NameOrId>,
         body: &'a types::DiskPath,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/instances/{}/disks/detach",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut _query = Vec::with_capacity(2usize);
+        let mut query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            _query.push(("organization", v.to_string()));
+            query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            _query.push(("project", v.to_string()));
+            query.push(("project", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            202u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            202u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -14975,41 +14975,41 @@ impl Client {
         project: Option<&'a types::NameOrId>,
         body: &'a types::InstanceMigrate,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/instances/{}/migrate",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut _query = Vec::with_capacity(2usize);
+        let mut query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            _query.push(("organization", v.to_string()));
+            query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            _query.push(("project", v.to_string()));
+            query.push(("project", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -15022,40 +15022,40 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         project: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/instances/{}/reboot",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut _query = Vec::with_capacity(2usize);
+        let mut query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            _query.push(("organization", v.to_string()));
+            query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            _query.push(("project", v.to_string()));
+            query.push(("project", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            202u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            202u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -15087,52 +15087,52 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         project: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<types::InstanceSerialConsoleData>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/instances/{}/serial-console",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut _query = Vec::with_capacity(5usize);
+        let mut query = Vec::with_capacity(5usize);
         if let Some(v) = &from_start {
-            _query.push(("from_start", v.to_string()));
+            query.push(("from_start", v.to_string()));
         }
 
         if let Some(v) = &max_bytes {
-            _query.push(("max_bytes", v.to_string()));
+            query.push(("max_bytes", v.to_string()));
         }
 
         if let Some(v) = &most_recent {
-            _query.push(("most_recent", v.to_string()));
+            query.push(("most_recent", v.to_string()));
         }
 
         if let Some(v) = &organization {
-            _query.push(("organization", v.to_string()));
+            query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            _query.push(("project", v.to_string()));
+            query.push(("project", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -15146,24 +15146,24 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         project: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/instances/{}/serial-console/stream",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut _query = Vec::with_capacity(2usize);
+        let mut query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            _query.push(("organization", v.to_string()));
+            query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            _query.push(("project", v.to_string()));
+            query.push(("project", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
-            .query(&_query)
+            .get(url)
+            .query(&query)
             .header(reqwest::header::CONNECTION, "Upgrade")
             .header(reqwest::header::UPGRADE, "websocket")
             .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -15175,12 +15175,12 @@ impl Client {
                 ),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            101u16 => ResponseValue::upgrade(_response).await,
-            200..=299 => ResponseValue::upgrade(_response).await,
-            _ => Err(Error::UnexpectedResponse(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            101u16 => ResponseValue::upgrade(response).await,
+            200..=299 => ResponseValue::upgrade(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -15193,40 +15193,40 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         project: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/instances/{}/start",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut _query = Vec::with_capacity(2usize);
+        let mut query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            _query.push(("organization", v.to_string()));
+            query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            _query.push(("project", v.to_string()));
+            query.push(("project", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            202u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            202u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -15239,40 +15239,40 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         project: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/instances/{}/stop",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut _query = Vec::with_capacity(2usize);
+        let mut query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            _query.push(("organization", v.to_string()));
+            query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            _query.push(("project", v.to_string()));
+            query.push(("project", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            202u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            202u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -15291,40 +15291,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
-        let _url = format!("{}/v1/organizations", self.baseurl,);
-        let mut _query = Vec::with_capacity(3usize);
+        let url = format!("{}/v1/organizations", self.baseurl,);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -15381,27 +15381,27 @@ impl Client {
         &'a self,
         body: &'a types::OrganizationCreate,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let _url = format!("{}/v1/organizations", self.baseurl,);
-        let _request = self
+        let url = format!("{}/v1/organizations", self.baseurl,);
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -15412,30 +15412,30 @@ impl Client {
         &'a self,
         organization: &'a types::NameOrId,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/organizations/{}",
             self.baseurl,
             encode_path(&organization.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -15447,31 +15447,31 @@ impl Client {
         organization: &'a types::NameOrId,
         body: &'a types::OrganizationUpdate,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/organizations/{}",
             self.baseurl,
             encode_path(&organization.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .put(_url)
+            .put(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -15482,30 +15482,30 @@ impl Client {
         &'a self,
         organization: &'a types::NameOrId,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/organizations/{}",
             self.baseurl,
             encode_path(&organization.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .delete(_url)
+            .delete(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -15516,30 +15516,30 @@ impl Client {
         &'a self,
         organization: &'a types::NameOrId,
     ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/organizations/{}/policy",
             self.baseurl,
             encode_path(&organization.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -15551,31 +15551,31 @@ impl Client {
         organization: &'a types::NameOrId,
         body: &'a types::OrganizationRolePolicy,
     ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/organizations/{}/policy",
             self.baseurl,
             encode_path(&organization.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .put(_url)
+            .put(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -15596,44 +15596,44 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
-        let _url = format!("{}/v1/projects", self.baseurl,);
-        let mut _query = Vec::with_capacity(4usize);
+        let url = format!("{}/v1/projects", self.baseurl,);
+        let mut query = Vec::with_capacity(4usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &organization {
-            _query.push(("organization", v.to_string()));
+            query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -15692,30 +15692,30 @@ impl Client {
         organization: &'a types::NameOrId,
         body: &'a types::ProjectCreate,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-        let _url = format!("{}/v1/projects", self.baseurl,);
-        let mut _query = Vec::with_capacity(1usize);
-        _query.push(("organization", organization.to_string()));
-        let _request = self
+        let url = format!("{}/v1/projects", self.baseurl,);
+        let mut query = Vec::with_capacity(1usize);
+        query.push(("organization", organization.to_string()));
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -15727,36 +15727,36 @@ impl Client {
         project: &'a types::NameOrId,
         organization: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/projects/{}",
             self.baseurl,
             encode_path(&project.to_string()),
         );
-        let mut _query = Vec::with_capacity(1usize);
+        let mut query = Vec::with_capacity(1usize);
         if let Some(v) = &organization {
-            _query.push(("organization", v.to_string()));
+            query.push(("organization", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -15769,37 +15769,37 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         body: &'a types::ProjectUpdate,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/projects/{}",
             self.baseurl,
             encode_path(&project.to_string()),
         );
-        let mut _query = Vec::with_capacity(1usize);
+        let mut query = Vec::with_capacity(1usize);
         if let Some(v) = &organization {
-            _query.push(("organization", v.to_string()));
+            query.push(("organization", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .put(_url)
+            .put(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -15811,36 +15811,36 @@ impl Client {
         project: &'a types::NameOrId,
         organization: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/projects/{}",
             self.baseurl,
             encode_path(&project.to_string()),
         );
-        let mut _query = Vec::with_capacity(1usize);
+        let mut query = Vec::with_capacity(1usize);
         if let Some(v) = &organization {
-            _query.push(("organization", v.to_string()));
+            query.push(("organization", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .delete(_url)
+            .delete(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -15852,36 +15852,36 @@ impl Client {
         project: &'a types::NameOrId,
         organization: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/projects/{}/policy",
             self.baseurl,
             encode_path(&project.to_string()),
         );
-        let mut _query = Vec::with_capacity(1usize);
+        let mut query = Vec::with_capacity(1usize);
         if let Some(v) = &organization {
-            _query.push(("organization", v.to_string()));
+            query.push(("organization", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -15894,37 +15894,37 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         body: &'a types::ProjectRolePolicy,
     ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/projects/{}/policy",
             self.baseurl,
             encode_path(&project.to_string()),
         );
-        let mut _query = Vec::with_capacity(1usize);
+        let mut query = Vec::with_capacity(1usize);
         if let Some(v) = &organization {
-            _query.push(("organization", v.to_string()));
+            query.push(("organization", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .put(_url)
+            .put(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -15943,40 +15943,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UpdateableComponentResultsPage>, Error<types::Error>> {
-        let _url = format!("{}/v1/system/update/components", self.baseurl,);
-        let mut _query = Vec::with_capacity(3usize);
+        let url = format!("{}/v1/system/update/components", self.baseurl,);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -16041,40 +16041,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UpdateDeploymentResultsPage>, Error<types::Error>> {
-        let _url = format!("{}/v1/system/update/deployments", self.baseurl,);
-        let mut _query = Vec::with_capacity(3usize);
+        let url = format!("{}/v1/system/update/deployments", self.baseurl,);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -16131,30 +16131,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/system/update/deployments/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -16164,26 +16164,26 @@ impl Client {
     pub async fn system_update_refresh<'a>(
         &'a self,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!("{}/v1/system/update/refresh", self.baseurl,);
-        let _request = self
+        let url = format!("{}/v1/system/update/refresh", self.baseurl,);
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -16194,27 +16194,27 @@ impl Client {
         &'a self,
         body: &'a types::SystemUpdateStart,
     ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
-        let _url = format!("{}/v1/system/update/start", self.baseurl,);
-        let _request = self
+        let url = format!("{}/v1/system/update/start", self.baseurl,);
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            202u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            202u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -16226,26 +16226,26 @@ impl Client {
     pub async fn system_update_stop<'a>(
         &'a self,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!("{}/v1/system/update/stop", self.baseurl,);
-        let _request = self
+        let url = format!("{}/v1/system/update/stop", self.baseurl,);
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -16264,40 +16264,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SystemUpdateResultsPage>, Error<types::Error>> {
-        let _url = format!("{}/v1/system/update/updates", self.baseurl,);
-        let mut _query = Vec::with_capacity(3usize);
+        let url = format!("{}/v1/system/update/updates", self.baseurl,);
+        let mut query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            _query.push(("limit", v.to_string()));
+            query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            _query.push(("page_token", v.to_string()));
+            query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            _query.push(("sort_by", v.to_string()));
+            query.push(("sort_by", v.to_string()));
         }
 
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -16354,30 +16354,30 @@ impl Client {
         &'a self,
         version: &'a types::SemverVersion,
     ) -> Result<ResponseValue<types::SystemUpdate>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/system/update/updates/{}",
             self.baseurl,
             encode_path(&version.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -16389,30 +16389,30 @@ impl Client {
         &'a self,
         version: &'a types::SemverVersion,
     ) -> Result<ResponseValue<types::ComponentUpdateResultsPage>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/v1/system/update/updates/{}/components",
             self.baseurl,
             encode_path(&version.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -16422,26 +16422,26 @@ impl Client {
     pub async fn system_version<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::SystemVersion>, Error<types::Error>> {
-        let _url = format!("{}/v1/system/update/version", self.baseurl,);
-        let _request = self
+        let url = format!("{}/v1/system/update/version", self.baseurl,);
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 }

--- a/progenitor-impl/tests/output/nexus-positional.out
+++ b/progenitor-impl/tests/output/nexus-positional.out
@@ -5957,30 +5957,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/by-id/disks/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -5991,30 +5991,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/by-id/images/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -6025,30 +6025,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/by-id/instances/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -6059,30 +6059,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/by-id/network-interfaces/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -6095,30 +6095,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/by-id/organizations/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -6131,30 +6131,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/by-id/projects/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -6165,30 +6165,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/by-id/snapshots/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -6199,30 +6199,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/by-id/vpc-router-routes/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -6233,30 +6233,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/by-id/vpc-routers/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -6267,30 +6267,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/by-id/vpc-subnets/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -6301,30 +6301,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/by-id/vpcs/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -6339,19 +6339,13 @@ impl Client {
         &'a self,
         body: &'a types::DeviceAuthRequest,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-        let __progenitor_url = format!("{}/device/auth", self.baseurl,);
-        let __progenitor_request = self
-            .client
-            .post(__progenitor_url)
-            .form_urlencoded(&body)?
-            .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
-            _ => Err(Error::ErrorResponse(ResponseValue::stream(
-                __progenitor_response,
-            ))),
+        let _url = format!("{}/device/auth", self.baseurl,);
+        let _request = self.client.post(_url).form_urlencoded(&body)?.build()?;
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200..=299 => Ok(ResponseValue::stream(_response)),
+            _ => Err(Error::ErrorResponse(ResponseValue::stream(_response))),
         }
     }
 
@@ -6367,27 +6361,27 @@ impl Client {
         &'a self,
         body: &'a types::DeviceAuthVerify,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/device/confirm", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/device/confirm", self.baseurl,);
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -6401,19 +6395,13 @@ impl Client {
         &'a self,
         body: &'a types::DeviceAccessTokenRequest,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-        let __progenitor_url = format!("{}/device/token", self.baseurl,);
-        let __progenitor_request = self
-            .client
-            .post(__progenitor_url)
-            .form_urlencoded(&body)?
-            .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
-            _ => Err(Error::ErrorResponse(ResponseValue::stream(
-                __progenitor_response,
-            ))),
+        let _url = format!("{}/device/token", self.baseurl,);
+        let _request = self.client.post(_url).form_urlencoded(&body)?.build()?;
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200..=299 => Ok(ResponseValue::stream(_response)),
+            _ => Err(Error::ErrorResponse(ResponseValue::stream(_response))),
         }
     }
 
@@ -6432,40 +6420,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/groups", self.baseurl,);
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let _url = format!("{}/groups", self.baseurl,);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -6519,27 +6507,27 @@ impl Client {
         &'a self,
         body: &'a types::SpoofLoginBody,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/login", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/login", self.baseurl,);
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -6551,23 +6539,23 @@ impl Client {
         silo_name: &'a types::Name,
         body: &'a types::UsernamePasswordCredentials,
     ) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/login/{}/local",
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let __progenitor_request = self.client.post(__progenitor_url).json(&body).build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
+        let _request = self.client.post(_url).json(&body).build()?;
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200..=299 => Ok(ResponseValue::stream(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -6582,24 +6570,24 @@ impl Client {
         silo_name: &'a types::Name,
         provider_name: &'a types::Name,
     ) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/login/{}/saml/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
             encode_path(&provider_name.to_string()),
         );
-        let __progenitor_request = self.client.get(__progenitor_url).build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
+        let _request = self.client.get(_url).build()?;
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200..=299 => Ok(ResponseValue::stream(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -6612,57 +6600,57 @@ impl Client {
         provider_name: &'a types::Name,
         body: B,
     ) -> Result<ResponseValue<ByteStream>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/login/{}/saml/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
             encode_path(&provider_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::CONTENT_TYPE,
                 reqwest::header::HeaderValue::from_static("application/octet-stream"),
             )
             .body(body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200..=299 => Ok(ResponseValue::stream(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
     ///Sends a `POST` request to `/logout`
     pub async fn logout<'a>(&'a self) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/logout", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/logout", self.baseurl,);
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -6683,40 +6671,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/organizations", self.baseurl,);
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let _url = format!("{}/organizations", self.baseurl,);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -6777,27 +6765,27 @@ impl Client {
         &'a self,
         body: &'a types::OrganizationCreate,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/organizations", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/organizations", self.baseurl,);
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -6813,30 +6801,30 @@ impl Client {
         &'a self,
         organization_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -6854,31 +6842,31 @@ impl Client {
         organization_name: &'a types::Name,
         body: &'a types::OrganizationUpdate,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .put(__progenitor_url)
+            .put(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -6894,30 +6882,30 @@ impl Client {
         &'a self,
         organization_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .delete(__progenitor_url)
+            .delete(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -6933,30 +6921,30 @@ impl Client {
         &'a self,
         organization_name: &'a types::Name,
     ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/policy",
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -6974,31 +6962,31 @@ impl Client {
         organization_name: &'a types::Name,
         body: &'a types::OrganizationRolePolicy,
     ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/policy",
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .put(__progenitor_url)
+            .put(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -7021,44 +7009,44 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects",
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -7126,31 +7114,31 @@ impl Client {
         organization_name: &'a types::Name,
         body: &'a types::ProjectCreate,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects",
             self.baseurl,
             encode_path(&organization_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -7169,31 +7157,31 @@ impl Client {
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -7214,32 +7202,32 @@ impl Client {
         project_name: &'a types::Name,
         body: &'a types::ProjectUpdate,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .put(__progenitor_url)
+            .put(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -7258,31 +7246,31 @@ impl Client {
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .delete(__progenitor_url)
+            .delete(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -7308,45 +7296,45 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/disks",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -7423,32 +7411,32 @@ impl Client {
         project_name: &'a types::Name,
         body: &'a types::DiskCreate,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/disks",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -7465,32 +7453,32 @@ impl Client {
         project_name: &'a types::Name,
         disk_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/disks/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&disk_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -7505,32 +7493,32 @@ impl Client {
         project_name: &'a types::Name,
         disk_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/disks/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&disk_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .delete(__progenitor_url)
+            .delete(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -7561,7 +7549,7 @@ impl Client {
         page_token: Option<&'a str>,
         start_time: Option<&'a chrono::DateTime<chrono::offset::Utc>>,
     ) -> Result<ResponseValue<types::MeasurementResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/disks/{}/metrics/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -7569,43 +7557,43 @@ impl Client {
             encode_path(&disk_name.to_string()),
             encode_path(&metric_name.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(4usize);
+        let mut _query = Vec::with_capacity(4usize);
         if let Some(v) = &end_time {
-            __progenitor_query.push(("end_time", v.to_string()));
+            _query.push(("end_time", v.to_string()));
         }
 
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &start_time {
-            __progenitor_query.push(("start_time", v.to_string()));
+            _query.push(("start_time", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -7707,45 +7695,45 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::ImageResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/images",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -7825,32 +7813,32 @@ impl Client {
         project_name: &'a types::Name,
         body: &'a types::ImageCreate,
     ) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/images",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -7867,32 +7855,32 @@ impl Client {
         project_name: &'a types::Name,
         image_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Image>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/images/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&image_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -7911,32 +7899,32 @@ impl Client {
         project_name: &'a types::Name,
         image_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/images/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&image_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .delete(__progenitor_url)
+            .delete(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -7960,45 +7948,45 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/instances",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -8076,32 +8064,32 @@ impl Client {
         project_name: &'a types::Name,
         body: &'a types::InstanceCreate,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/instances",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -8118,32 +8106,32 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/instances/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -8158,32 +8146,32 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/instances/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .delete(__progenitor_url)
+            .delete(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -8212,46 +8200,46 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/disks",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -8337,33 +8325,33 @@ impl Client {
         instance_name: &'a types::Name,
         body: &'a types::DiskIdentifier,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/disks/attach",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            202u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            202u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -8381,33 +8369,33 @@ impl Client {
         instance_name: &'a types::Name,
         body: &'a types::DiskIdentifier,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/disks/detach",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            202u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            202u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -8422,32 +8410,32 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
     ) -> Result<ResponseValue<types::ExternalIpResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/external-ips",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -8465,33 +8453,33 @@ impl Client {
         instance_name: &'a types::Name,
         body: &'a types::InstanceMigrate,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/migrate",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -8518,46 +8506,46 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::NetworkInterfaceResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -8640,33 +8628,33 @@ impl Client {
         instance_name: &'a types::Name,
         body: &'a types::NetworkInterfaceCreate,
     ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/network-interfaces",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -8682,7 +8670,7 @@ impl Client {
         instance_name: &'a types::Name,
         interface_name: &'a types::Name,
     ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -8690,25 +8678,25 @@ impl Client {
             encode_path(&instance_name.to_string()),
             encode_path(&interface_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -8725,7 +8713,7 @@ impl Client {
         interface_name: &'a types::Name,
         body: &'a types::NetworkInterfaceUpdate,
     ) -> Result<ResponseValue<types::NetworkInterface>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -8733,26 +8721,26 @@ impl Client {
             encode_path(&instance_name.to_string()),
             encode_path(&interface_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .put(__progenitor_url)
+            .put(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -8773,7 +8761,7 @@ impl Client {
         instance_name: &'a types::Name,
         interface_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/network-interfaces/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -8781,25 +8769,25 @@ impl Client {
             encode_path(&instance_name.to_string()),
             encode_path(&interface_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .delete(__progenitor_url)
+            .delete(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -8816,32 +8804,32 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/reboot",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            202u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            202u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -8877,46 +8865,46 @@ impl Client {
         max_bytes: Option<u64>,
         most_recent: Option<u64>,
     ) -> Result<ResponseValue<types::InstanceSerialConsoleData>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/serial-console",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &from_start {
-            __progenitor_query.push(("from_start", v.to_string()));
+            _query.push(("from_start", v.to_string()));
         }
 
         if let Some(v) = &max_bytes {
-            __progenitor_query.push(("max_bytes", v.to_string()));
+            _query.push(("max_bytes", v.to_string()));
         }
 
         if let Some(v) = &most_recent {
-            __progenitor_query.push(("most_recent", v.to_string()));
+            _query.push(("most_recent", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -8933,16 +8921,16 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
     ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/serial-console/stream",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(reqwest::header::CONNECTION, "Upgrade")
             .header(reqwest::header::UPGRADE, "websocket")
             .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -8954,12 +8942,12 @@ impl Client {
                 ),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            101u16 => ResponseValue::upgrade(__progenitor_response).await,
-            200..=299 => ResponseValue::upgrade(__progenitor_response).await,
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            101u16 => ResponseValue::upgrade(_response).await,
+            200..=299 => ResponseValue::upgrade(_response).await,
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -8976,32 +8964,32 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/start",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            202u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            202u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -9018,32 +9006,32 @@ impl Client {
         project_name: &'a types::Name,
         instance_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/instances/{}/stop",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&instance_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            202u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            202u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -9062,31 +9050,31 @@ impl Client {
         organization_name: &'a types::Name,
         project_name: &'a types::Name,
     ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/policy",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -9105,32 +9093,32 @@ impl Client {
         project_name: &'a types::Name,
         body: &'a types::ProjectRolePolicy,
     ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/policy",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .put(__progenitor_url)
+            .put(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -9154,45 +9142,45 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::SnapshotResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/snapshots",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -9270,32 +9258,32 @@ impl Client {
         project_name: &'a types::Name,
         body: &'a types::SnapshotCreate,
     ) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/snapshots",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -9310,32 +9298,32 @@ impl Client {
         project_name: &'a types::Name,
         snapshot_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Snapshot>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/snapshots/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&snapshot_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -9350,32 +9338,32 @@ impl Client {
         project_name: &'a types::Name,
         snapshot_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/snapshots/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&snapshot_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .delete(__progenitor_url)
+            .delete(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -9399,45 +9387,45 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::VpcResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/vpcs",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -9512,32 +9500,32 @@ impl Client {
         project_name: &'a types::Name,
         body: &'a types::VpcCreate,
     ) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/vpcs",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -9552,32 +9540,32 @@ impl Client {
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -9593,33 +9581,33 @@ impl Client {
         vpc_name: &'a types::Name,
         body: &'a types::VpcUpdate,
     ) -> Result<ResponseValue<types::Vpc>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .put(__progenitor_url)
+            .put(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -9634,32 +9622,32 @@ impl Client {
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .delete(__progenitor_url)
+            .delete(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -9674,32 +9662,32 @@ impl Client {
         project_name: &'a types::Name,
         vpc_name: &'a types::Name,
     ) -> Result<ResponseValue<types::VpcFirewallRules>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -9715,33 +9703,33 @@ impl Client {
         vpc_name: &'a types::Name,
         body: &'a types::VpcFirewallRuleUpdateParams,
     ) -> Result<ResponseValue<types::VpcFirewallRules>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/firewall/rules",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .put(__progenitor_url)
+            .put(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -9768,46 +9756,46 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::VpcRouterResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -9890,33 +9878,33 @@ impl Client {
         vpc_name: &'a types::Name,
         body: &'a types::VpcRouterCreate,
     ) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -9932,7 +9920,7 @@ impl Client {
         vpc_name: &'a types::Name,
         router_name: &'a types::Name,
     ) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -9940,25 +9928,25 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -9975,7 +9963,7 @@ impl Client {
         router_name: &'a types::Name,
         body: &'a types::VpcRouterUpdate,
     ) -> Result<ResponseValue<types::VpcRouter>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -9983,26 +9971,26 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .put(__progenitor_url)
+            .put(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -10018,7 +10006,7 @@ impl Client {
         vpc_name: &'a types::Name,
         router_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10026,25 +10014,25 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .delete(__progenitor_url)
+            .delete(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -10075,7 +10063,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::RouterRouteResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10083,39 +10071,39 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -10206,7 +10194,7 @@ impl Client {
         router_name: &'a types::Name,
         body: &'a types::RouterRouteCreateParams,
     ) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10214,26 +10202,26 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&router_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -10250,7 +10238,7 @@ impl Client {
         router_name: &'a types::Name,
         route_name: &'a types::Name,
     ) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10259,25 +10247,25 @@ impl Client {
             encode_path(&router_name.to_string()),
             encode_path(&route_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -10295,7 +10283,7 @@ impl Client {
         route_name: &'a types::Name,
         body: &'a types::RouterRouteUpdateParams,
     ) -> Result<ResponseValue<types::RouterRoute>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10304,26 +10292,26 @@ impl Client {
             encode_path(&router_name.to_string()),
             encode_path(&route_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .put(__progenitor_url)
+            .put(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -10340,7 +10328,7 @@ impl Client {
         router_name: &'a types::Name,
         route_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/routers/{}/routes/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10349,25 +10337,25 @@ impl Client {
             encode_path(&router_name.to_string()),
             encode_path(&route_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .delete(__progenitor_url)
+            .delete(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -10394,46 +10382,46 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::VpcSubnetResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -10516,33 +10504,33 @@ impl Client {
         vpc_name: &'a types::Name,
         body: &'a types::VpcSubnetCreate,
     ) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets",
             self.baseurl,
             encode_path(&organization_name.to_string()),
             encode_path(&project_name.to_string()),
             encode_path(&vpc_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -10558,7 +10546,7 @@ impl Client {
         vpc_name: &'a types::Name,
         subnet_name: &'a types::Name,
     ) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10566,25 +10554,25 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&subnet_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -10601,7 +10589,7 @@ impl Client {
         subnet_name: &'a types::Name,
         body: &'a types::VpcSubnetUpdate,
     ) -> Result<ResponseValue<types::VpcSubnet>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10609,26 +10597,26 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&subnet_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .put(__progenitor_url)
+            .put(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -10644,7 +10632,7 @@ impl Client {
         vpc_name: &'a types::Name,
         subnet_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10652,25 +10640,25 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&subnet_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .delete(__progenitor_url)
+            .delete(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -10699,7 +10687,7 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::NetworkInterfaceResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/organizations/{}/projects/{}/vpcs/{}/subnets/{}/network-interfaces",
             self.baseurl,
             encode_path(&organization_name.to_string()),
@@ -10707,39 +10695,39 @@ impl Client {
             encode_path(&vpc_name.to_string()),
             encode_path(&subnet_name.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -10821,26 +10809,26 @@ impl Client {
     pub async fn policy_view<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/policy", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/policy", self.baseurl,);
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -10851,27 +10839,27 @@ impl Client {
         &'a self,
         body: &'a types::SiloRolePolicy,
     ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/policy", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/policy", self.baseurl,);
+        let _request = self
             .client
-            .put(__progenitor_url)
+            .put(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -10888,36 +10876,36 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::RoleResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/roles", self.baseurl,);
-        let mut __progenitor_query = Vec::with_capacity(2usize);
+        let _url = format!("{}/roles", self.baseurl,);
+        let mut _query = Vec::with_capacity(2usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -10974,30 +10962,30 @@ impl Client {
         &'a self,
         role_name: &'a str,
     ) -> Result<ResponseValue<types::Role>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/roles/{}",
             self.baseurl,
             encode_path(&role_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -11007,26 +10995,26 @@ impl Client {
     pub async fn session_me<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::User>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/session/me", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/session/me", self.baseurl,);
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -11045,40 +11033,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/session/me/groups", self.baseurl,);
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let _url = format!("{}/session/me/groups", self.baseurl,);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -11144,40 +11132,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::SshKeyResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/session/me/sshkeys", self.baseurl,);
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let _url = format!("{}/session/me/sshkeys", self.baseurl,);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -11237,27 +11225,27 @@ impl Client {
         &'a self,
         body: &'a types::SshKeyCreate,
     ) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/session/me/sshkeys", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/session/me/sshkeys", self.baseurl,);
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -11271,30 +11259,30 @@ impl Client {
         &'a self,
         ssh_key_name: &'a types::Name,
     ) -> Result<ResponseValue<types::SshKey>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/session/me/sshkeys/{}",
             self.baseurl,
             encode_path(&ssh_key_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -11308,30 +11296,30 @@ impl Client {
         &'a self,
         ssh_key_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/session/me/sshkeys/{}",
             self.baseurl,
             encode_path(&ssh_key_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .delete(__progenitor_url)
+            .delete(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -11342,30 +11330,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/by-id/images/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -11376,30 +11364,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/by-id/ip-pools/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -11410,30 +11398,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/by-id/silos/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -11456,40 +11444,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::CertificateResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/system/certificates", self.baseurl,);
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let _url = format!("{}/system/certificates", self.baseurl,);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -11553,27 +11541,27 @@ impl Client {
         &'a self,
         body: &'a types::CertificateCreate,
     ) -> Result<ResponseValue<types::Certificate>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/system/certificates", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/system/certificates", self.baseurl,);
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -11586,30 +11574,30 @@ impl Client {
         &'a self,
         certificate: &'a types::NameOrId,
     ) -> Result<ResponseValue<types::Certificate>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/certificates/{}",
             self.baseurl,
             encode_path(&certificate.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -11622,30 +11610,30 @@ impl Client {
         &'a self,
         certificate: &'a types::NameOrId,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/certificates/{}",
             self.baseurl,
             encode_path(&certificate.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .delete(__progenitor_url)
+            .delete(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -11664,40 +11652,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::PhysicalDiskResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/system/hardware/disks", self.baseurl,);
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let _url = format!("{}/system/hardware/disks", self.baseurl,);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -11762,40 +11750,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::RackResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/system/hardware/racks", self.baseurl,);
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let _url = format!("{}/system/hardware/racks", self.baseurl,);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -11854,30 +11842,30 @@ impl Client {
         &'a self,
         rack_id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Rack>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/hardware/racks/{}",
             self.baseurl,
             encode_path(&rack_id.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -11896,40 +11884,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SledResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/system/hardware/sleds", self.baseurl,);
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let _url = format!("{}/system/hardware/sleds", self.baseurl,);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -11988,30 +11976,30 @@ impl Client {
         &'a self,
         sled_id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Sled>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/hardware/sleds/{}",
             self.baseurl,
             encode_path(&sled_id.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -12032,44 +12020,44 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::PhysicalDiskResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/hardware/sleds/{}/disks",
             self.baseurl,
             encode_path(&sled_id.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -12141,40 +12129,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::GlobalImageResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/system/images", self.baseurl,);
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let _url = format!("{}/system/images", self.baseurl,);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -12238,27 +12226,27 @@ impl Client {
         &'a self,
         body: &'a types::GlobalImageCreate,
     ) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/system/images", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/system/images", self.baseurl,);
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -12271,30 +12259,30 @@ impl Client {
         &'a self,
         image_name: &'a types::Name,
     ) -> Result<ResponseValue<types::GlobalImage>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/images/{}",
             self.baseurl,
             encode_path(&image_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -12309,30 +12297,30 @@ impl Client {
         &'a self,
         image_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/images/{}",
             self.baseurl,
             encode_path(&image_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .delete(__progenitor_url)
+            .delete(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -12351,40 +12339,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::IpPoolResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/system/ip-pools", self.baseurl,);
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let _url = format!("{}/system/ip-pools", self.baseurl,);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -12440,27 +12428,27 @@ impl Client {
         &'a self,
         body: &'a types::IpPoolCreate,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/system/ip-pools", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/system/ip-pools", self.baseurl,);
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -12471,30 +12459,30 @@ impl Client {
         &'a self,
         pool_name: &'a types::Name,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/ip-pools/{}",
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -12506,31 +12494,31 @@ impl Client {
         pool_name: &'a types::Name,
         body: &'a types::IpPoolUpdate,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/ip-pools/{}",
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .put(__progenitor_url)
+            .put(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -12541,30 +12529,30 @@ impl Client {
         &'a self,
         pool_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/ip-pools/{}",
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .delete(__progenitor_url)
+            .delete(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -12585,40 +12573,40 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/ip-pools/{}/ranges",
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(2usize);
+        let mut _query = Vec::with_capacity(2usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -12678,31 +12666,31 @@ impl Client {
         pool_name: &'a types::Name,
         body: &'a types::IpRange,
     ) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/ip-pools/{}/ranges/add",
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -12714,31 +12702,31 @@ impl Client {
         pool_name: &'a types::Name,
         body: &'a types::IpRange,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/ip-pools/{}/ranges/remove",
             self.baseurl,
             encode_path(&pool_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -12748,26 +12736,26 @@ impl Client {
     pub async fn ip_pool_service_view<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::IpPool>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/system/ip-pools-service", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/system/ip-pools-service", self.baseurl,);
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -12786,36 +12774,36 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/system/ip-pools-service/ranges", self.baseurl,);
-        let mut __progenitor_query = Vec::with_capacity(2usize);
+        let _url = format!("{}/system/ip-pools-service/ranges", self.baseurl,);
+        let mut _query = Vec::with_capacity(2usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -12872,27 +12860,27 @@ impl Client {
         &'a self,
         body: &'a types::IpRange,
     ) -> Result<ResponseValue<types::IpPoolRange>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/system/ip-pools-service/ranges/add", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/system/ip-pools-service/ranges/add", self.baseurl,);
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -12903,27 +12891,27 @@ impl Client {
         &'a self,
         body: &'a types::IpRange,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/system/ip-pools-service/ranges/remove", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/system/ip-pools-service/ranges/remove", self.baseurl,);
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -12948,49 +12936,49 @@ impl Client {
         page_token: Option<&'a str>,
         start_time: Option<&'a chrono::DateTime<chrono::offset::Utc>>,
     ) -> Result<ResponseValue<types::MeasurementResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/metrics/{}",
             self.baseurl,
             encode_path(&metric_name.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(5usize);
+        let mut _query = Vec::with_capacity(5usize);
         if let Some(v) = &end_time {
-            __progenitor_query.push(("end_time", v.to_string()));
+            _query.push(("end_time", v.to_string()));
         }
 
-        __progenitor_query.push(("id", id.to_string()));
+        _query.push(("id", id.to_string()));
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &start_time {
-            __progenitor_query.push(("start_time", v.to_string()));
+            _query.push(("start_time", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -13000,26 +12988,26 @@ impl Client {
     pub async fn system_policy_view<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/system/policy", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/system/policy", self.baseurl,);
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -13030,27 +13018,27 @@ impl Client {
         &'a self,
         body: &'a types::FleetRolePolicy,
     ) -> Result<ResponseValue<types::FleetRolePolicy>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/system/policy", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/system/policy", self.baseurl,);
+        let _request = self
             .client
-            .put(__progenitor_url)
+            .put(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -13069,40 +13057,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SagaResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/system/sagas", self.baseurl,);
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let _url = format!("{}/system/sagas", self.baseurl,);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -13158,30 +13146,30 @@ impl Client {
         &'a self,
         saga_id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::Saga>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/sagas/{}",
             self.baseurl,
             encode_path(&saga_id.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -13202,40 +13190,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::SiloResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/system/silos", self.baseurl,);
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let _url = format!("{}/system/silos", self.baseurl,);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -13293,27 +13281,27 @@ impl Client {
         &'a self,
         body: &'a types::SiloCreate,
     ) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/system/silos", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/system/silos", self.baseurl,);
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -13329,30 +13317,30 @@ impl Client {
         &'a self,
         silo_name: &'a types::Name,
     ) -> Result<ResponseValue<types::Silo>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/silos/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -13368,30 +13356,30 @@ impl Client {
         &'a self,
         silo_name: &'a types::Name,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/silos/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .delete(__progenitor_url)
+            .delete(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -13412,44 +13400,44 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::IdentityProviderResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/silos/{}/identity-providers",
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -13519,31 +13507,31 @@ impl Client {
         silo_name: &'a types::Name,
         body: &'a types::UserCreate,
     ) -> Result<ResponseValue<types::User>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/silos/{}/identity-providers/local/users",
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -13560,31 +13548,31 @@ impl Client {
         silo_name: &'a types::Name,
         user_id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/silos/{}/identity-providers/local/users/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
             encode_path(&user_id.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .delete(__progenitor_url)
+            .delete(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -13607,32 +13595,32 @@ impl Client {
         user_id: &'a uuid::Uuid,
         body: &'a types::UserPassword,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/silos/{}/identity-providers/local/users/{}/set-password",
             self.baseurl,
             encode_path(&silo_name.to_string()),
             encode_path(&user_id.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -13649,31 +13637,31 @@ impl Client {
         silo_name: &'a types::Name,
         body: &'a types::SamlIdentityProviderCreate,
     ) -> Result<ResponseValue<types::SamlIdentityProvider>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/silos/{}/identity-providers/saml",
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -13690,31 +13678,31 @@ impl Client {
         silo_name: &'a types::Name,
         provider_name: &'a types::Name,
     ) -> Result<ResponseValue<types::SamlIdentityProvider>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/silos/{}/identity-providers/saml/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
             encode_path(&provider_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -13728,30 +13716,30 @@ impl Client {
         &'a self,
         silo_name: &'a types::Name,
     ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/silos/{}/policy",
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -13767,31 +13755,31 @@ impl Client {
         silo_name: &'a types::Name,
         body: &'a types::SiloRolePolicy,
     ) -> Result<ResponseValue<types::SiloRolePolicy>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/silos/{}/policy",
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .put(__progenitor_url)
+            .put(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -13812,44 +13800,44 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/silos/{}/users/all",
             self.baseurl,
             encode_path(&silo_name.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -13912,31 +13900,31 @@ impl Client {
         silo_name: &'a types::Name,
         user_id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::User>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/silos/{}/users/id/{}",
             self.baseurl,
             encode_path(&silo_name.to_string()),
             encode_path(&user_id.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -13955,40 +13943,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameSortMode>,
     ) -> Result<ResponseValue<types::UserBuiltinResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/system/user", self.baseurl,);
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let _url = format!("{}/system/user", self.baseurl,);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -14048,30 +14036,30 @@ impl Client {
         &'a self,
         user_name: &'a types::Name,
     ) -> Result<ResponseValue<types::UserBuiltin>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/system/user/{}",
             self.baseurl,
             encode_path(&user_name.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -14088,36 +14076,36 @@ impl Client {
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
     ) -> Result<ResponseValue<types::TimeseriesSchemaResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/timeseries/schema", self.baseurl,);
-        let mut __progenitor_query = Vec::with_capacity(2usize);
+        let _url = format!("{}/timeseries/schema", self.baseurl,);
+        let mut _query = Vec::with_capacity(2usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -14180,40 +14168,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/users", self.baseurl,);
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let _url = format!("{}/users", self.baseurl,);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -14281,48 +14269,48 @@ impl Client {
         project: Option<&'a types::NameOrId>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/v1/disks", self.baseurl,);
-        let mut __progenitor_query = Vec::with_capacity(5usize);
+        let _url = format!("{}/v1/disks", self.baseurl,);
+        let mut _query = Vec::with_capacity(5usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &organization {
-            __progenitor_query.push(("organization", v.to_string()));
+            _query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &project {
-            __progenitor_query.push(("project", v.to_string()));
+            _query.push(("project", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -14384,34 +14372,34 @@ impl Client {
         project: &'a types::NameOrId,
         body: &'a types::DiskCreate,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/v1/disks", self.baseurl,);
-        let mut __progenitor_query = Vec::with_capacity(2usize);
+        let _url = format!("{}/v1/disks", self.baseurl,);
+        let mut _query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            __progenitor_query.push(("organization", v.to_string()));
+            _query.push(("organization", v.to_string()));
         }
 
-        __progenitor_query.push(("project", project.to_string()));
-        let __progenitor_request = self
+        _query.push(("project", project.to_string()));
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -14424,40 +14412,40 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         project: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/disks/{}",
             self.baseurl,
             encode_path(&disk.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(2usize);
+        let mut _query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            __progenitor_query.push(("organization", v.to_string()));
+            _query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            __progenitor_query.push(("project", v.to_string()));
+            _query.push(("project", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -14470,40 +14458,40 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         project: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/disks/{}",
             self.baseurl,
             encode_path(&disk.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(2usize);
+        let mut _query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            __progenitor_query.push(("organization", v.to_string()));
+            _query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            __progenitor_query.push(("project", v.to_string()));
+            _query.push(("project", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .delete(__progenitor_url)
+            .delete(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -14526,48 +14514,48 @@ impl Client {
         project: Option<&'a types::NameOrId>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/v1/instances", self.baseurl,);
-        let mut __progenitor_query = Vec::with_capacity(5usize);
+        let _url = format!("{}/v1/instances", self.baseurl,);
+        let mut _query = Vec::with_capacity(5usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &organization {
-            __progenitor_query.push(("organization", v.to_string()));
+            _query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &project {
-            __progenitor_query.push(("project", v.to_string()));
+            _query.push(("project", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -14630,34 +14618,34 @@ impl Client {
         project: &'a types::NameOrId,
         body: &'a types::InstanceCreate,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/v1/instances", self.baseurl,);
-        let mut __progenitor_query = Vec::with_capacity(2usize);
+        let _url = format!("{}/v1/instances", self.baseurl,);
+        let mut _query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            __progenitor_query.push(("organization", v.to_string()));
+            _query.push(("organization", v.to_string()));
         }
 
-        __progenitor_query.push(("project", project.to_string()));
-        let __progenitor_request = self
+        _query.push(("project", project.to_string()));
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -14670,40 +14658,40 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         project: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/instances/{}",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(2usize);
+        let mut _query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            __progenitor_query.push(("organization", v.to_string()));
+            _query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            __progenitor_query.push(("project", v.to_string()));
+            _query.push(("project", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -14716,40 +14704,40 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         project: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/instances/{}",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(2usize);
+        let mut _query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            __progenitor_query.push(("organization", v.to_string()));
+            _query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            __progenitor_query.push(("project", v.to_string()));
+            _query.push(("project", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .delete(__progenitor_url)
+            .delete(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -14774,52 +14762,52 @@ impl Client {
         project: Option<&'a types::NameOrId>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/instances/{}/disks",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(5usize);
+        let mut _query = Vec::with_capacity(5usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &organization {
-            __progenitor_query.push(("organization", v.to_string()));
+            _query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &project {
-            __progenitor_query.push(("project", v.to_string()));
+            _query.push(("project", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -14891,41 +14879,41 @@ impl Client {
         project: Option<&'a types::NameOrId>,
         body: &'a types::DiskPath,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/instances/{}/disks/attach",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(2usize);
+        let mut _query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            __progenitor_query.push(("organization", v.to_string()));
+            _query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            __progenitor_query.push(("project", v.to_string()));
+            _query.push(("project", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            202u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            202u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -14939,41 +14927,41 @@ impl Client {
         project: Option<&'a types::NameOrId>,
         body: &'a types::DiskPath,
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/instances/{}/disks/detach",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(2usize);
+        let mut _query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            __progenitor_query.push(("organization", v.to_string()));
+            _query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            __progenitor_query.push(("project", v.to_string()));
+            _query.push(("project", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            202u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            202u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -14987,41 +14975,41 @@ impl Client {
         project: Option<&'a types::NameOrId>,
         body: &'a types::InstanceMigrate,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/instances/{}/migrate",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(2usize);
+        let mut _query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            __progenitor_query.push(("organization", v.to_string()));
+            _query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            __progenitor_query.push(("project", v.to_string()));
+            _query.push(("project", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -15034,40 +15022,40 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         project: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/instances/{}/reboot",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(2usize);
+        let mut _query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            __progenitor_query.push(("organization", v.to_string()));
+            _query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            __progenitor_query.push(("project", v.to_string()));
+            _query.push(("project", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            202u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            202u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -15099,52 +15087,52 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         project: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<types::InstanceSerialConsoleData>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/instances/{}/serial-console",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(5usize);
+        let mut _query = Vec::with_capacity(5usize);
         if let Some(v) = &from_start {
-            __progenitor_query.push(("from_start", v.to_string()));
+            _query.push(("from_start", v.to_string()));
         }
 
         if let Some(v) = &max_bytes {
-            __progenitor_query.push(("max_bytes", v.to_string()));
+            _query.push(("max_bytes", v.to_string()));
         }
 
         if let Some(v) = &most_recent {
-            __progenitor_query.push(("most_recent", v.to_string()));
+            _query.push(("most_recent", v.to_string()));
         }
 
         if let Some(v) = &organization {
-            __progenitor_query.push(("organization", v.to_string()));
+            _query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            __progenitor_query.push(("project", v.to_string()));
+            _query.push(("project", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -15158,24 +15146,24 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         project: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/instances/{}/serial-console/stream",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(2usize);
+        let mut _query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            __progenitor_query.push(("organization", v.to_string()));
+            _query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            __progenitor_query.push(("project", v.to_string()));
+            _query.push(("project", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
-            .query(&__progenitor_query)
+            .get(_url)
+            .query(&_query)
             .header(reqwest::header::CONNECTION, "Upgrade")
             .header(reqwest::header::UPGRADE, "websocket")
             .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -15187,12 +15175,12 @@ impl Client {
                 ),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            101u16 => ResponseValue::upgrade(__progenitor_response).await,
-            200..=299 => ResponseValue::upgrade(__progenitor_response).await,
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            101u16 => ResponseValue::upgrade(_response).await,
+            200..=299 => ResponseValue::upgrade(_response).await,
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -15205,40 +15193,40 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         project: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/instances/{}/start",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(2usize);
+        let mut _query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            __progenitor_query.push(("organization", v.to_string()));
+            _query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            __progenitor_query.push(("project", v.to_string()));
+            _query.push(("project", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            202u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            202u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -15251,40 +15239,40 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         project: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/instances/{}/stop",
             self.baseurl,
             encode_path(&instance.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(2usize);
+        let mut _query = Vec::with_capacity(2usize);
         if let Some(v) = &organization {
-            __progenitor_query.push(("organization", v.to_string()));
+            _query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &project {
-            __progenitor_query.push(("project", v.to_string()));
+            _query.push(("project", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            202u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            202u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -15303,40 +15291,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/v1/organizations", self.baseurl,);
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let _url = format!("{}/v1/organizations", self.baseurl,);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -15393,27 +15381,27 @@ impl Client {
         &'a self,
         body: &'a types::OrganizationCreate,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/v1/organizations", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/v1/organizations", self.baseurl,);
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -15424,30 +15412,30 @@ impl Client {
         &'a self,
         organization: &'a types::NameOrId,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/organizations/{}",
             self.baseurl,
             encode_path(&organization.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -15459,31 +15447,31 @@ impl Client {
         organization: &'a types::NameOrId,
         body: &'a types::OrganizationUpdate,
     ) -> Result<ResponseValue<types::Organization>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/organizations/{}",
             self.baseurl,
             encode_path(&organization.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .put(__progenitor_url)
+            .put(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -15494,30 +15482,30 @@ impl Client {
         &'a self,
         organization: &'a types::NameOrId,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/organizations/{}",
             self.baseurl,
             encode_path(&organization.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .delete(__progenitor_url)
+            .delete(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -15528,30 +15516,30 @@ impl Client {
         &'a self,
         organization: &'a types::NameOrId,
     ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/organizations/{}/policy",
             self.baseurl,
             encode_path(&organization.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -15563,31 +15551,31 @@ impl Client {
         organization: &'a types::NameOrId,
         body: &'a types::OrganizationRolePolicy,
     ) -> Result<ResponseValue<types::OrganizationRolePolicy>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/organizations/{}/policy",
             self.baseurl,
             encode_path(&organization.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .put(__progenitor_url)
+            .put(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -15608,44 +15596,44 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::NameOrIdSortMode>,
     ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/v1/projects", self.baseurl,);
-        let mut __progenitor_query = Vec::with_capacity(4usize);
+        let _url = format!("{}/v1/projects", self.baseurl,);
+        let mut _query = Vec::with_capacity(4usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &organization {
-            __progenitor_query.push(("organization", v.to_string()));
+            _query.push(("organization", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -15704,30 +15692,30 @@ impl Client {
         organization: &'a types::NameOrId,
         body: &'a types::ProjectCreate,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/v1/projects", self.baseurl,);
-        let mut __progenitor_query = Vec::with_capacity(1usize);
-        __progenitor_query.push(("organization", organization.to_string()));
-        let __progenitor_request = self
+        let _url = format!("{}/v1/projects", self.baseurl,);
+        let mut _query = Vec::with_capacity(1usize);
+        _query.push(("organization", organization.to_string()));
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -15739,36 +15727,36 @@ impl Client {
         project: &'a types::NameOrId,
         organization: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/projects/{}",
             self.baseurl,
             encode_path(&project.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(1usize);
+        let mut _query = Vec::with_capacity(1usize);
         if let Some(v) = &organization {
-            __progenitor_query.push(("organization", v.to_string()));
+            _query.push(("organization", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -15781,37 +15769,37 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         body: &'a types::ProjectUpdate,
     ) -> Result<ResponseValue<types::Project>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/projects/{}",
             self.baseurl,
             encode_path(&project.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(1usize);
+        let mut _query = Vec::with_capacity(1usize);
         if let Some(v) = &organization {
-            __progenitor_query.push(("organization", v.to_string()));
+            _query.push(("organization", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .put(__progenitor_url)
+            .put(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -15823,36 +15811,36 @@ impl Client {
         project: &'a types::NameOrId,
         organization: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/projects/{}",
             self.baseurl,
             encode_path(&project.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(1usize);
+        let mut _query = Vec::with_capacity(1usize);
         if let Some(v) = &organization {
-            __progenitor_query.push(("organization", v.to_string()));
+            _query.push(("organization", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .delete(__progenitor_url)
+            .delete(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -15864,36 +15852,36 @@ impl Client {
         project: &'a types::NameOrId,
         organization: Option<&'a types::NameOrId>,
     ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/projects/{}/policy",
             self.baseurl,
             encode_path(&project.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(1usize);
+        let mut _query = Vec::with_capacity(1usize);
         if let Some(v) = &organization {
-            __progenitor_query.push(("organization", v.to_string()));
+            _query.push(("organization", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -15906,37 +15894,37 @@ impl Client {
         organization: Option<&'a types::NameOrId>,
         body: &'a types::ProjectRolePolicy,
     ) -> Result<ResponseValue<types::ProjectRolePolicy>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/projects/{}/policy",
             self.baseurl,
             encode_path(&project.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(1usize);
+        let mut _query = Vec::with_capacity(1usize);
         if let Some(v) = &organization {
-            __progenitor_query.push(("organization", v.to_string()));
+            _query.push(("organization", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .put(__progenitor_url)
+            .put(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -15955,40 +15943,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UpdateableComponentResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/v1/system/update/components", self.baseurl,);
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let _url = format!("{}/v1/system/update/components", self.baseurl,);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -16053,40 +16041,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::UpdateDeploymentResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/v1/system/update/deployments", self.baseurl,);
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let _url = format!("{}/v1/system/update/deployments", self.baseurl,);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -16143,30 +16131,30 @@ impl Client {
         &'a self,
         id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/system/update/deployments/{}",
             self.baseurl,
             encode_path(&id.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -16176,26 +16164,26 @@ impl Client {
     pub async fn system_update_refresh<'a>(
         &'a self,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/v1/system/update/refresh", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/v1/system/update/refresh", self.baseurl,);
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -16206,27 +16194,27 @@ impl Client {
         &'a self,
         body: &'a types::SystemUpdateStart,
     ) -> Result<ResponseValue<types::UpdateDeployment>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/v1/system/update/start", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/v1/system/update/start", self.baseurl,);
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            202u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            202u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -16238,26 +16226,26 @@ impl Client {
     pub async fn system_update_stop<'a>(
         &'a self,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/v1/system/update/stop", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/v1/system/update/stop", self.baseurl,);
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -16276,40 +16264,40 @@ impl Client {
         page_token: Option<&'a str>,
         sort_by: Option<types::IdSortMode>,
     ) -> Result<ResponseValue<types::SystemUpdateResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/v1/system/update/updates", self.baseurl,);
-        let mut __progenitor_query = Vec::with_capacity(3usize);
+        let _url = format!("{}/v1/system/update/updates", self.baseurl,);
+        let mut _query = Vec::with_capacity(3usize);
         if let Some(v) = &limit {
-            __progenitor_query.push(("limit", v.to_string()));
+            _query.push(("limit", v.to_string()));
         }
 
         if let Some(v) = &page_token {
-            __progenitor_query.push(("page_token", v.to_string()));
+            _query.push(("page_token", v.to_string()));
         }
 
         if let Some(v) = &sort_by {
-            __progenitor_query.push(("sort_by", v.to_string()));
+            _query.push(("sort_by", v.to_string()));
         }
 
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -16366,30 +16354,30 @@ impl Client {
         &'a self,
         version: &'a types::SemverVersion,
     ) -> Result<ResponseValue<types::SystemUpdate>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/system/update/updates/{}",
             self.baseurl,
             encode_path(&version.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -16401,30 +16389,30 @@ impl Client {
         &'a self,
         version: &'a types::SemverVersion,
     ) -> Result<ResponseValue<types::ComponentUpdateResultsPage>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/v1/system/update/updates/{}/components",
             self.baseurl,
             encode_path(&version.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -16434,26 +16422,26 @@ impl Client {
     pub async fn system_version<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::SystemVersion>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/v1/system/update/version", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/v1/system/update/version", self.baseurl,);
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 }

--- a/progenitor-impl/tests/output/param-collision-builder-tagged.out
+++ b/progenitor-impl/tests/output/param-collision-builder-tagged.out
@@ -1,0 +1,236 @@
+#[allow(unused_imports)]
+use progenitor_client::{encode_path, RequestBuilderExt};
+pub use progenitor_client::{ByteStream, Error, ResponseValue};
+#[allow(unused_imports)]
+use reqwest::header::{HeaderMap, HeaderValue};
+pub mod types {
+    use serde::{Deserialize, Serialize};
+    #[allow(unused_imports)]
+    use std::convert::TryFrom;
+}
+
+#[derive(Clone, Debug)]
+///Client for Parameter name collision test
+///
+///Minimal API for testing collision between parameter names and generated code
+///
+///Version: v1
+pub struct Client {
+    pub(crate) baseurl: String,
+    pub(crate) client: reqwest::Client,
+}
+
+impl Client {
+    /// Create a new client.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
+    pub fn new(baseurl: &str) -> Self {
+        #[cfg(not(target_arch = "wasm32"))]
+        let client = {
+            let dur = std::time::Duration::from_secs(15);
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+        };
+        #[cfg(target_arch = "wasm32")]
+        let client = reqwest::ClientBuilder::new();
+        Self::new_with_client(baseurl, client.build().unwrap())
+    }
+
+    /// Construct a new client with an existing `reqwest::Client`,
+    /// allowing more control over its configuration.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
+    pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
+        Self {
+            baseurl: baseurl.to_string(),
+            client,
+        }
+    }
+
+    /// Get the base URL to which requests are made.
+    pub fn baseurl(&self) -> &String {
+        &self.baseurl
+    }
+
+    /// Get the internal `reqwest::Client` used to make requests.
+    pub fn client(&self) -> &reqwest::Client {
+        &self.client
+    }
+
+    /// Get the version of this API.
+    ///
+    /// This string is pulled directly from the source OpenAPI
+    /// document and may be in any format the API selects.
+    pub fn api_version(&self) -> &'static str {
+        "v1"
+    }
+}
+
+impl Client {
+    ///Gets a key
+    ///
+    ///Sends a `GET` request to `/key/{query}`
+    ///
+    ///Arguments:
+    /// - `query`: Parameter name that was previously colliding
+    /// - `client`: Parameter name that was previously colliding
+    /// - `request`: Parameter name that was previously colliding
+    /// - `response`: Parameter name that was previously colliding
+    /// - `result`: Parameter name that was previously colliding
+    /// - `url`: Parameter name that was previously colliding
+    ///```ignore
+    /// let response = client.key_get()
+    ///    .query(query)
+    ///    .client(client)
+    ///    .request(request)
+    ///    .response(response)
+    ///    .result(result)
+    ///    .url(url)
+    ///    .send()
+    ///    .await;
+    /// ```
+    pub fn key_get(&self) -> builder::KeyGet {
+        builder::KeyGet::new(self)
+    }
+}
+
+pub mod builder {
+    use super::types;
+    #[allow(unused_imports)]
+    use super::{
+        encode_path, ByteStream, Error, HeaderMap, HeaderValue, RequestBuilderExt, ResponseValue,
+    };
+    ///Builder for [`Client::key_get`]
+    ///
+    ///[`Client::key_get`]: super::Client::key_get
+    #[derive(Debug, Clone)]
+    pub struct KeyGet<'a> {
+        _client: &'a super::Client,
+        query: Result<bool, String>,
+        client: Result<bool, String>,
+        request: Result<bool, String>,
+        response: Result<bool, String>,
+        result: Result<bool, String>,
+        url: Result<bool, String>,
+    }
+
+    impl<'a> KeyGet<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self {
+                _client: client,
+                query: Err("query was not initialized".to_string()),
+                client: Err("client was not initialized".to_string()),
+                request: Err("request was not initialized".to_string()),
+                response: Err("response was not initialized".to_string()),
+                result: Err("result was not initialized".to_string()),
+                url: Err("url was not initialized".to_string()),
+            }
+        }
+
+        pub fn query<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<bool>,
+        {
+            self.query = value
+                .try_into()
+                .map_err(|_| "conversion to `bool` for query failed".to_string());
+            self
+        }
+
+        pub fn client<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<bool>,
+        {
+            self.client = value
+                .try_into()
+                .map_err(|_| "conversion to `bool` for client failed".to_string());
+            self
+        }
+
+        pub fn request<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<bool>,
+        {
+            self.request = value
+                .try_into()
+                .map_err(|_| "conversion to `bool` for request failed".to_string());
+            self
+        }
+
+        pub fn response<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<bool>,
+        {
+            self.response = value
+                .try_into()
+                .map_err(|_| "conversion to `bool` for response failed".to_string());
+            self
+        }
+
+        pub fn result<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<bool>,
+        {
+            self.result = value
+                .try_into()
+                .map_err(|_| "conversion to `bool` for result failed".to_string());
+            self
+        }
+
+        pub fn url<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<bool>,
+        {
+            self.url = value
+                .try_into()
+                .map_err(|_| "conversion to `bool` for url failed".to_string());
+            self
+        }
+
+        ///Sends a `GET` request to `/key/{query}`
+        pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
+            let Self {
+                _client,
+                query,
+                client,
+                request,
+                response,
+                result,
+                url,
+            } = self;
+            let query = query.map_err(Error::InvalidRequest)?;
+            let client = client.map_err(Error::InvalidRequest)?;
+            let request = request.map_err(Error::InvalidRequest)?;
+            let response = response.map_err(Error::InvalidRequest)?;
+            let result = result.map_err(Error::InvalidRequest)?;
+            let url = url.map_err(Error::InvalidRequest)?;
+            let _url = format!(
+                "{}/key/{}",
+                _client.baseurl,
+                encode_path(&query.to_string()),
+            );
+            let mut _query = Vec::with_capacity(5usize);
+            _query.push(("client", client.to_string()));
+            _query.push(("request", request.to_string()));
+            _query.push(("response", response.to_string()));
+            _query.push(("result", result.to_string()));
+            _query.push(("url", url.to_string()));
+            let _request = _client.client.get(_url).query(&_query).build()?;
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => Ok(ResponseValue::empty(_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
+            }
+        }
+    }
+}
+
+pub mod prelude {
+    pub use super::Client;
+}

--- a/progenitor-impl/tests/output/param-collision-builder.out
+++ b/progenitor-impl/tests/output/param-collision-builder.out
@@ -1,0 +1,236 @@
+#[allow(unused_imports)]
+use progenitor_client::{encode_path, RequestBuilderExt};
+pub use progenitor_client::{ByteStream, Error, ResponseValue};
+#[allow(unused_imports)]
+use reqwest::header::{HeaderMap, HeaderValue};
+pub mod types {
+    use serde::{Deserialize, Serialize};
+    #[allow(unused_imports)]
+    use std::convert::TryFrom;
+}
+
+#[derive(Clone, Debug)]
+///Client for Parameter name collision test
+///
+///Minimal API for testing collision between parameter names and generated code
+///
+///Version: v1
+pub struct Client {
+    pub(crate) baseurl: String,
+    pub(crate) client: reqwest::Client,
+}
+
+impl Client {
+    /// Create a new client.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
+    pub fn new(baseurl: &str) -> Self {
+        #[cfg(not(target_arch = "wasm32"))]
+        let client = {
+            let dur = std::time::Duration::from_secs(15);
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+        };
+        #[cfg(target_arch = "wasm32")]
+        let client = reqwest::ClientBuilder::new();
+        Self::new_with_client(baseurl, client.build().unwrap())
+    }
+
+    /// Construct a new client with an existing `reqwest::Client`,
+    /// allowing more control over its configuration.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
+    pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
+        Self {
+            baseurl: baseurl.to_string(),
+            client,
+        }
+    }
+
+    /// Get the base URL to which requests are made.
+    pub fn baseurl(&self) -> &String {
+        &self.baseurl
+    }
+
+    /// Get the internal `reqwest::Client` used to make requests.
+    pub fn client(&self) -> &reqwest::Client {
+        &self.client
+    }
+
+    /// Get the version of this API.
+    ///
+    /// This string is pulled directly from the source OpenAPI
+    /// document and may be in any format the API selects.
+    pub fn api_version(&self) -> &'static str {
+        "v1"
+    }
+}
+
+impl Client {
+    ///Gets a key
+    ///
+    ///Sends a `GET` request to `/key/{query}`
+    ///
+    ///Arguments:
+    /// - `query`: Parameter name that was previously colliding
+    /// - `client`: Parameter name that was previously colliding
+    /// - `request`: Parameter name that was previously colliding
+    /// - `response`: Parameter name that was previously colliding
+    /// - `result`: Parameter name that was previously colliding
+    /// - `url`: Parameter name that was previously colliding
+    ///```ignore
+    /// let response = client.key_get()
+    ///    .query(query)
+    ///    .client(client)
+    ///    .request(request)
+    ///    .response(response)
+    ///    .result(result)
+    ///    .url(url)
+    ///    .send()
+    ///    .await;
+    /// ```
+    pub fn key_get(&self) -> builder::KeyGet {
+        builder::KeyGet::new(self)
+    }
+}
+
+pub mod builder {
+    use super::types;
+    #[allow(unused_imports)]
+    use super::{
+        encode_path, ByteStream, Error, HeaderMap, HeaderValue, RequestBuilderExt, ResponseValue,
+    };
+    ///Builder for [`Client::key_get`]
+    ///
+    ///[`Client::key_get`]: super::Client::key_get
+    #[derive(Debug, Clone)]
+    pub struct KeyGet<'a> {
+        _client: &'a super::Client,
+        query: Result<bool, String>,
+        client: Result<bool, String>,
+        request: Result<bool, String>,
+        response: Result<bool, String>,
+        result: Result<bool, String>,
+        url: Result<bool, String>,
+    }
+
+    impl<'a> KeyGet<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self {
+                _client: client,
+                query: Err("query was not initialized".to_string()),
+                client: Err("client was not initialized".to_string()),
+                request: Err("request was not initialized".to_string()),
+                response: Err("response was not initialized".to_string()),
+                result: Err("result was not initialized".to_string()),
+                url: Err("url was not initialized".to_string()),
+            }
+        }
+
+        pub fn query<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<bool>,
+        {
+            self.query = value
+                .try_into()
+                .map_err(|_| "conversion to `bool` for query failed".to_string());
+            self
+        }
+
+        pub fn client<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<bool>,
+        {
+            self.client = value
+                .try_into()
+                .map_err(|_| "conversion to `bool` for client failed".to_string());
+            self
+        }
+
+        pub fn request<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<bool>,
+        {
+            self.request = value
+                .try_into()
+                .map_err(|_| "conversion to `bool` for request failed".to_string());
+            self
+        }
+
+        pub fn response<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<bool>,
+        {
+            self.response = value
+                .try_into()
+                .map_err(|_| "conversion to `bool` for response failed".to_string());
+            self
+        }
+
+        pub fn result<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<bool>,
+        {
+            self.result = value
+                .try_into()
+                .map_err(|_| "conversion to `bool` for result failed".to_string());
+            self
+        }
+
+        pub fn url<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<bool>,
+        {
+            self.url = value
+                .try_into()
+                .map_err(|_| "conversion to `bool` for url failed".to_string());
+            self
+        }
+
+        ///Sends a `GET` request to `/key/{query}`
+        pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
+            let Self {
+                _client,
+                query,
+                client,
+                request,
+                response,
+                result,
+                url,
+            } = self;
+            let query = query.map_err(Error::InvalidRequest)?;
+            let client = client.map_err(Error::InvalidRequest)?;
+            let request = request.map_err(Error::InvalidRequest)?;
+            let response = response.map_err(Error::InvalidRequest)?;
+            let result = result.map_err(Error::InvalidRequest)?;
+            let url = url.map_err(Error::InvalidRequest)?;
+            let _url = format!(
+                "{}/key/{}",
+                _client.baseurl,
+                encode_path(&query.to_string()),
+            );
+            let mut _query = Vec::with_capacity(5usize);
+            _query.push(("client", client.to_string()));
+            _query.push(("request", request.to_string()));
+            _query.push(("response", response.to_string()));
+            _query.push(("result", result.to_string()));
+            _query.push(("url", url.to_string()));
+            let _request = _client.client.get(_url).query(&_query).build()?;
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => Ok(ResponseValue::empty(_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
+            }
+        }
+    }
+}
+
+pub mod prelude {
+    pub use self::super::Client;
+}

--- a/progenitor-impl/tests/output/param-collision-cli.out
+++ b/progenitor-impl/tests/output/param-collision-cli.out
@@ -1,0 +1,138 @@
+pub struct Cli<T: CliOverride = ()> {
+    client: sdk::Client,
+    over: T,
+}
+
+impl Cli {
+    pub fn new(client: sdk::Client) -> Self {
+        Self { client, over: () }
+    }
+
+    pub fn get_command(cmd: CliCommand) -> clap::Command {
+        match cmd {
+            CliCommand::KeyGet => Self::cli_key_get(),
+        }
+    }
+
+    pub fn cli_key_get() -> clap::Command {
+        clap::Command::new("")
+            .arg(
+                clap::Arg::new("client")
+                    .long("client")
+                    .value_parser(clap::value_parser!(bool))
+                    .required(true)
+                    .help("Parameter name that was previously colliding"),
+            )
+            .arg(
+                clap::Arg::new("query")
+                    .long("query")
+                    .value_parser(clap::value_parser!(bool))
+                    .required(true)
+                    .help("Parameter name that was previously colliding"),
+            )
+            .arg(
+                clap::Arg::new("request")
+                    .long("request")
+                    .value_parser(clap::value_parser!(bool))
+                    .required(true)
+                    .help("Parameter name that was previously colliding"),
+            )
+            .arg(
+                clap::Arg::new("response")
+                    .long("response")
+                    .value_parser(clap::value_parser!(bool))
+                    .required(true)
+                    .help("Parameter name that was previously colliding"),
+            )
+            .arg(
+                clap::Arg::new("result")
+                    .long("result")
+                    .value_parser(clap::value_parser!(bool))
+                    .required(true)
+                    .help("Parameter name that was previously colliding"),
+            )
+            .arg(
+                clap::Arg::new("url")
+                    .long("url")
+                    .value_parser(clap::value_parser!(bool))
+                    .required(true)
+                    .help("Parameter name that was previously colliding"),
+            )
+            .long_about("Gets a key")
+    }
+}
+
+impl<T: CliOverride> Cli<T> {
+    pub fn new_with_override(client: sdk::Client, over: T) -> Self {
+        Self { client, over }
+    }
+
+    pub async fn execute(&self, cmd: CliCommand, matches: &clap::ArgMatches) {
+        match cmd {
+            CliCommand::KeyGet => {
+                self.execute_key_get(matches).await;
+            }
+        }
+    }
+
+    pub async fn execute_key_get(&self, matches: &clap::ArgMatches) {
+        let mut request = self.client.key_get();
+        if let Some(value) = matches.get_one::<bool>("client") {
+            request = request.client(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<bool>("query") {
+            request = request.query(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<bool>("request") {
+            request = request.request(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<bool>("response") {
+            request = request.response(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<bool>("result") {
+            request = request.result(value.clone());
+        }
+
+        if let Some(value) = matches.get_one::<bool>("url") {
+            request = request.url(value.clone());
+        }
+
+        self.over.execute_key_get(matches, &mut request).unwrap();
+        let result = request.send().await;
+        match result {
+            Ok(r) => {
+                println!("success\n{:#?}", r)
+            }
+            Err(r) => {
+                println!("success\n{:#?}", r)
+            }
+        }
+    }
+}
+
+pub trait CliOverride {
+    fn execute_key_get(
+        &self,
+        matches: &clap::ArgMatches,
+        request: &mut builder::KeyGet,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+impl CliOverride for () {}
+
+#[derive(Copy, Clone, Debug)]
+pub enum CliCommand {
+    KeyGet,
+}
+
+impl CliCommand {
+    pub fn iter() -> impl Iterator<Item = CliCommand> {
+        vec![CliCommand::KeyGet].into_iter()
+    }
+}

--- a/progenitor-impl/tests/output/param-collision-httpmock.out
+++ b/progenitor-impl/tests/output/param-collision-httpmock.out
@@ -1,0 +1,84 @@
+pub mod operations {
+    #![doc = r" [`When`](httpmock::When) and [`Then`](httpmock::Then)"]
+    #![doc = r" wrappers for each operation. Each can be converted to"]
+    #![doc = r" its inner type with a call to `into_inner()`. This can"]
+    #![doc = r" be used to explicitly deviate from permitted values."]
+    use sdk::*;
+    pub struct KeyGetWhen(httpmock::When);
+    impl KeyGetWhen {
+        pub fn new(inner: httpmock::When) -> Self {
+            Self(
+                inner
+                    .method(httpmock::Method::GET)
+                    .path_matches(regex::Regex::new("^/key/[^/]*$").unwrap()),
+            )
+        }
+
+        pub fn into_inner(self) -> httpmock::When {
+            self.0
+        }
+
+        pub fn query(self, value: bool) -> Self {
+            let re = regex::Regex::new(&format!("^/key/{}$", value.to_string())).unwrap();
+            Self(self.0.path_matches(re))
+        }
+
+        pub fn client(self, value: bool) -> Self {
+            Self(self.0.query_param("client", value.to_string()))
+        }
+
+        pub fn request(self, value: bool) -> Self {
+            Self(self.0.query_param("request", value.to_string()))
+        }
+
+        pub fn response(self, value: bool) -> Self {
+            Self(self.0.query_param("response", value.to_string()))
+        }
+
+        pub fn result(self, value: bool) -> Self {
+            Self(self.0.query_param("result", value.to_string()))
+        }
+
+        pub fn url(self, value: bool) -> Self {
+            Self(self.0.query_param("url", value.to_string()))
+        }
+    }
+
+    pub struct KeyGetThen(httpmock::Then);
+    impl KeyGetThen {
+        pub fn new(inner: httpmock::Then) -> Self {
+            Self(inner)
+        }
+
+        pub fn into_inner(self) -> httpmock::Then {
+            self.0
+        }
+
+        pub fn ok(self) -> Self {
+            Self(self.0.status(200u16))
+        }
+    }
+}
+
+#[doc = r" An extension trait for [`MockServer`](httpmock::MockServer) that"]
+#[doc = r" adds a method for each operation. These are the equivalent of"]
+#[doc = r" type-checked [`mock()`](httpmock::MockServer::mock) calls."]
+pub trait MockServerExt {
+    fn key_get<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(operations::KeyGetWhen, operations::KeyGetThen);
+}
+
+impl MockServerExt for httpmock::MockServer {
+    fn key_get<F>(&self, config_fn: F) -> httpmock::Mock
+    where
+        F: FnOnce(operations::KeyGetWhen, operations::KeyGetThen),
+    {
+        self.mock(|when, then| {
+            config_fn(
+                operations::KeyGetWhen::new(when),
+                operations::KeyGetThen::new(then),
+            )
+        })
+    }
+}

--- a/progenitor-impl/tests/output/param-collision-positional.out
+++ b/progenitor-impl/tests/output/param-collision-positional.out
@@ -1,0 +1,114 @@
+#[allow(unused_imports)]
+use progenitor_client::{encode_path, RequestBuilderExt};
+pub use progenitor_client::{ByteStream, Error, ResponseValue};
+#[allow(unused_imports)]
+use reqwest::header::{HeaderMap, HeaderValue};
+pub mod types {
+    use serde::{Deserialize, Serialize};
+    #[allow(unused_imports)]
+    use std::convert::TryFrom;
+}
+
+#[derive(Clone, Debug)]
+///Client for Parameter name collision test
+///
+///Minimal API for testing collision between parameter names and generated code
+///
+///Version: v1
+pub struct Client {
+    pub(crate) baseurl: String,
+    pub(crate) client: reqwest::Client,
+}
+
+impl Client {
+    /// Create a new client.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
+    pub fn new(baseurl: &str) -> Self {
+        #[cfg(not(target_arch = "wasm32"))]
+        let client = {
+            let dur = std::time::Duration::from_secs(15);
+            reqwest::ClientBuilder::new()
+                .connect_timeout(dur)
+                .timeout(dur)
+        };
+        #[cfg(target_arch = "wasm32")]
+        let client = reqwest::ClientBuilder::new();
+        Self::new_with_client(baseurl, client.build().unwrap())
+    }
+
+    /// Construct a new client with an existing `reqwest::Client`,
+    /// allowing more control over its configuration.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
+    pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
+        Self {
+            baseurl: baseurl.to_string(),
+            client,
+        }
+    }
+
+    /// Get the base URL to which requests are made.
+    pub fn baseurl(&self) -> &String {
+        &self.baseurl
+    }
+
+    /// Get the internal `reqwest::Client` used to make requests.
+    pub fn client(&self) -> &reqwest::Client {
+        &self.client
+    }
+
+    /// Get the version of this API.
+    ///
+    /// This string is pulled directly from the source OpenAPI
+    /// document and may be in any format the API selects.
+    pub fn api_version(&self) -> &'static str {
+        "v1"
+    }
+}
+
+impl Client {
+    ///Gets a key
+    ///
+    ///Sends a `GET` request to `/key/{query}`
+    ///
+    ///Arguments:
+    /// - `query`: Parameter name that was previously colliding
+    /// - `client`: Parameter name that was previously colliding
+    /// - `request`: Parameter name that was previously colliding
+    /// - `response`: Parameter name that was previously colliding
+    /// - `result`: Parameter name that was previously colliding
+    /// - `url`: Parameter name that was previously colliding
+    pub async fn key_get<'a>(
+        &'a self,
+        query: bool,
+        client: bool,
+        request: bool,
+        response: bool,
+        result: bool,
+        url: bool,
+    ) -> Result<ResponseValue<()>, Error<()>> {
+        let _url = format!("{}/key/{}", self.baseurl, encode_path(&query.to_string()),);
+        let mut _query = Vec::with_capacity(5usize);
+        _query.push(("client", client.to_string()));
+        _query.push(("request", request.to_string()));
+        _query.push(("response", response.to_string()));
+        _query.push(("result", result.to_string()));
+        _query.push(("url", url.to_string()));
+        let _request = self.client.get(_url).query(&_query).build()?;
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => Ok(ResponseValue::empty(_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
+        }
+    }
+}
+
+pub mod prelude {
+    pub use super::Client;
+}

--- a/progenitor-impl/tests/output/param-overrides-builder-tagged.out
+++ b/progenitor-impl/tests/output/param-overrides-builder-tagged.out
@@ -104,7 +104,7 @@ pub mod builder {
     ///[`Client::key_get`]: super::Client::key_get
     #[derive(Debug, Clone)]
     pub struct KeyGet<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         key: Result<Option<bool>, String>,
         unique_key: Result<Option<String>, String>,
     }
@@ -112,7 +112,7 @@ pub mod builder {
     impl<'a> KeyGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 key: Ok(None),
                 unique_key: Ok(None),
             }
@@ -143,26 +143,26 @@ pub mod builder {
         ///Sends a `GET` request to `/key`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self {
-                _client,
+                client,
                 key,
                 unique_key,
             } = self;
             let key = key.map_err(Error::InvalidRequest)?;
             let unique_key = unique_key.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/key", _client.baseurl,);
-            let mut _query = Vec::with_capacity(2usize);
+            let url = format!("{}/key", client.baseurl,);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &key {
-                _query.push(("key", v.to_string()));
+                query.push(("key", v.to_string()));
             }
             if let Some(v) = &unique_key {
-                _query.push(("uniqueKey", v.to_string()));
+                query.push(("uniqueKey", v.to_string()));
             }
-            let _request = _client.client.get(_url).query(&_query).build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(_response)),
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let request = client.client.get(url).query(&query).build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => Ok(ResponseValue::empty(response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/param-overrides-builder-tagged.out
+++ b/progenitor-impl/tests/output/param-overrides-builder-tagged.out
@@ -104,7 +104,7 @@ pub mod builder {
     ///[`Client::key_get`]: super::Client::key_get
     #[derive(Debug, Clone)]
     pub struct KeyGet<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         key: Result<Option<bool>, String>,
         unique_key: Result<Option<String>, String>,
     }
@@ -112,7 +112,7 @@ pub mod builder {
     impl<'a> KeyGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 key: Ok(None),
                 unique_key: Ok(None),
             }
@@ -143,33 +143,26 @@ pub mod builder {
         ///Sends a `GET` request to `/key`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self {
-                __progenitor_client,
+                _client,
                 key,
                 unique_key,
             } = self;
             let key = key.map_err(Error::InvalidRequest)?;
             let unique_key = unique_key.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/key", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let _url = format!("{}/key", _client.baseurl,);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &key {
-                __progenitor_query.push(("key", v.to_string()));
+                _query.push(("key", v.to_string()));
             }
             if let Some(v) = &unique_key {
-                __progenitor_query.push(("uniqueKey", v.to_string()));
+                _query.push(("uniqueKey", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
-                .client
-                .get(__progenitor_url)
-                .query(&__progenitor_query)
-                .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(__progenitor_response)),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _request = _client.client.get(_url).query(&_query).build()?;
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => Ok(ResponseValue::empty(_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/param-overrides-builder.out
+++ b/progenitor-impl/tests/output/param-overrides-builder.out
@@ -104,7 +104,7 @@ pub mod builder {
     ///[`Client::key_get`]: super::Client::key_get
     #[derive(Debug, Clone)]
     pub struct KeyGet<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         key: Result<Option<bool>, String>,
         unique_key: Result<Option<String>, String>,
     }
@@ -112,7 +112,7 @@ pub mod builder {
     impl<'a> KeyGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 key: Ok(None),
                 unique_key: Ok(None),
             }
@@ -143,26 +143,26 @@ pub mod builder {
         ///Sends a `GET` request to `/key`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self {
-                _client,
+                client,
                 key,
                 unique_key,
             } = self;
             let key = key.map_err(Error::InvalidRequest)?;
             let unique_key = unique_key.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/key", _client.baseurl,);
-            let mut _query = Vec::with_capacity(2usize);
+            let url = format!("{}/key", client.baseurl,);
+            let mut query = Vec::with_capacity(2usize);
             if let Some(v) = &key {
-                _query.push(("key", v.to_string()));
+                query.push(("key", v.to_string()));
             }
             if let Some(v) = &unique_key {
-                _query.push(("uniqueKey", v.to_string()));
+                query.push(("uniqueKey", v.to_string()));
             }
-            let _request = _client.client.get(_url).query(&_query).build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(_response)),
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let request = client.client.get(url).query(&query).build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => Ok(ResponseValue::empty(response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/param-overrides-builder.out
+++ b/progenitor-impl/tests/output/param-overrides-builder.out
@@ -104,7 +104,7 @@ pub mod builder {
     ///[`Client::key_get`]: super::Client::key_get
     #[derive(Debug, Clone)]
     pub struct KeyGet<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         key: Result<Option<bool>, String>,
         unique_key: Result<Option<String>, String>,
     }
@@ -112,7 +112,7 @@ pub mod builder {
     impl<'a> KeyGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 key: Ok(None),
                 unique_key: Ok(None),
             }
@@ -143,33 +143,26 @@ pub mod builder {
         ///Sends a `GET` request to `/key`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<()>> {
             let Self {
-                __progenitor_client,
+                _client,
                 key,
                 unique_key,
             } = self;
             let key = key.map_err(Error::InvalidRequest)?;
             let unique_key = unique_key.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/key", __progenitor_client.baseurl,);
-            let mut __progenitor_query = Vec::with_capacity(2usize);
+            let _url = format!("{}/key", _client.baseurl,);
+            let mut _query = Vec::with_capacity(2usize);
             if let Some(v) = &key {
-                __progenitor_query.push(("key", v.to_string()));
+                _query.push(("key", v.to_string()));
             }
             if let Some(v) = &unique_key {
-                __progenitor_query.push(("uniqueKey", v.to_string()));
+                _query.push(("uniqueKey", v.to_string()));
             }
-            let __progenitor_request = __progenitor_client
-                .client
-                .get(__progenitor_url)
-                .query(&__progenitor_query)
-                .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => Ok(ResponseValue::empty(__progenitor_response)),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _request = _client.client.get(_url).query(&_query).build()?;
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => Ok(ResponseValue::empty(_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/param-overrides-positional.out
+++ b/progenitor-impl/tests/output/param-overrides-positional.out
@@ -86,26 +86,22 @@ impl Client {
         key: Option<bool>,
         unique_key: Option<&'a str>,
     ) -> Result<ResponseValue<()>, Error<()>> {
-        let __progenitor_url = format!("{}/key", self.baseurl,);
-        let mut __progenitor_query = Vec::with_capacity(2usize);
+        let _url = format!("{}/key", self.baseurl,);
+        let mut _query = Vec::with_capacity(2usize);
         if let Some(v) = &key {
-            __progenitor_query.push(("key", v.to_string()));
+            _query.push(("key", v.to_string()));
         }
 
         if let Some(v) = &unique_key {
-            __progenitor_query.push(("uniqueKey", v.to_string()));
+            _query.push(("uniqueKey", v.to_string()));
         }
 
-        let __progenitor_request = self
-            .client
-            .get(__progenitor_url)
-            .query(&__progenitor_query)
-            .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => Ok(ResponseValue::empty(__progenitor_response)),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+        let _request = self.client.get(_url).query(&_query).build()?;
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => Ok(ResponseValue::empty(_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 }

--- a/progenitor-impl/tests/output/param-overrides-positional.out
+++ b/progenitor-impl/tests/output/param-overrides-positional.out
@@ -86,22 +86,22 @@ impl Client {
         key: Option<bool>,
         unique_key: Option<&'a str>,
     ) -> Result<ResponseValue<()>, Error<()>> {
-        let _url = format!("{}/key", self.baseurl,);
-        let mut _query = Vec::with_capacity(2usize);
+        let url = format!("{}/key", self.baseurl,);
+        let mut query = Vec::with_capacity(2usize);
         if let Some(v) = &key {
-            _query.push(("key", v.to_string()));
+            query.push(("key", v.to_string()));
         }
 
         if let Some(v) = &unique_key {
-            _query.push(("uniqueKey", v.to_string()));
+            query.push(("uniqueKey", v.to_string()));
         }
 
-        let _request = self.client.get(_url).query(&_query).build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => Ok(ResponseValue::empty(_response)),
-            _ => Err(Error::UnexpectedResponse(_response)),
+        let request = self.client.get(url).query(&query).build()?;
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => Ok(ResponseValue::empty(response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 }

--- a/progenitor-impl/tests/output/propolis-server-builder-tagged.out
+++ b/progenitor-impl/tests/output/propolis-server-builder-tagged.out
@@ -2113,46 +2113,39 @@ pub mod builder {
     ///[`Client::instance_get`]: super::Client::instance_get
     #[derive(Debug, Clone)]
     pub struct InstanceGet<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> InstanceGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `GET` request to `/instance`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url = format!("{}/instance", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/instance", _client.baseurl,);
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2162,14 +2155,14 @@ pub mod builder {
     ///[`Client::instance_ensure`]: super::Client::instance_ensure
     #[derive(Debug, Clone)]
     pub struct InstanceEnsure<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::InstanceEnsureRequest, String>,
     }
 
     impl<'a> InstanceEnsure<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::InstanceEnsureRequest::default()),
             }
         }
@@ -2199,37 +2192,31 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::InstanceEnsureResponse>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceEnsureRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/instance", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/instance", _client.baseurl,);
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2239,7 +2226,7 @@ pub mod builder {
     ///[`Client::instance_issue_crucible_snapshot_request`]: super::Client::instance_issue_crucible_snapshot_request
     #[derive(Debug, Clone)]
     pub struct InstanceIssueCrucibleSnapshotRequest<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
         snapshot_id: Result<uuid::Uuid, String>,
     }
@@ -2247,7 +2234,7 @@ pub mod builder {
     impl<'a> InstanceIssueCrucibleSnapshotRequest<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
                 snapshot_id: Err("snapshot_id was not initialized".to_string()),
             }
@@ -2277,40 +2264,37 @@ pub mod builder {
         /// `/instance/disk/{id}/snapshot/{snapshot_id}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 id,
                 snapshot_id,
             } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let snapshot_id = snapshot_id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/instance/disk/{}/snapshot/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
                 encode_path(&snapshot_id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2320,14 +2304,14 @@ pub mod builder {
     ///[`Client::instance_migrate_status`]: super::Client::instance_migrate_status
     #[derive(Debug, Clone)]
     pub struct InstanceMigrateStatus<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::InstanceMigrateStatusRequest, String>,
     }
 
     impl<'a> InstanceMigrateStatus<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::InstanceMigrateStatusRequest::default()),
             }
         }
@@ -2357,38 +2341,31 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceMigrateStatusResponse>, Error<types::Error>>
         {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceMigrateStatusRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url =
-                format!("{}/instance/migrate/status", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/instance/migrate/status", _client.baseurl,);
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2398,27 +2375,23 @@ pub mod builder {
     ///[`Client::instance_serial`]: super::Client::instance_serial
     #[derive(Debug, Clone)]
     pub struct InstanceSerial<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> InstanceSerial<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `GET` request to `/instance/serial`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url = format!("{}/instance/serial", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/instance/serial", _client.baseurl,);
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(reqwest::header::CONNECTION, "Upgrade")
                 .header(reqwest::header::UPGRADE, "websocket")
                 .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -2430,15 +2403,12 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                101u16 => ResponseValue::upgrade(__progenitor_response).await,
-                200..=299 => ResponseValue::upgrade(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                101u16 => ResponseValue::upgrade(_response).await,
+                200..=299 => ResponseValue::upgrade(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2448,14 +2418,14 @@ pub mod builder {
     ///[`Client::instance_state_put`]: super::Client::instance_state_put
     #[derive(Debug, Clone)]
     pub struct InstanceStatePut<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::InstanceStateRequested, String>,
     }
 
     impl<'a> InstanceStatePut<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -2472,35 +2442,29 @@ pub mod builder {
 
         ///Sends a `PUT` request to `/instance/state`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/instance/state", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/instance/state", _client.baseurl,);
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2510,14 +2474,14 @@ pub mod builder {
     ///[`Client::instance_state_monitor`]: super::Client::instance_state_monitor
     #[derive(Debug, Clone)]
     pub struct InstanceStateMonitor<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::InstanceStateMonitorRequest, String>,
     }
 
     impl<'a> InstanceStateMonitor<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::InstanceStateMonitorRequest::default()),
             }
         }
@@ -2547,38 +2511,31 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceStateMonitorResponse>, Error<types::Error>>
         {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceStateMonitorRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url =
-                format!("{}/instance/state-monitor", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/instance/state-monitor", _client.baseurl,);
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/propolis-server-builder-tagged.out
+++ b/progenitor-impl/tests/output/propolis-server-builder-tagged.out
@@ -2113,39 +2113,39 @@ pub mod builder {
     ///[`Client::instance_get`]: super::Client::instance_get
     #[derive(Debug, Clone)]
     pub struct InstanceGet<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> InstanceGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `GET` request to `/instance`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
-            let Self { _client } = self;
-            let _url = format!("{}/instance", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/instance", client.baseurl,);
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2155,14 +2155,14 @@ pub mod builder {
     ///[`Client::instance_ensure`]: super::Client::instance_ensure
     #[derive(Debug, Clone)]
     pub struct InstanceEnsure<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::InstanceEnsureRequest, String>,
     }
 
     impl<'a> InstanceEnsure<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::InstanceEnsureRequest::default()),
             }
         }
@@ -2192,31 +2192,31 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::InstanceEnsureResponse>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceEnsureRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/instance", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/instance", client.baseurl,);
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2226,7 +2226,7 @@ pub mod builder {
     ///[`Client::instance_issue_crucible_snapshot_request`]: super::Client::instance_issue_crucible_snapshot_request
     #[derive(Debug, Clone)]
     pub struct InstanceIssueCrucibleSnapshotRequest<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
         snapshot_id: Result<uuid::Uuid, String>,
     }
@@ -2234,7 +2234,7 @@ pub mod builder {
     impl<'a> InstanceIssueCrucibleSnapshotRequest<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
                 snapshot_id: Err("snapshot_id was not initialized".to_string()),
             }
@@ -2264,37 +2264,37 @@ pub mod builder {
         /// `/instance/disk/{id}/snapshot/{snapshot_id}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 id,
                 snapshot_id,
             } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let snapshot_id = snapshot_id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/instance/disk/{}/snapshot/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
                 encode_path(&snapshot_id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2304,14 +2304,14 @@ pub mod builder {
     ///[`Client::instance_migrate_status`]: super::Client::instance_migrate_status
     #[derive(Debug, Clone)]
     pub struct InstanceMigrateStatus<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::InstanceMigrateStatusRequest, String>,
     }
 
     impl<'a> InstanceMigrateStatus<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::InstanceMigrateStatusRequest::default()),
             }
         }
@@ -2341,31 +2341,31 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceMigrateStatusResponse>, Error<types::Error>>
         {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceMigrateStatusRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/instance/migrate/status", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/instance/migrate/status", client.baseurl,);
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2375,23 +2375,23 @@ pub mod builder {
     ///[`Client::instance_serial`]: super::Client::instance_serial
     #[derive(Debug, Clone)]
     pub struct InstanceSerial<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> InstanceSerial<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `GET` request to `/instance/serial`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
-            let Self { _client } = self;
-            let _url = format!("{}/instance/serial", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/instance/serial", client.baseurl,);
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(reqwest::header::CONNECTION, "Upgrade")
                 .header(reqwest::header::UPGRADE, "websocket")
                 .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -2403,12 +2403,12 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                101u16 => ResponseValue::upgrade(_response).await,
-                200..=299 => ResponseValue::upgrade(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                101u16 => ResponseValue::upgrade(response).await,
+                200..=299 => ResponseValue::upgrade(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2418,14 +2418,14 @@ pub mod builder {
     ///[`Client::instance_state_put`]: super::Client::instance_state_put
     #[derive(Debug, Clone)]
     pub struct InstanceStatePut<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::InstanceStateRequested, String>,
     }
 
     impl<'a> InstanceStatePut<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -2442,29 +2442,29 @@ pub mod builder {
 
         ///Sends a `PUT` request to `/instance/state`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/instance/state", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/instance/state", client.baseurl,);
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2474,14 +2474,14 @@ pub mod builder {
     ///[`Client::instance_state_monitor`]: super::Client::instance_state_monitor
     #[derive(Debug, Clone)]
     pub struct InstanceStateMonitor<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::InstanceStateMonitorRequest, String>,
     }
 
     impl<'a> InstanceStateMonitor<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::InstanceStateMonitorRequest::default()),
             }
         }
@@ -2511,31 +2511,31 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceStateMonitorResponse>, Error<types::Error>>
         {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceStateMonitorRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/instance/state-monitor", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/instance/state-monitor", client.baseurl,);
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/propolis-server-builder.out
+++ b/progenitor-impl/tests/output/propolis-server-builder.out
@@ -2119,39 +2119,39 @@ pub mod builder {
     ///[`Client::instance_get`]: super::Client::instance_get
     #[derive(Debug, Clone)]
     pub struct InstanceGet<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> InstanceGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `GET` request to `/instance`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
-            let Self { _client } = self;
-            let _url = format!("{}/instance", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/instance", client.baseurl,);
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2161,14 +2161,14 @@ pub mod builder {
     ///[`Client::instance_ensure`]: super::Client::instance_ensure
     #[derive(Debug, Clone)]
     pub struct InstanceEnsure<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::InstanceEnsureRequest, String>,
     }
 
     impl<'a> InstanceEnsure<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::InstanceEnsureRequest::default()),
             }
         }
@@ -2198,31 +2198,31 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::InstanceEnsureResponse>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceEnsureRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/instance", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/instance", client.baseurl,);
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                201u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                201u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2232,7 +2232,7 @@ pub mod builder {
     ///[`Client::instance_issue_crucible_snapshot_request`]: super::Client::instance_issue_crucible_snapshot_request
     #[derive(Debug, Clone)]
     pub struct InstanceIssueCrucibleSnapshotRequest<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
         snapshot_id: Result<uuid::Uuid, String>,
     }
@@ -2240,7 +2240,7 @@ pub mod builder {
     impl<'a> InstanceIssueCrucibleSnapshotRequest<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 id: Err("id was not initialized".to_string()),
                 snapshot_id: Err("snapshot_id was not initialized".to_string()),
             }
@@ -2270,37 +2270,37 @@ pub mod builder {
         /// `/instance/disk/{id}/snapshot/{snapshot_id}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                _client,
+                client,
                 id,
                 snapshot_id,
             } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let snapshot_id = snapshot_id.map_err(Error::InvalidRequest)?;
-            let _url = format!(
+            let url = format!(
                 "{}/instance/disk/{}/snapshot/{}",
-                _client.baseurl,
+                client.baseurl,
                 encode_path(&id.to_string()),
                 encode_path(&snapshot_id.to_string()),
             );
-            let _request = _client
+            let request = client
                 .client
-                .post(_url)
+                .post(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2310,14 +2310,14 @@ pub mod builder {
     ///[`Client::instance_migrate_status`]: super::Client::instance_migrate_status
     #[derive(Debug, Clone)]
     pub struct InstanceMigrateStatus<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::InstanceMigrateStatusRequest, String>,
     }
 
     impl<'a> InstanceMigrateStatus<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::InstanceMigrateStatusRequest::default()),
             }
         }
@@ -2347,31 +2347,31 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceMigrateStatusResponse>, Error<types::Error>>
         {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceMigrateStatusRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/instance/migrate/status", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/instance/migrate/status", client.baseurl,);
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2381,23 +2381,23 @@ pub mod builder {
     ///[`Client::instance_serial`]: super::Client::instance_serial
     #[derive(Debug, Clone)]
     pub struct InstanceSerial<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
     }
 
     impl<'a> InstanceSerial<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { _client: client }
+            Self { client: client }
         }
 
         ///Sends a `GET` request to `/instance/serial`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
-            let Self { _client } = self;
-            let _url = format!("{}/instance/serial", _client.baseurl,);
-            let _request = _client
+            let Self { client } = self;
+            let url = format!("{}/instance/serial", client.baseurl,);
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(reqwest::header::CONNECTION, "Upgrade")
                 .header(reqwest::header::UPGRADE, "websocket")
                 .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -2409,12 +2409,12 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                101u16 => ResponseValue::upgrade(_response).await,
-                200..=299 => ResponseValue::upgrade(_response).await,
-                _ => Err(Error::UnexpectedResponse(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                101u16 => ResponseValue::upgrade(response).await,
+                200..=299 => ResponseValue::upgrade(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2424,14 +2424,14 @@ pub mod builder {
     ///[`Client::instance_state_put`]: super::Client::instance_state_put
     #[derive(Debug, Clone)]
     pub struct InstanceStatePut<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::InstanceStateRequested, String>,
     }
 
     impl<'a> InstanceStatePut<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -2448,29 +2448,29 @@ pub mod builder {
 
         ///Sends a `PUT` request to `/instance/state`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/instance/state", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/instance/state", client.baseurl,);
+            let request = client
                 .client
-                .put(_url)
+                .put(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(_response)),
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }
@@ -2480,14 +2480,14 @@ pub mod builder {
     ///[`Client::instance_state_monitor`]: super::Client::instance_state_monitor
     #[derive(Debug, Clone)]
     pub struct InstanceStateMonitor<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::InstanceStateMonitorRequest, String>,
     }
 
     impl<'a> InstanceStateMonitor<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::InstanceStateMonitorRequest::default()),
             }
         }
@@ -2517,31 +2517,31 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceStateMonitorResponse>, Error<types::Error>>
         {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceStateMonitorRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/instance/state-monitor", _client.baseurl,);
-            let _request = _client
+            let url = format!("{}/instance/state-monitor", client.baseurl,);
+            let request = client
                 .client
-                .get(_url)
+                .get(url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200u16 => ResponseValue::from_response(_response).await,
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(_response).await?,
+                    ResponseValue::from_response(response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(_response)),
+                _ => Err(Error::UnexpectedResponse(response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/propolis-server-builder.out
+++ b/progenitor-impl/tests/output/propolis-server-builder.out
@@ -2119,46 +2119,39 @@ pub mod builder {
     ///[`Client::instance_get`]: super::Client::instance_get
     #[derive(Debug, Clone)]
     pub struct InstanceGet<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> InstanceGet<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `GET` request to `/instance`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url = format!("{}/instance", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/instance", _client.baseurl,);
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2168,14 +2161,14 @@ pub mod builder {
     ///[`Client::instance_ensure`]: super::Client::instance_ensure
     #[derive(Debug, Clone)]
     pub struct InstanceEnsure<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::InstanceEnsureRequest, String>,
     }
 
     impl<'a> InstanceEnsure<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::InstanceEnsureRequest::default()),
             }
         }
@@ -2205,37 +2198,31 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::InstanceEnsureResponse>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceEnsureRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/instance", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/instance", _client.baseurl,);
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                201u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                201u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2245,7 +2232,7 @@ pub mod builder {
     ///[`Client::instance_issue_crucible_snapshot_request`]: super::Client::instance_issue_crucible_snapshot_request
     #[derive(Debug, Clone)]
     pub struct InstanceIssueCrucibleSnapshotRequest<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         id: Result<uuid::Uuid, String>,
         snapshot_id: Result<uuid::Uuid, String>,
     }
@@ -2253,7 +2240,7 @@ pub mod builder {
     impl<'a> InstanceIssueCrucibleSnapshotRequest<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 id: Err("id was not initialized".to_string()),
                 snapshot_id: Err("snapshot_id was not initialized".to_string()),
             }
@@ -2283,40 +2270,37 @@ pub mod builder {
         /// `/instance/disk/{id}/snapshot/{snapshot_id}`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
             let Self {
-                __progenitor_client,
+                _client,
                 id,
                 snapshot_id,
             } = self;
             let id = id.map_err(Error::InvalidRequest)?;
             let snapshot_id = snapshot_id.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!(
+            let _url = format!(
                 "{}/instance/disk/{}/snapshot/{}",
-                __progenitor_client.baseurl,
+                _client.baseurl,
                 encode_path(&id.to_string()),
                 encode_path(&snapshot_id.to_string()),
             );
-            let __progenitor_request = __progenitor_client
+            let _request = _client
                 .client
-                .post(__progenitor_url)
+                .post(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2326,14 +2310,14 @@ pub mod builder {
     ///[`Client::instance_migrate_status`]: super::Client::instance_migrate_status
     #[derive(Debug, Clone)]
     pub struct InstanceMigrateStatus<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::InstanceMigrateStatusRequest, String>,
     }
 
     impl<'a> InstanceMigrateStatus<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::InstanceMigrateStatusRequest::default()),
             }
         }
@@ -2363,38 +2347,31 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceMigrateStatusResponse>, Error<types::Error>>
         {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceMigrateStatusRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url =
-                format!("{}/instance/migrate/status", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/instance/migrate/status", _client.baseurl,);
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2404,27 +2381,23 @@ pub mod builder {
     ///[`Client::instance_serial`]: super::Client::instance_serial
     #[derive(Debug, Clone)]
     pub struct InstanceSerial<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
     }
 
     impl<'a> InstanceSerial<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self {
-                __progenitor_client: client,
-            }
+            Self { _client: client }
         }
 
         ///Sends a `GET` request to `/instance/serial`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
-            let Self {
-                __progenitor_client,
-            } = self;
-            let __progenitor_url = format!("{}/instance/serial", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let Self { _client } = self;
+            let _url = format!("{}/instance/serial", _client.baseurl,);
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(reqwest::header::CONNECTION, "Upgrade")
                 .header(reqwest::header::UPGRADE, "websocket")
                 .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -2436,15 +2409,12 @@ pub mod builder {
                     ),
                 )
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                101u16 => ResponseValue::upgrade(__progenitor_response).await,
-                200..=299 => ResponseValue::upgrade(__progenitor_response).await,
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                101u16 => ResponseValue::upgrade(_response).await,
+                200..=299 => ResponseValue::upgrade(_response).await,
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2454,14 +2424,14 @@ pub mod builder {
     ///[`Client::instance_state_put`]: super::Client::instance_state_put
     #[derive(Debug, Clone)]
     pub struct InstanceStatePut<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::InstanceStateRequested, String>,
     }
 
     impl<'a> InstanceStatePut<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -2478,35 +2448,29 @@ pub mod builder {
 
         ///Sends a `PUT` request to `/instance/state`
         pub async fn send(self) -> Result<ResponseValue<()>, Error<types::Error>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body.map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/instance/state", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/instance/state", _client.baseurl,);
+            let _request = _client
                 .client
-                .put(__progenitor_url)
+                .put(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                204u16 => Ok(ResponseValue::empty(_response)),
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }
@@ -2516,14 +2480,14 @@ pub mod builder {
     ///[`Client::instance_state_monitor`]: super::Client::instance_state_monitor
     #[derive(Debug, Clone)]
     pub struct InstanceStateMonitor<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::InstanceStateMonitorRequest, String>,
     }
 
     impl<'a> InstanceStateMonitor<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::InstanceStateMonitorRequest::default()),
             }
         }
@@ -2553,38 +2517,31 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::InstanceStateMonitorResponse>, Error<types::Error>>
         {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::InstanceStateMonitorRequest>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url =
-                format!("{}/instance/state-monitor", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
+            let _url = format!("{}/instance/state-monitor", _client.baseurl,);
+            let _request = _client
                 .client
-                .get(__progenitor_url)
+                .get(_url)
                 .header(
                     reqwest::header::ACCEPT,
                     reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
                 .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200u16 => ResponseValue::from_response(__progenitor_response).await,
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200u16 => ResponseValue::from_response(_response).await,
                 400u16..=499u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
                 500u16..=599u16 => Err(Error::ErrorResponse(
-                    ResponseValue::from_response(__progenitor_response).await?,
+                    ResponseValue::from_response(_response).await?,
                 )),
-                _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+                _ => Err(Error::UnexpectedResponse(_response)),
             }
         }
     }

--- a/progenitor-impl/tests/output/propolis-server-positional.out
+++ b/progenitor-impl/tests/output/propolis-server-positional.out
@@ -671,26 +671,26 @@ impl Client {
     pub async fn instance_get<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
-        let _url = format!("{}/instance", self.baseurl,);
-        let _request = self
+        let url = format!("{}/instance", self.baseurl,);
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -699,27 +699,27 @@ impl Client {
         &'a self,
         body: &'a types::InstanceEnsureRequest,
     ) -> Result<ResponseValue<types::InstanceEnsureResponse>, Error<types::Error>> {
-        let _url = format!("{}/instance", self.baseurl,);
-        let _request = self
+        let url = format!("{}/instance", self.baseurl,);
+        let request = self
             .client
-            .put(_url)
+            .put(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            201u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            201u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -731,31 +731,31 @@ impl Client {
         id: &'a uuid::Uuid,
         snapshot_id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/instance/disk/{}/snapshot/{}",
             self.baseurl,
             encode_path(&id.to_string()),
             encode_path(&snapshot_id.to_string()),
         );
-        let _request = self
+        let request = self
             .client
-            .post(_url)
+            .post(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -764,27 +764,27 @@ impl Client {
         &'a self,
         body: &'a types::InstanceMigrateStatusRequest,
     ) -> Result<ResponseValue<types::InstanceMigrateStatusResponse>, Error<types::Error>> {
-        let _url = format!("{}/instance/migrate/status", self.baseurl,);
-        let _request = self
+        let url = format!("{}/instance/migrate/status", self.baseurl,);
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -792,10 +792,10 @@ impl Client {
     pub async fn instance_serial<'a>(
         &'a self,
     ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
-        let _url = format!("{}/instance/serial", self.baseurl,);
-        let _request = self
+        let url = format!("{}/instance/serial", self.baseurl,);
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(reqwest::header::CONNECTION, "Upgrade")
             .header(reqwest::header::UPGRADE, "websocket")
             .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -807,12 +807,12 @@ impl Client {
                 ),
             )
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            101u16 => ResponseValue::upgrade(_response).await,
-            200..=299 => ResponseValue::upgrade(_response).await,
-            _ => Err(Error::UnexpectedResponse(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            101u16 => ResponseValue::upgrade(response).await,
+            200..=299 => ResponseValue::upgrade(response).await,
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -821,27 +821,27 @@ impl Client {
         &'a self,
         body: types::InstanceStateRequested,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!("{}/instance/state", self.baseurl,);
-        let _request = self
+        let url = format!("{}/instance/state", self.baseurl,);
+        let request = self
             .client
-            .put(_url)
+            .put(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -850,27 +850,27 @@ impl Client {
         &'a self,
         body: &'a types::InstanceStateMonitorRequest,
     ) -> Result<ResponseValue<types::InstanceStateMonitorResponse>, Error<types::Error>> {
-        let _url = format!("{}/instance/state-monitor", self.baseurl,);
-        let _request = self
+        let url = format!("{}/instance/state-monitor", self.baseurl,);
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200u16 => ResponseValue::from_response(_response).await,
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 }

--- a/progenitor-impl/tests/output/propolis-server-positional.out
+++ b/progenitor-impl/tests/output/propolis-server-positional.out
@@ -671,26 +671,26 @@ impl Client {
     pub async fn instance_get<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::InstanceGetResponse>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/instance", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/instance", self.baseurl,);
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -699,27 +699,27 @@ impl Client {
         &'a self,
         body: &'a types::InstanceEnsureRequest,
     ) -> Result<ResponseValue<types::InstanceEnsureResponse>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/instance", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/instance", self.baseurl,);
+        let _request = self
             .client
-            .put(__progenitor_url)
+            .put(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            201u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            201u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -731,31 +731,31 @@ impl Client {
         id: &'a uuid::Uuid,
         snapshot_id: &'a uuid::Uuid,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/instance/disk/{}/snapshot/{}",
             self.baseurl,
             encode_path(&id.to_string()),
             encode_path(&snapshot_id.to_string()),
         );
-        let __progenitor_request = self
+        let _request = self
             .client
-            .post(__progenitor_url)
+            .post(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -764,27 +764,27 @@ impl Client {
         &'a self,
         body: &'a types::InstanceMigrateStatusRequest,
     ) -> Result<ResponseValue<types::InstanceMigrateStatusResponse>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/instance/migrate/status", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/instance/migrate/status", self.baseurl,);
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -792,10 +792,10 @@ impl Client {
     pub async fn instance_serial<'a>(
         &'a self,
     ) -> Result<ResponseValue<reqwest::Upgraded>, Error<reqwest::Upgraded>> {
-        let __progenitor_url = format!("{}/instance/serial", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/instance/serial", self.baseurl,);
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(reqwest::header::CONNECTION, "Upgrade")
             .header(reqwest::header::UPGRADE, "websocket")
             .header(reqwest::header::SEC_WEBSOCKET_VERSION, "13")
@@ -807,12 +807,12 @@ impl Client {
                 ),
             )
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            101u16 => ResponseValue::upgrade(__progenitor_response).await,
-            200..=299 => ResponseValue::upgrade(__progenitor_response).await,
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            101u16 => ResponseValue::upgrade(_response).await,
+            200..=299 => ResponseValue::upgrade(_response).await,
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -821,27 +821,27 @@ impl Client {
         &'a self,
         body: types::InstanceStateRequested,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/instance/state", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/instance/state", self.baseurl,);
+        let _request = self
             .client
-            .put(__progenitor_url)
+            .put(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 
@@ -850,27 +850,27 @@ impl Client {
         &'a self,
         body: &'a types::InstanceStateMonitorRequest,
     ) -> Result<ResponseValue<types::InstanceStateMonitorResponse>, Error<types::Error>> {
-        let __progenitor_url = format!("{}/instance/state-monitor", self.baseurl,);
-        let __progenitor_request = self
+        let _url = format!("{}/instance/state-monitor", self.baseurl,);
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
             .json(&body)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200u16 => ResponseValue::from_response(__progenitor_response).await,
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200u16 => ResponseValue::from_response(_response).await,
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 }

--- a/progenitor-impl/tests/output/test_default_params_builder.out
+++ b/progenitor-impl/tests/output/test_default_params_builder.out
@@ -309,14 +309,14 @@ pub mod builder {
     ///[`Client::default_params`]: super::Client::default_params
     #[derive(Debug, Clone)]
     pub struct DefaultParams<'a> {
-        __progenitor_client: &'a super::Client,
+        _client: &'a super::Client,
         body: Result<types::builder::BodyWithDefaults, String>,
     }
 
     impl<'a> DefaultParams<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                __progenitor_client: client,
+                _client: client,
                 body: Ok(types::builder::BodyWithDefaults::default()),
             }
         }
@@ -344,29 +344,17 @@ pub mod builder {
 
         ///Sends a `POST` request to `/`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-            let Self {
-                __progenitor_client,
-                body,
-            } = self;
+            let Self { _client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::BodyWithDefaults>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let __progenitor_url = format!("{}/", __progenitor_client.baseurl,);
-            let __progenitor_request = __progenitor_client
-                .client
-                .post(__progenitor_url)
-                .json(&body)
-                .build()?;
-            let __progenitor_result = __progenitor_client
-                .client
-                .execute(__progenitor_request)
-                .await;
-            let __progenitor_response = __progenitor_result?;
-            match __progenitor_response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
-                _ => Err(Error::ErrorResponse(ResponseValue::stream(
-                    __progenitor_response,
-                ))),
+            let _url = format!("{}/", _client.baseurl,);
+            let _request = _client.client.post(_url).json(&body).build()?;
+            let _result = _client.client.execute(_request).await;
+            let _response = _result?;
+            match _response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(_response)),
+                _ => Err(Error::ErrorResponse(ResponseValue::stream(_response))),
             }
         }
     }

--- a/progenitor-impl/tests/output/test_default_params_builder.out
+++ b/progenitor-impl/tests/output/test_default_params_builder.out
@@ -309,14 +309,14 @@ pub mod builder {
     ///[`Client::default_params`]: super::Client::default_params
     #[derive(Debug, Clone)]
     pub struct DefaultParams<'a> {
-        _client: &'a super::Client,
+        client: &'a super::Client,
         body: Result<types::builder::BodyWithDefaults, String>,
     }
 
     impl<'a> DefaultParams<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
-                _client: client,
+                client: client,
                 body: Ok(types::builder::BodyWithDefaults::default()),
             }
         }
@@ -344,17 +344,17 @@ pub mod builder {
 
         ///Sends a `POST` request to `/`
         pub async fn send(self) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-            let Self { _client, body } = self;
+            let Self { client, body } = self;
             let body = body
                 .and_then(std::convert::TryInto::<types::BodyWithDefaults>::try_into)
                 .map_err(Error::InvalidRequest)?;
-            let _url = format!("{}/", _client.baseurl,);
-            let _request = _client.client.post(_url).json(&body).build()?;
-            let _result = _client.client.execute(_request).await;
-            let _response = _result?;
-            match _response.status().as_u16() {
-                200..=299 => Ok(ResponseValue::stream(_response)),
-                _ => Err(Error::ErrorResponse(ResponseValue::stream(_response))),
+            let url = format!("{}/", client.baseurl,);
+            let request = client.client.post(url).json(&body).build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200..=299 => Ok(ResponseValue::stream(response)),
+                _ => Err(Error::ErrorResponse(ResponseValue::stream(response))),
             }
         }
     }

--- a/progenitor-impl/tests/output/test_default_params_positional.out
+++ b/progenitor-impl/tests/output/test_default_params_positional.out
@@ -120,15 +120,13 @@ impl Client {
         &'a self,
         body: &'a types::BodyWithDefaults,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-        let __progenitor_url = format!("{}/", self.baseurl,);
-        let __progenitor_request = self.client.post(__progenitor_url).json(&body).build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
-            _ => Err(Error::ErrorResponse(ResponseValue::stream(
-                __progenitor_response,
-            ))),
+        let _url = format!("{}/", self.baseurl,);
+        let _request = self.client.post(_url).json(&body).build()?;
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200..=299 => Ok(ResponseValue::stream(_response)),
+            _ => Err(Error::ErrorResponse(ResponseValue::stream(_response))),
         }
     }
 }

--- a/progenitor-impl/tests/output/test_default_params_positional.out
+++ b/progenitor-impl/tests/output/test_default_params_positional.out
@@ -120,13 +120,13 @@ impl Client {
         &'a self,
         body: &'a types::BodyWithDefaults,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-        let _url = format!("{}/", self.baseurl,);
-        let _request = self.client.post(_url).json(&body).build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200..=299 => Ok(ResponseValue::stream(_response)),
-            _ => Err(Error::ErrorResponse(ResponseValue::stream(_response))),
+        let url = format!("{}/", self.baseurl,);
+        let request = self.client.post(url).json(&body).build()?;
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200..=299 => Ok(ResponseValue::stream(response)),
+            _ => Err(Error::ErrorResponse(ResponseValue::stream(response))),
         }
     }
 }

--- a/progenitor-impl/tests/output/test_freeform_response.out
+++ b/progenitor-impl/tests/output/test_freeform_response.out
@@ -88,15 +88,13 @@ impl Client {
     pub async fn freeform_response<'a>(
         &'a self,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-        let __progenitor_url = format!("{}/", self.baseurl,);
-        let __progenitor_request = self.client.get(__progenitor_url).build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            200..=299 => Ok(ResponseValue::stream(__progenitor_response)),
-            _ => Err(Error::ErrorResponse(ResponseValue::stream(
-                __progenitor_response,
-            ))),
+        let _url = format!("{}/", self.baseurl,);
+        let _request = self.client.get(_url).build()?;
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            200..=299 => Ok(ResponseValue::stream(_response)),
+            _ => Err(Error::ErrorResponse(ResponseValue::stream(_response))),
         }
     }
 }

--- a/progenitor-impl/tests/output/test_freeform_response.out
+++ b/progenitor-impl/tests/output/test_freeform_response.out
@@ -88,13 +88,13 @@ impl Client {
     pub async fn freeform_response<'a>(
         &'a self,
     ) -> Result<ResponseValue<ByteStream>, Error<ByteStream>> {
-        let _url = format!("{}/", self.baseurl,);
-        let _request = self.client.get(_url).build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            200..=299 => Ok(ResponseValue::stream(_response)),
-            _ => Err(Error::ErrorResponse(ResponseValue::stream(_response))),
+        let url = format!("{}/", self.baseurl,);
+        let request = self.client.get(url).build()?;
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            200..=299 => Ok(ResponseValue::stream(response)),
+            _ => Err(Error::ErrorResponse(ResponseValue::stream(response))),
         }
     }
 }

--- a/progenitor-impl/tests/output/test_renamed_parameters.out
+++ b/progenitor-impl/tests/output/test_renamed_parameters.out
@@ -94,37 +94,37 @@ impl Client {
         in_: &'a str,
         use_: &'a str,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let _url = format!(
+        let url = format!(
             "{}/{}/{}/{}",
             self.baseurl,
             encode_path(&ref_.to_string()),
             encode_path(&type_.to_string()),
             encode_path(&trait_.to_string()),
         );
-        let mut _query = Vec::with_capacity(3usize);
-        _query.push(("if", if_.to_string()));
-        _query.push(("in", in_.to_string()));
-        _query.push(("use", use_.to_string()));
-        let _request = self
+        let mut query = Vec::with_capacity(3usize);
+        query.push(("if", if_.to_string()));
+        query.push(("in", in_.to_string()));
+        query.push(("use", use_.to_string()));
+        let request = self
             .client
-            .get(_url)
+            .get(url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&_query)
+            .query(&query)
             .build()?;
-        let _result = self.client.execute(_request).await;
-        let _response = _result?;
-        match _response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(_response)),
+        let result = self.client.execute(request).await;
+        let response = result?;
+        match response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(_response).await?,
+                ResponseValue::from_response(response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(_response)),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 }

--- a/progenitor-impl/tests/output/test_renamed_parameters.out
+++ b/progenitor-impl/tests/output/test_renamed_parameters.out
@@ -94,37 +94,37 @@ impl Client {
         in_: &'a str,
         use_: &'a str,
     ) -> Result<ResponseValue<()>, Error<types::Error>> {
-        let __progenitor_url = format!(
+        let _url = format!(
             "{}/{}/{}/{}",
             self.baseurl,
             encode_path(&ref_.to_string()),
             encode_path(&type_.to_string()),
             encode_path(&trait_.to_string()),
         );
-        let mut __progenitor_query = Vec::with_capacity(3usize);
-        __progenitor_query.push(("if", if_.to_string()));
-        __progenitor_query.push(("in", in_.to_string()));
-        __progenitor_query.push(("use", use_.to_string()));
-        let __progenitor_request = self
+        let mut _query = Vec::with_capacity(3usize);
+        _query.push(("if", if_.to_string()));
+        _query.push(("in", in_.to_string()));
+        _query.push(("use", use_.to_string()));
+        let _request = self
             .client
-            .get(__progenitor_url)
+            .get(_url)
             .header(
                 reqwest::header::ACCEPT,
                 reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&__progenitor_query)
+            .query(&_query)
             .build()?;
-        let __progenitor_result = self.client.execute(__progenitor_request).await;
-        let __progenitor_response = __progenitor_result?;
-        match __progenitor_response.status().as_u16() {
-            204u16 => Ok(ResponseValue::empty(__progenitor_response)),
+        let _result = self.client.execute(_request).await;
+        let _response = _result?;
+        match _response.status().as_u16() {
+            204u16 => Ok(ResponseValue::empty(_response)),
             400u16..=499u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
             500u16..=599u16 => Err(Error::ErrorResponse(
-                ResponseValue::from_response(__progenitor_response).await?,
+                ResponseValue::from_response(_response).await?,
             )),
-            _ => Err(Error::UnexpectedResponse(__progenitor_response)),
+            _ => Err(Error::UnexpectedResponse(_response)),
         }
     }
 }

--- a/progenitor-impl/tests/test_output.rs
+++ b/progenitor-impl/tests/test_output.rs
@@ -157,6 +157,11 @@ fn test_yaml() {
     verify_apis("param-overrides.yaml");
 }
 
+#[test]
+fn test_param_collision() {
+    verify_apis("param-collision.json");
+}
+
 // TODO this file is full of inconsistencies and incorrectly specified types.
 // It's an interesting test to consider whether we try to do our best to
 // interpret the intent or just fail.

--- a/sample_openapi/param-collision.json
+++ b/sample_openapi/param-collision.json
@@ -1,0 +1,78 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "description": "Minimal API for testing collision between parameter names and generated code",
+        "title": "Parameter name collision test",
+        "version": "v1"
+    },
+    "paths": {
+        "/key/{query}": {
+            "get": {
+                "description": "Gets a key",
+                "operationId": "key.get",
+                "parameters": [
+                    {
+                        "description": "Parameter name that was previously colliding",
+                        "in": "path",
+                        "name": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "description": "Parameter name that was previously colliding",
+                        "in": "query",
+                        "name": "url",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "description": "Parameter name that was previously colliding",
+                        "in": "query",
+                        "name": "request",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "description": "Parameter name that was previously colliding",
+                        "in": "query",
+                        "name": "response",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "description": "Parameter name that was previously colliding",
+                        "in": "query",
+                        "name": "result",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "description": "Parameter name that was previously colliding",
+                        "in": "query",
+                        "name": "client",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "type": "string",
+                        "description": "Successful response"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Ok we're back, one last time for now. 🤞

There are two changes here:

1. @augustuswm suggested that I add the test he'd introduced in the now-closed https://github.com/oxidecomputer/progenitor/pull/261.
2. In doing so I realized generating a unique name for internal variables from the params wouldn't be hard and it'd create less noise in generated output. I feel better about this than the static prefixes I introduces earlier.

Example output from new test:
```rust
impl Client {
    ///Gets a key
    ///
    ///Sends a `GET` request to `/key/{query}`
    ///
    ///Arguments:
    /// - `query`: Parameter name that was previously colliding
    /// - `client`: Parameter name that was previously colliding
    /// - `request`: Parameter name that was previously colliding
    /// - `response`: Parameter name that was previously colliding
    /// - `result`: Parameter name that was previously colliding
    /// - `url`: Parameter name that was previously colliding
    pub async fn key_get<'a>(
        &'a self,
        query: bool,
        client: bool,
        request: bool,
        response: bool,
        result: bool,
        url: bool,
    ) -> Result<ResponseValue<()>, Error<()>> {
        let _url = format!("{}/key/{}", self.baseurl, encode_path(&query.to_string()),);
        let mut _query = Vec::with_capacity(5usize);
        _query.push(("client", client.to_string()));
        _query.push(("request", request.to_string()));
        _query.push(("response", response.to_string()));
        _query.push(("result", result.to_string()));
        _query.push(("url", url.to_string()));
        let _request = self.client.get(_url).query(&_query).build()?;
        let _result = self.client.execute(_request).await;
        let _response = _result?;
        match _response.status().as_u16() {
            200u16 => Ok(ResponseValue::empty(_response)),
            _ => Err(Error::UnexpectedResponse(_response)),
        }
    }
}
```