### PR TITLE
Allow API to reside at submodule of crate

### DIFF
--- a/progenitor-impl/src/cli.rs
+++ b/progenitor-impl/src/cli.rs
@@ -100,15 +100,20 @@ impl Generator {
             })
             .collect::<Vec<_>>();
 
-        let crate_ident = format_ident!("{}", crate_name);
+        let crate_path = syn::TypePath {
+            qself: None,
+            path: syn::parse_str(&crate_name).unwrap(),
+        };
 
         let code = quote! {
+            use #crate_path::*;
+
             pub struct Cli<T: CliOverride = ()> {
-                client: #crate_ident::Client,
+                client: Client,
                 over: T,
             }
             impl Cli {
-                pub fn new(client: #crate_ident::Client) -> Self {
+                pub fn new(client: Client) -> Self {
                     Self { client, over: () }
                 }
 
@@ -125,7 +130,7 @@ impl Generator {
 
             impl<T: CliOverride> Cli<T> {
                 pub fn new_with_override(
-                    client: #crate_ident::Client,
+                    client: Client,
                     over: T,
                 ) -> Self {
                     Self { client, over }

--- a/progenitor-impl/src/httpmock.rs
+++ b/progenitor-impl/src/httpmock.rs
@@ -79,7 +79,10 @@ impl Generator {
         let then_impl =
             methods.iter().map(|op| &op.then_impl).collect::<Vec<_>>();
 
-        let crate_ident = format_ident!("{}", crate_name);
+        let crate_path = syn::TypePath {
+            qself: None,
+            path: syn::parse_str(&crate_name).unwrap(),
+        };
 
         let code = quote! {
             pub mod operations {
@@ -89,7 +92,7 @@ impl Generator {
                 //! its inner type with a call to `into_inner()`. This can
                 //! be used to explicitly deviate from permitted values.
 
-                use #crate_ident::*;
+                use #crate_path::*;
 
                 #(
                     pub struct #when(httpmock::When);

--- a/progenitor-impl/tests/output/buildomat-cli.out
+++ b/progenitor-impl/tests/output/buildomat-cli.out
@@ -1,10 +1,11 @@
+use sdk::*;
 pub struct Cli<T: CliOverride = ()> {
-    client: sdk::Client,
+    client: Client,
     over: T,
 }
 
 impl Cli {
-    pub fn new(client: sdk::Client) -> Self {
+    pub fn new(client: Client) -> Self {
         Self { client, over: () }
     }
 
@@ -317,7 +318,7 @@ impl Cli {
 }
 
 impl<T: CliOverride> Cli<T> {
-    pub fn new_with_override(client: sdk::Client, over: T) -> Self {
+    pub fn new_with_override(client: Client, over: T) -> Self {
         Self { client, over }
     }
 

--- a/progenitor-impl/tests/output/keeper-cli.out
+++ b/progenitor-impl/tests/output/keeper-cli.out
@@ -1,10 +1,11 @@
+use sdk::*;
 pub struct Cli<T: CliOverride = ()> {
-    client: sdk::Client,
+    client: Client,
     over: T,
 }
 
 impl Cli {
-    pub fn new(client: sdk::Client) -> Self {
+    pub fn new(client: Client) -> Self {
         Self { client, over: () }
     }
 
@@ -183,7 +184,7 @@ impl Cli {
 }
 
 impl<T: CliOverride> Cli<T> {
-    pub fn new_with_override(client: sdk::Client, over: T) -> Self {
+    pub fn new_with_override(client: Client, over: T) -> Self {
         Self { client, over }
     }
 

--- a/progenitor-impl/tests/output/nexus-cli.out
+++ b/progenitor-impl/tests/output/nexus-cli.out
@@ -1,10 +1,11 @@
+use sdk::*;
 pub struct Cli<T: CliOverride = ()> {
-    client: sdk::Client,
+    client: Client,
     over: T,
 }
 
 impl Cli {
-    pub fn new(client: sdk::Client) -> Self {
+    pub fn new(client: Client) -> Self {
         Self { client, over: () }
     }
 
@@ -5608,7 +5609,7 @@ impl Cli {
 }
 
 impl<T: CliOverride> Cli<T> {
-    pub fn new_with_override(client: sdk::Client, over: T) -> Self {
+    pub fn new_with_override(client: Client, over: T) -> Self {
         Self { client, over }
     }
 

--- a/progenitor-impl/tests/output/param-collision-cli.out
+++ b/progenitor-impl/tests/output/param-collision-cli.out
@@ -1,10 +1,11 @@
+use sdk::*;
 pub struct Cli<T: CliOverride = ()> {
-    client: sdk::Client,
+    client: Client,
     over: T,
 }
 
 impl Cli {
-    pub fn new(client: sdk::Client) -> Self {
+    pub fn new(client: Client) -> Self {
         Self { client, over: () }
     }
 
@@ -63,7 +64,7 @@ impl Cli {
 }
 
 impl<T: CliOverride> Cli<T> {
-    pub fn new_with_override(client: sdk::Client, over: T) -> Self {
+    pub fn new_with_override(client: Client, over: T) -> Self {
         Self { client, over }
     }
 

--- a/progenitor-impl/tests/output/param-overrides-cli.out
+++ b/progenitor-impl/tests/output/param-overrides-cli.out
@@ -1,10 +1,11 @@
+use sdk::*;
 pub struct Cli<T: CliOverride = ()> {
-    client: sdk::Client,
+    client: Client,
     over: T,
 }
 
 impl Cli {
-    pub fn new(client: sdk::Client) -> Self {
+    pub fn new(client: Client) -> Self {
         Self { client, over: () }
     }
 
@@ -35,7 +36,7 @@ impl Cli {
 }
 
 impl<T: CliOverride> Cli<T> {
-    pub fn new_with_override(client: sdk::Client, over: T) -> Self {
+    pub fn new_with_override(client: Client, over: T) -> Self {
         Self { client, over }
     }
 

--- a/progenitor-impl/tests/output/propolis-server-cli.out
+++ b/progenitor-impl/tests/output/propolis-server-cli.out
@@ -1,10 +1,11 @@
+use sdk::*;
 pub struct Cli<T: CliOverride = ()> {
-    client: sdk::Client,
+    client: Client,
     over: T,
 }
 
 impl Cli {
-    pub fn new(client: sdk::Client) -> Self {
+    pub fn new(client: Client) -> Self {
         Self { client, over: () }
     }
 
@@ -139,7 +140,7 @@ impl Cli {
 }
 
 impl<T: CliOverride> Cli<T> {
-    pub fn new_with_override(client: sdk::Client, over: T) -> Self {
+    pub fn new_with_override(client: Client, over: T) -> Self {
         Self { client, over }
     }
 


### PR DESCRIPTION
Split off from https://github.com/oxidecomputer/progenitor/pull/638

Potentially `crate_name` args should be renamed.