### PR TITLE
Include Response bytes when payload didn't deserialize as expected

### DIFF
--- a/docs/progenitor-client.md
+++ b/docs/progenitor-client.md
@@ -74,7 +74,7 @@ There are five sub-categories of error covered by the error type variants:
 - An expected error response, defined by the OpenAPI document with a 4xx or 5xx
   status code
 
-- An expected status code (whose payload didn't deserialize as expected (this
+- An expected status code whose payload didn't deserialize as expected (this
   could be viewed as a sub-type of communication error), but it is separately
   identified as there's more information; note that this covers both success and
   error status codes
@@ -88,7 +88,8 @@ pub enum Error<E = ()> {
     InvalidRequest(String),
     CommunicationError(reqwest::Error),
     ErrorResponse(ResponseValue<E>),
-    InvalidResponsePayload(reqwest::Error),
+    InvalidResponseBytes(reqwest::Error),
+    InvalidResponsePayload(bytes::Bytes, reqwest::Error),
     UnexpectedResponse(reqwest::Response),
 }
 ```

--- a/docs/progenitor-client.md
+++ b/docs/progenitor-client.md
@@ -63,21 +63,24 @@ It can be used as the type `T` in most instances and extracted as a `T` using
 
 ## `Error<E>`
 
-There are five sub-categories of error covered by the error type variants:
+There are seven sub-categories of error covered by the error type variants:
 
-- A request that did not conform to API requirements. This can occur when
-  required builder or body parameters were not specified, and the error message
-  will denote the specific failure.
+- A request that did not conform to API requirements.
+  This can occur when required builder or body parameters were not specified,
+  and the error message will denote the specific failure.
 
 - A communication error
 
-- An expected error response, defined by the OpenAPI document with a 4xx or 5xx
-  status code
+- An expected error response when upgrading connection.
 
-- An expected status code whose payload didn't deserialize as expected (this
-  could be viewed as a sub-type of communication error), but it is separately
-  identified as there's more information; note that this covers both success and
-  error status codes
+- An expected error response, defined by the OpenAPI document
+  with a 4xx or 5xx status code
+
+- An expected status code that encountered an error reading the body
+  or the payload deserialization failed
+  (this could be viewed as a sub-type of communication error),
+  but it is separately identified as there's more information;
+  note that this covers both success and error status codes
 
 - An unexpected status code in the response
 
@@ -87,8 +90,9 @@ These errors are covered by the variants of the `Error<E>` type:
 pub enum Error<E = ()> {
     InvalidRequest(String),
     CommunicationError(reqwest::Error),
+    InvalidUpgrade(reqwest::Error),
     ErrorResponse(ResponseValue<E>),
-    InvalidResponseBytes(reqwest::Error),
+    ResponseBodyError(reqwest::Error),
     InvalidResponsePayload(bytes::Bytes, reqwest::Error),
     UnexpectedResponse(reqwest::Response),
 }


### PR DESCRIPTION
The current error handling for `progenatior-client` does not allow for reattempts at deserializing.
This is very useful when creating clients that will need a little more flexibility such as forwards compatibility.

This changeset breaks out the `InvalidResponsePayload` within `progenatior-client` into two separate errors:

- `InvalidResponseBytes`: When `reqwest` fails to actually get the bytes for the response.
- `InvalidResponsePayload`: When the payload didn't deserialize as expected, now also includes the bytes.