### PR TITLE
explicitly ignore clippy

### DIFF
--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -353,6 +353,7 @@ impl Generator {
             use reqwest::header::{HeaderMap, HeaderValue};
 
             /// Types used as operation parameters and responses.
+            #[allow(clippy::all)]
             pub mod types {
                 use serde::{Deserialize, Serialize};
 
@@ -449,6 +450,7 @@ impl Generator {
             .map(|method| self.positional_method(method))
             .collect::<Result<Vec<_>>>()?;
         let out = quote! {
+            #[allow(clippy::all)]
             impl Client {
                 #(#methods)*
             }
@@ -481,6 +483,7 @@ impl Generator {
             }
 
             /// Types for composing operation parameters.
+            #[allow(clippy::all)]
             pub mod builder {
                 use super::types;
                 #[allow(unused_imports)]
@@ -523,6 +526,7 @@ impl Generator {
             #traits_and_impls
 
             /// Types for composing operation parameters.
+            #[allow(clippy::all)]
             pub mod builder {
                 use super::types;
                 #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/buildomat_builder.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder.rs
@@ -4,6 +4,7 @@ pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
 /// Types used as operation parameters and responses.
+#[allow(clippy::all)]
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -2379,6 +2380,7 @@ impl Client {
 }
 
 /// Types for composing operation parameters.
+#[allow(clippy::all)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
@@ -4,6 +4,7 @@ pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
 /// Types used as operation parameters and responses.
+#[allow(clippy::all)]
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -2379,6 +2380,7 @@ impl Client {
 }
 
 /// Types for composing operation parameters.
+#[allow(clippy::all)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/buildomat_positional.rs
+++ b/progenitor-impl/tests/output/src/buildomat_positional.rs
@@ -4,6 +4,7 @@ pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
 /// Types used as operation parameters and responses.
+#[allow(clippy::all)]
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -821,6 +822,7 @@ impl Client {
     }
 }
 
+#[allow(clippy::all)]
 impl Client {
     ///Sends a `POST` request to `/v1/control/hold`
     pub async fn control_hold<'a>(&'a self) -> Result<ResponseValue<()>, Error<()>> {

--- a/progenitor-impl/tests/output/src/keeper_builder.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder.rs
@@ -4,6 +4,7 @@ pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
 /// Types used as operation parameters and responses.
+#[allow(clippy::all)]
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -1365,6 +1366,7 @@ impl Client {
 }
 
 /// Types for composing operation parameters.
+#[allow(clippy::all)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
@@ -4,6 +4,7 @@ pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
 /// Types used as operation parameters and responses.
+#[allow(clippy::all)]
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -1365,6 +1366,7 @@ impl Client {
 }
 
 /// Types for composing operation parameters.
+#[allow(clippy::all)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/keeper_positional.rs
+++ b/progenitor-impl/tests/output/src/keeper_positional.rs
@@ -4,6 +4,7 @@ pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
 /// Types used as operation parameters and responses.
+#[allow(clippy::all)]
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -508,6 +509,7 @@ impl Client {
     }
 }
 
+#[allow(clippy::all)]
 impl Client {
     ///Sends a `POST` request to `/enrol`
     ///

--- a/progenitor-impl/tests/output/src/nexus_builder.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder.rs
@@ -4,6 +4,7 @@ pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
 /// Types used as operation parameters and responses.
+#[allow(clippy::all)]
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -28669,6 +28670,7 @@ impl Client {
 }
 
 /// Types for composing operation parameters.
+#[allow(clippy::all)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
@@ -4,6 +4,7 @@ pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
 /// Types used as operation parameters and responses.
+#[allow(clippy::all)]
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -28588,6 +28589,7 @@ impl ClientVpcsExt for Client {
 }
 
 /// Types for composing operation parameters.
+#[allow(clippy::all)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/nexus_positional.rs
+++ b/progenitor-impl/tests/output/src/nexus_positional.rs
@@ -4,6 +4,7 @@ pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
 /// Types used as operation parameters and responses.
+#[allow(clippy::all)]
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -13419,6 +13420,7 @@ impl Client {
     }
 }
 
+#[allow(clippy::all)]
 impl Client {
     ///Fetch a disk by id
     ///

--- a/progenitor-impl/tests/output/src/param_collision_builder.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder.rs
@@ -4,6 +4,7 @@ pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
 /// Types used as operation parameters and responses.
+#[allow(clippy::all)]
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -130,6 +131,7 @@ impl Client {
 }
 
 /// Types for composing operation parameters.
+#[allow(clippy::all)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
@@ -4,6 +4,7 @@ pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
 /// Types used as operation parameters and responses.
+#[allow(clippy::all)]
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -130,6 +131,7 @@ impl Client {
 }
 
 /// Types for composing operation parameters.
+#[allow(clippy::all)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/param_collision_positional.rs
+++ b/progenitor-impl/tests/output/src/param_collision_positional.rs
@@ -4,6 +4,7 @@ pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
 /// Types used as operation parameters and responses.
+#[allow(clippy::all)]
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -101,6 +102,7 @@ impl Client {
     }
 }
 
+#[allow(clippy::all)]
 impl Client {
     ///Gets a key
     ///

--- a/progenitor-impl/tests/output/src/param_overrides_builder.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder.rs
@@ -4,6 +4,7 @@ pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
 /// Types used as operation parameters and responses.
+#[allow(clippy::all)]
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -124,6 +125,7 @@ impl Client {
 }
 
 /// Types for composing operation parameters.
+#[allow(clippy::all)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
@@ -4,6 +4,7 @@ pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
 /// Types used as operation parameters and responses.
+#[allow(clippy::all)]
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -124,6 +125,7 @@ impl Client {
 }
 
 /// Types for composing operation parameters.
+#[allow(clippy::all)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/param_overrides_positional.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_positional.rs
@@ -4,6 +4,7 @@ pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
 /// Types used as operation parameters and responses.
+#[allow(clippy::all)]
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -101,6 +102,7 @@ impl Client {
     }
 }
 
+#[allow(clippy::all)]
 impl Client {
     ///Gets a key
     ///

--- a/progenitor-impl/tests/output/src/propolis_server_builder.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder.rs
@@ -4,6 +4,7 @@ pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
 /// Types used as operation parameters and responses.
+#[allow(clippy::all)]
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -2975,6 +2976,7 @@ impl Client {
 }
 
 /// Types for composing operation parameters.
+#[allow(clippy::all)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
@@ -4,6 +4,7 @@ pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
 /// Types used as operation parameters and responses.
+#[allow(clippy::all)]
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -2939,6 +2940,7 @@ impl Client {
 }
 
 /// Types for composing operation parameters.
+#[allow(clippy::all)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/propolis_server_positional.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_positional.rs
@@ -4,6 +4,7 @@ pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
 /// Types used as operation parameters and responses.
+#[allow(clippy::all)]
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -1483,6 +1484,7 @@ impl Client {
     }
 }
 
+#[allow(clippy::all)]
 impl Client {
     ///Sends a `GET` request to `/instance`
     pub async fn instance_get<'a>(

--- a/progenitor-impl/tests/output/src/test_default_params_builder.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_builder.rs
@@ -4,6 +4,7 @@ pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
 /// Types used as operation parameters and responses.
+#[allow(clippy::all)]
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -392,6 +393,7 @@ impl Client {
 }
 
 /// Types for composing operation parameters.
+#[allow(clippy::all)]
 pub mod builder {
     use super::types;
     #[allow(unused_imports)]

--- a/progenitor-impl/tests/output/src/test_default_params_positional.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_positional.rs
@@ -4,6 +4,7 @@ pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
 /// Types used as operation parameters and responses.
+#[allow(clippy::all)]
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -206,6 +207,7 @@ impl Client {
     }
 }
 
+#[allow(clippy::all)]
 impl Client {
     ///Sends a `POST` request to `/`
     pub async fn default_params<'a>(

--- a/progenitor-impl/tests/output/src/test_freeform_response.rs
+++ b/progenitor-impl/tests/output/src/test_freeform_response.rs
@@ -4,6 +4,7 @@ pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
 /// Types used as operation parameters and responses.
+#[allow(clippy::all)]
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -139,6 +140,7 @@ impl Client {
     }
 }
 
+#[allow(clippy::all)]
 impl Client {
     ///Sends a `GET` request to `/`
     pub async fn freeform_response<'a>(

--- a/progenitor-impl/tests/output/src/test_renamed_parameters.rs
+++ b/progenitor-impl/tests/output/src/test_renamed_parameters.rs
@@ -4,6 +4,7 @@ pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
 /// Types used as operation parameters and responses.
+#[allow(clippy::all)]
 pub mod types {
     use serde::{Deserialize, Serialize};
     #[allow(unused_imports)]
@@ -139,6 +140,7 @@ impl Client {
     }
 }
 
+#[allow(clippy::all)]
 impl Client {
     ///Sends a `GET` request to `/{ref}/{type}/{trait}`
     pub async fn renamed_parameters<'a>(


### PR DESCRIPTION
Fixes #701 

I thought this was going to be awful, but it turns out to just require an annotation in two places:
- above `mod types` where all the types are defined 
- either above `impl Client` for positional clients or above `mod builder` for builder clients (i.e. where the potentially offensive code is dropped)