### PR TITLE
enable buildomat check suites on push and pull request

### DIFF
--- a/.github/buildomat/config.toml
+++ b/.github/buildomat/config.toml
@@ -1,0 +1,22 @@
+#
+# This file, with this flag, must be present in the default branch in order for
+# the buildomat integration to create check suites.
+#
+enable = true
+
+#
+# Require approval for pull requests made by users outside our organisation.
+#
+org_only = true
+
+#
+# We accept pull requests from several automated services that are outside the
+# organisation.  Allow jobs from those sources to proceed without manual
+# approval:
+#
+allow_users = [
+	"dependabot[bot]",
+	"oxide-reflector-bot[bot]",
+	"oxide-renovate[bot]",
+	"renovate[bot]",
+]


### PR DESCRIPTION
This change does nothing except ask buildomat to be aware of pushes and pull requests in this repository.  In order to be able to kick the tyres on a potential buildomat job in a branch or a pull request, this file needs to appear in the head commit of the default branch.