### PR TITLE
update generated code for Rust 1.76

### DIFF
--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -350,9 +350,13 @@ impl Generator {
 
         let version_str = &spec.info.version;
 
+        // The allow(unused_imports) on the `pub use` is necessary with Rust 1.76+, in case the
+        // generated file is not at the top level of the crate.
+
         let file = quote! {
             // Re-export ResponseValue and Error since those are used by the
             // public interface of Client.
+            #[allow(unused_imports)]
             pub use progenitor_client::{ByteStream, Error, ResponseValue};
             #[allow(unused_imports)]
             use progenitor_client::{encode_path, RequestBuilderExt};
@@ -456,6 +460,10 @@ impl Generator {
             .iter()
             .map(|method| self.positional_method(method))
             .collect::<Result<Vec<_>>>()?;
+
+        // The allow(unused_imports) on the `pub use` is necessary with Rust 1.76+, in case the
+        // generated file is not at the top level of the crate.
+
         let out = quote! {
             #[allow(clippy::all)]
             impl Client {
@@ -464,6 +472,7 @@ impl Generator {
 
             /// Items consumers will typically use such as the Client.
             pub mod prelude {
+                #[allow(unused_imports)]
                 pub use super::Client;
             }
         };
@@ -529,6 +538,9 @@ impl Generator {
         let (traits_and_impls, trait_preludes) =
             self.builder_tags(input_methods, &tag_info);
 
+        // The allow(unused_imports) on the `pub use` is necessary with Rust 1.76+, in case the
+        // generated file is not at the top level of the crate.
+
         let out = quote! {
             #traits_and_impls
 
@@ -553,6 +565,7 @@ impl Generator {
             /// Items consumers will typically use such as the Client and
             /// extension traits.
             pub mod prelude {
+                #[allow(unused_imports)]
                 pub use super::Client;
                 #trait_preludes
             }

--- a/progenitor-impl/tests/output/src/buildomat_builder.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
+#[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};

--- a/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
+#[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
@@ -3405,5 +3406,6 @@ pub mod builder {
 /// Items consumers will typically use such as the Client and
 /// extension traits.
 pub mod prelude {
+    #[allow(unused_imports)]
     pub use super::Client;
 }

--- a/progenitor-impl/tests/output/src/buildomat_positional.rs
+++ b/progenitor-impl/tests/output/src/buildomat_positional.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
+#[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
@@ -1259,5 +1260,6 @@ impl Client {
 
 /// Items consumers will typically use such as the Client.
 pub mod prelude {
+    #[allow(unused_imports)]
     pub use super::Client;
 }

--- a/progenitor-impl/tests/output/src/keeper_builder.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
+#[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};

--- a/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/keeper_builder_tagged.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
+#[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
@@ -1821,5 +1822,6 @@ pub mod builder {
 /// Items consumers will typically use such as the Client and
 /// extension traits.
 pub mod prelude {
+    #[allow(unused_imports)]
     pub use super::Client;
 }

--- a/progenitor-impl/tests/output/src/keeper_positional.rs
+++ b/progenitor-impl/tests/output/src/keeper_positional.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
+#[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
@@ -696,5 +697,6 @@ impl Client {
 
 /// Items consumers will typically use such as the Client.
 pub mod prelude {
+    #[allow(unused_imports)]
     pub use super::Client;
 }

--- a/progenitor-impl/tests/output/src/nexus_builder.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
+#[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};

--- a/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
+#[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
@@ -48973,6 +48974,7 @@ pub mod builder {
 /// Items consumers will typically use such as the Client and
 /// extension traits.
 pub mod prelude {
+    #[allow(unused_imports)]
     pub use super::Client;
     pub use super::ClientDisksExt;
     pub use super::ClientHiddenExt;

--- a/progenitor-impl/tests/output/src/nexus_positional.rs
+++ b/progenitor-impl/tests/output/src/nexus_positional.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
+#[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
@@ -24114,5 +24115,6 @@ impl Client {
 
 /// Items consumers will typically use such as the Client.
 pub mod prelude {
+    #[allow(unused_imports)]
     pub use super::Client;
 }

--- a/progenitor-impl/tests/output/src/param_collision_builder.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
+#[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};

--- a/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_collision_builder_tagged.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
+#[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
@@ -268,5 +269,6 @@ pub mod builder {
 /// Items consumers will typically use such as the Client and
 /// extension traits.
 pub mod prelude {
+    #[allow(unused_imports)]
     pub use super::Client;
 }

--- a/progenitor-impl/tests/output/src/param_collision_positional.rs
+++ b/progenitor-impl/tests/output/src/param_collision_positional.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
+#[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
@@ -144,5 +145,6 @@ impl Client {
 
 /// Items consumers will typically use such as the Client.
 pub mod prelude {
+    #[allow(unused_imports)]
     pub use super::Client;
 }

--- a/progenitor-impl/tests/output/src/param_overrides_builder.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
+#[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};

--- a/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
+#[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
@@ -205,5 +206,6 @@ pub mod builder {
 /// Items consumers will typically use such as the Client and
 /// extension traits.
 pub mod prelude {
+    #[allow(unused_imports)]
     pub use super::Client;
 }

--- a/progenitor-impl/tests/output/src/param_overrides_positional.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_positional.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
+#[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
@@ -141,5 +142,6 @@ impl Client {
 
 /// Items consumers will typically use such as the Client.
 pub mod prelude {
+    #[allow(unused_imports)]
     pub use super::Client;
 }

--- a/progenitor-impl/tests/output/src/propolis_server_builder.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
+#[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};

--- a/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_builder_tagged.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
+#[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
@@ -3407,5 +3408,6 @@ pub mod builder {
 /// Items consumers will typically use such as the Client and
 /// extension traits.
 pub mod prelude {
+    #[allow(unused_imports)]
     pub use super::Client;
 }

--- a/progenitor-impl/tests/output/src/propolis_server_positional.rs
+++ b/progenitor-impl/tests/output/src/propolis_server_positional.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
+#[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
@@ -1703,5 +1704,6 @@ impl Client {
 
 /// Items consumers will typically use such as the Client.
 pub mod prelude {
+    #[allow(unused_imports)]
     pub use super::Client;
 }

--- a/progenitor-impl/tests/output/src/test_default_params_builder.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_builder.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
+#[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};

--- a/progenitor-impl/tests/output/src/test_default_params_positional.rs
+++ b/progenitor-impl/tests/output/src/test_default_params_positional.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
+#[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
@@ -228,5 +229,6 @@ impl Client {
 
 /// Items consumers will typically use such as the Client.
 pub mod prelude {
+    #[allow(unused_imports)]
     pub use super::Client;
 }

--- a/progenitor-impl/tests/output/src/test_freeform_response.rs
+++ b/progenitor-impl/tests/output/src/test_freeform_response.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
+#[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
@@ -160,5 +161,6 @@ impl Client {
 
 /// Items consumers will typically use such as the Client.
 pub mod prelude {
+    #[allow(unused_imports)]
     pub use super::Client;
 }

--- a/progenitor-impl/tests/output/src/test_renamed_parameters.rs
+++ b/progenitor-impl/tests/output/src/test_renamed_parameters.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use progenitor_client::{encode_path, RequestBuilderExt};
+#[allow(unused_imports)]
 pub use progenitor_client::{ByteStream, Error, ResponseValue};
 #[allow(unused_imports)]
 use reqwest::header::{HeaderMap, HeaderValue};
@@ -190,5 +191,6 @@ impl Client {
 
 /// Items consumers will typically use such as the Client.
 pub mod prelude {
+    #[allow(unused_imports)]
     pub use super::Client;
 }


### PR DESCRIPTION
In some cases (e.g. ddm-admin-client and mg-admin-client in omicron), the
progenitor-generated file was not used at the top level. With Rust 1.76, `pub
use` for a type that's not actually exported publicly warns as well.
