### PR TITLE
Mock code doesn't compile if path parameters are renamed

### DIFF
--- a/progenitor-impl/src/httpmock.rs
+++ b/progenitor-impl/src/httpmock.rs
@@ -191,7 +191,7 @@ impl Generator {
                 let name_ident = format_ident!("{}", name);
                 let handler = match kind {
                     OperationParameterKind::Path => {
-                        let re_fmt = method.path.as_wildcard_param(name);
+                        let re_fmt = method.path.as_wildcard_param(api_name);
                         quote! {
                             let re = regex::Regex::new(
                                 &format!(#re_fmt, value.to_string())

--- a/progenitor-impl/src/httpmock.rs
+++ b/progenitor-impl/src/httpmock.rs
@@ -161,7 +161,11 @@ impl Generator {
         // can specify a prescribed value for that parameter.
         let when_methods = method.params.iter().map(
             |OperationParameter {
-                 name, typ, kind, ..
+                 name,
+                 typ,
+                 kind,
+                 api_name,
+                 description: _,
              }| {
                 let arg_type_name = match typ {
                     OperationParameterType::Type(arg_type_id) => self

--- a/progenitor-impl/tests/output/src/buildomat_builder.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder.rs
@@ -2174,7 +2174,7 @@ impl Client {
         builder::ControlResume::new(self)
     }
 
-    ///Sends a `GET` request to `/v1/task/{task}`
+    ///Sends a `GET` request to `/v1/task/{Task}`
     ///
     ///```ignore
     /// let response = client.task_get()
@@ -2478,7 +2478,7 @@ pub mod builder {
             self
         }
 
-        ///Sends a `GET` request to `/v1/task/{task}`
+        ///Sends a `GET` request to `/v1/task/{Task}`
         pub async fn send(self) -> Result<ResponseValue<types::Task>, Error<()>> {
             let Self { client, task } = self;
             let task = task.map_err(Error::InvalidRequest)?;

--- a/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
@@ -2174,7 +2174,7 @@ impl Client {
         builder::ControlResume::new(self)
     }
 
-    ///Sends a `GET` request to `/v1/task/{task}`
+    ///Sends a `GET` request to `/v1/task/{Task}`
     ///
     ///```ignore
     /// let response = client.task_get()
@@ -2478,7 +2478,7 @@ pub mod builder {
             self
         }
 
-        ///Sends a `GET` request to `/v1/task/{task}`
+        ///Sends a `GET` request to `/v1/task/{Task}`
         pub async fn send(self) -> Result<ResponseValue<types::Task>, Error<()>> {
             let Self { client, task } = self;
             let task = task.map_err(Error::InvalidRequest)?;

--- a/progenitor-impl/tests/output/src/buildomat_httpmock.rs
+++ b/progenitor-impl/tests/output/src/buildomat_httpmock.rs
@@ -84,7 +84,7 @@ pub mod operations {
         }
 
         pub fn task(self, value: &str) -> Self {
-            let re = regex::Regex::new(&format!("^/v1/task/{}$", value.to_string())).unwrap();
+            let re = regex::Regex::new(&format!("^/v1/task/.*$", value.to_string())).unwrap();
             Self(self.0.path_matches(re))
         }
     }

--- a/progenitor-impl/tests/output/src/buildomat_httpmock.rs
+++ b/progenitor-impl/tests/output/src/buildomat_httpmock.rs
@@ -84,7 +84,7 @@ pub mod operations {
         }
 
         pub fn task(self, value: &str) -> Self {
-            let re = regex::Regex::new(&format!("^/v1/task/.*$", value.to_string())).unwrap();
+            let re = regex::Regex::new(&format!("^/v1/task/{}$", value.to_string())).unwrap();
             Self(self.0.path_matches(re))
         }
     }

--- a/progenitor-impl/tests/output/src/buildomat_positional.rs
+++ b/progenitor-impl/tests/output/src/buildomat_positional.rs
@@ -858,7 +858,7 @@ impl Client {
         }
     }
 
-    ///Sends a `GET` request to `/v1/task/{task}`
+    ///Sends a `GET` request to `/v1/task/{Task}`
     pub async fn task_get<'a>(
         &'a self,
         task: &'a str,

--- a/sample_openapi/buildomat.json
+++ b/sample_openapi/buildomat.json
@@ -34,13 +34,13 @@
         }
       }
     },
-    "/v1/task/{task}": {
+    "/v1/task/{Task}": {
       "get": {
         "operationId": "task_get",
         "parameters": [
           {
             "in": "path",
-            "name": "task",
+            "name": "Task",
             "required": true,
             "schema": {
               "type": "string"


### PR DESCRIPTION
This occurs if path parameters are renamed e.g. because they aren't `lower_snake_case` or if they conflict with Rust keywords (e.g. `type`).

Fixes #780

@mkenigs I think this addresses the problem you raised; please let me know if this doesn't address it.