### PR TITLE
add mut request `pre_hook`

### DIFF
--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -63,6 +63,7 @@ pub struct GenerationSettings {
     inner_type: Option<TokenStream>,
     pre_hook: Option<TokenStream>,
     pre_hook_async: Option<TokenStream>,
+    pre_hook_mut: Option<TokenStream>,
     post_hook: Option<TokenStream>,
     extra_derives: Vec<String>,
 
@@ -143,6 +144,12 @@ impl GenerationSettings {
     /// Hook invoked before issuing the HTTP request.
     pub fn with_pre_hook_async(&mut self, pre_hook: TokenStream) -> &mut Self {
         self.pre_hook_async = Some(pre_hook);
+        self
+    }
+
+    /// Hook invoked before issuing the HTTP request, mutabily accessing the request.
+    pub fn with_pre_hook_mut(&mut self, pre_hook: TokenStream) -> &mut Self {
+        self.pre_hook_mut = Some(pre_hook);
         self
     }
 

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -1134,6 +1134,11 @@ impl Generator {
                 (#hook)(&#client.inner, &#request_ident);
             }
         });
+        let pre_hook_mut = self.settings.pre_hook_mut.as_ref().map(|hook| {
+            quote! {
+                (#hook)(&#client.inner, &mut #request_ident);
+            }
+        });
         let pre_hook_async = self.settings.pre_hook_async.as_ref().map(|hook| {
             quote! {
                 match (#hook)(&#client.inner, &mut #request_ident).await {
@@ -1167,6 +1172,7 @@ impl Generator {
                 .build()?;
 
             #pre_hook
+            #pre_hook_mut
             #pre_hook_async
             let #result_ident = #client.client
                 .execute(#request_ident)


### PR DESCRIPTION
Currently `progenitor` supports `pre_hook`, `pre_hook_async` and `post_hook`, where the further get a `&reqwest::Request` passed.
The auth mechanism for an `OpenAPI` spec requires to _sign_ the encoded query and append two key value pairs to the request, as such the `pre-hook` appears to be the right place to adjust the `Request` accordingly.

Proposal:

Add `with_pre_hook_mut` in addition, allowing to modify the `Request` accordingly.

Considerations:

Since it's a per-request signature, modifying the `Client` itself is not sufficient.

Altneratives:

Change the API of the current `pre_hook` to take a `&mut` and use lint exception to avoid getting warnings on existing code.