### PR TITLE
Basic support for vector query parameters.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,6 +1203,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2152,13 +2158,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.31"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
  "libc",
+ "num-conv",
  "num_threads",
  "powerfmt",
  "serde",
@@ -2174,10 +2181,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -836,14 +836,17 @@ impl Generator {
                 OperationParameterKind::Query(required) => {
                     let qn = &param.api_name;
                     let qn_ident = format_ident!("{}", &param.name);
+
+                    let assignment = quote! {
+                        #query_ident.push((#qn, #qn_ident .to_string()));
+                    };
+
                     let res = if *required {
-                        quote! {
-                            #query_ident.push((#qn, #qn_ident .to_string()));
-                        }
+                        assignment
                     } else {
                         quote! {
-                            if let Some(v) = & #qn_ident {
-                                #query_ident.push((#qn, v.to_string()));
+                            if let Some(#qn_ident) = & #qn_ident {
+                                #assignment
                             }
                         }
                     };

--- a/progenitor-impl/tests/output/src/buildomat_builder.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder.rs
@@ -2658,8 +2658,8 @@ pub mod builder {
                 encode_path(&task.to_string()),
             );
             let mut query = Vec::with_capacity(1usize);
-            if let Some(v) = &minseq {
-                query.push(("minseq", v.to_string()));
+            if let Some(minseq) = &minseq {
+                query.push(("minseq", minseq.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client

--- a/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/buildomat_builder_tagged.rs
@@ -2658,8 +2658,8 @@ pub mod builder {
                 encode_path(&task.to_string()),
             );
             let mut query = Vec::with_capacity(1usize);
-            if let Some(v) = &minseq {
-                query.push(("minseq", v.to_string()));
+            if let Some(minseq) = &minseq {
+                query.push(("minseq", minseq.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client

--- a/progenitor-impl/tests/output/src/buildomat_positional.rs
+++ b/progenitor-impl/tests/output/src/buildomat_positional.rs
@@ -941,8 +941,8 @@ impl Client {
             encode_path(&task.to_string()),
         );
         let mut query = Vec::with_capacity(1usize);
-        if let Some(v) = &minseq {
-            query.push(("minseq", v.to_string()));
+        if let Some(minseq) = &minseq {
+            query.push(("minseq", minseq.to_string()));
         }
 
         #[allow(unused_mut)]

--- a/progenitor-impl/tests/output/src/nexus_builder.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder.rs
@@ -29597,14 +29597,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/groups", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -30108,14 +30108,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/organizations", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -30725,14 +30725,14 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -31263,14 +31263,14 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -31789,17 +31789,17 @@ pub mod builder {
                 encode_path(&metric_name.to_string()),
             );
             let mut query = Vec::with_capacity(4usize);
-            if let Some(v) = &end_time {
-                query.push(("end_time", v.to_string()));
+            if let Some(end_time) = &end_time {
+                query.push(("end_time", end_time.to_string()));
             }
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &start_time {
-                query.push(("start_time", v.to_string()));
+            if let Some(start_time) = &start_time {
+                query.push(("start_time", start_time.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -31977,14 +31977,14 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -32457,14 +32457,14 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -32954,14 +32954,14 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -33618,14 +33618,14 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -34407,14 +34407,14 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &from_start {
-                query.push(("from_start", v.to_string()));
+            if let Some(from_start) = &from_start {
+                query.push(("from_start", from_start.to_string()));
             }
-            if let Some(v) = &max_bytes {
-                query.push(("max_bytes", v.to_string()));
+            if let Some(max_bytes) = &max_bytes {
+                query.push(("max_bytes", max_bytes.to_string()));
             }
-            if let Some(v) = &most_recent {
-                query.push(("most_recent", v.to_string()));
+            if let Some(most_recent) = &most_recent {
+                query.push(("most_recent", most_recent.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -35023,14 +35023,14 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -35504,14 +35504,14 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -36349,14 +36349,14 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -37043,14 +37043,14 @@ pub mod builder {
                 encode_path(&router_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -37794,14 +37794,14 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -38489,14 +38489,14 @@ pub mod builder {
                 encode_path(&subnet_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -38738,11 +38738,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/roles", client.baseurl,);
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -38983,14 +38983,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/groups", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -39131,14 +39131,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/sshkeys", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -39654,14 +39654,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/certificates", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -39999,14 +39999,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/hardware/disks", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -40147,14 +40147,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/hardware/racks", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -40355,14 +40355,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/hardware/sleds", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -40581,14 +40581,14 @@ pub mod builder {
                 encode_path(&sled_id.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -40729,14 +40729,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/images", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -41068,14 +41068,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -41498,11 +41498,11 @@ pub mod builder {
                 encode_path(&pool_name.to_string()),
             );
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -41825,11 +41825,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools-service/ranges", client.baseurl,);
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -42131,18 +42131,18 @@ pub mod builder {
                 encode_path(&metric_name.to_string()),
             );
             let mut query = Vec::with_capacity(5usize);
-            if let Some(v) = &end_time {
-                query.push(("end_time", v.to_string()));
+            if let Some(end_time) = &end_time {
+                query.push(("end_time", end_time.to_string()));
             }
             query.push(("id", id.to_string()));
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &start_time {
-                query.push(("start_time", v.to_string()));
+            if let Some(start_time) = &start_time {
+                query.push(("start_time", start_time.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -42351,14 +42351,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/sagas", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -42559,14 +42559,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/silos", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -42916,14 +42916,14 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -43683,14 +43683,14 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -43910,14 +43910,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/user", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -44104,11 +44104,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/timeseries/schema", client.baseurl,);
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -44248,14 +44248,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/users", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -44426,20 +44426,20 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/disks", client.baseurl,);
             let mut query = Vec::with_capacity(5usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -44591,8 +44591,8 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/disks", client.baseurl,);
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
             query.push(("project", project.to_string()));
             #[allow(unused_mut)]
@@ -44691,11 +44691,11 @@ pub mod builder {
                 encode_path(&disk.to_string()),
             );
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -44792,11 +44792,11 @@ pub mod builder {
                 encode_path(&disk.to_string()),
             );
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -44921,20 +44921,20 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/instances", client.baseurl,);
             let mut query = Vec::with_capacity(5usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -45086,8 +45086,8 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/instances", client.baseurl,);
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
             query.push(("project", project.to_string()));
             #[allow(unused_mut)]
@@ -45186,11 +45186,11 @@ pub mod builder {
                 encode_path(&instance.to_string()),
             );
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -45287,11 +45287,11 @@ pub mod builder {
                 encode_path(&instance.to_string()),
             );
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -45434,20 +45434,20 @@ pub mod builder {
                 encode_path(&instance.to_string()),
             );
             let mut query = Vec::with_capacity(5usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -45618,11 +45618,11 @@ pub mod builder {
                 encode_path(&instance.to_string()),
             );
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -45746,11 +45746,11 @@ pub mod builder {
                 encode_path(&instance.to_string()),
             );
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -45874,11 +45874,11 @@ pub mod builder {
                 encode_path(&instance.to_string()),
             );
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -45976,11 +45976,11 @@ pub mod builder {
                 encode_path(&instance.to_string()),
             );
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -46124,20 +46124,20 @@ pub mod builder {
                 encode_path(&instance.to_string()),
             );
             let mut query = Vec::with_capacity(5usize);
-            if let Some(v) = &from_start {
-                query.push(("from_start", v.to_string()));
+            if let Some(from_start) = &from_start {
+                query.push(("from_start", from_start.to_string()));
             }
-            if let Some(v) = &max_bytes {
-                query.push(("max_bytes", v.to_string()));
+            if let Some(max_bytes) = &max_bytes {
+                query.push(("max_bytes", max_bytes.to_string()));
             }
-            if let Some(v) = &most_recent {
-                query.push(("most_recent", v.to_string()));
+            if let Some(most_recent) = &most_recent {
+                query.push(("most_recent", most_recent.to_string()));
             }
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -46237,11 +46237,11 @@ pub mod builder {
                 encode_path(&instance.to_string()),
             );
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -46339,11 +46339,11 @@ pub mod builder {
                 encode_path(&instance.to_string()),
             );
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -46440,11 +46440,11 @@ pub mod builder {
                 encode_path(&instance.to_string()),
             );
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -46539,14 +46539,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/organizations", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -47152,17 +47152,17 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/projects", client.baseurl,);
             let mut query = Vec::with_capacity(4usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -47380,8 +47380,8 @@ pub mod builder {
                 encode_path(&project.to_string()),
             );
             let mut query = Vec::with_capacity(1usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -47489,8 +47489,8 @@ pub mod builder {
                 encode_path(&project.to_string()),
             );
             let mut query = Vec::with_capacity(1usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -47573,8 +47573,8 @@ pub mod builder {
                 encode_path(&project.to_string()),
             );
             let mut query = Vec::with_capacity(1usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -47658,8 +47658,8 @@ pub mod builder {
                 encode_path(&project.to_string()),
             );
             let mut query = Vec::with_capacity(1usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -47771,8 +47771,8 @@ pub mod builder {
                 encode_path(&project.to_string()),
             );
             let mut query = Vec::with_capacity(1usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -47869,14 +47869,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/components", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -48019,14 +48019,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/deployments", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -48384,14 +48384,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/updates", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client

--- a/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/nexus_builder_tagged.rs
@@ -29517,14 +29517,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/groups", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -30028,14 +30028,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/organizations", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -30645,14 +30645,14 @@ pub mod builder {
                 encode_path(&organization_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -31183,14 +31183,14 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -31709,17 +31709,17 @@ pub mod builder {
                 encode_path(&metric_name.to_string()),
             );
             let mut query = Vec::with_capacity(4usize);
-            if let Some(v) = &end_time {
-                query.push(("end_time", v.to_string()));
+            if let Some(end_time) = &end_time {
+                query.push(("end_time", end_time.to_string()));
             }
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &start_time {
-                query.push(("start_time", v.to_string()));
+            if let Some(start_time) = &start_time {
+                query.push(("start_time", start_time.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -31897,14 +31897,14 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -32377,14 +32377,14 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -32874,14 +32874,14 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -33538,14 +33538,14 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -34327,14 +34327,14 @@ pub mod builder {
                 encode_path(&instance_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &from_start {
-                query.push(("from_start", v.to_string()));
+            if let Some(from_start) = &from_start {
+                query.push(("from_start", from_start.to_string()));
             }
-            if let Some(v) = &max_bytes {
-                query.push(("max_bytes", v.to_string()));
+            if let Some(max_bytes) = &max_bytes {
+                query.push(("max_bytes", max_bytes.to_string()));
             }
-            if let Some(v) = &most_recent {
-                query.push(("most_recent", v.to_string()));
+            if let Some(most_recent) = &most_recent {
+                query.push(("most_recent", most_recent.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -34943,14 +34943,14 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -35424,14 +35424,14 @@ pub mod builder {
                 encode_path(&project_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -36269,14 +36269,14 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -36963,14 +36963,14 @@ pub mod builder {
                 encode_path(&router_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -37714,14 +37714,14 @@ pub mod builder {
                 encode_path(&vpc_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -38409,14 +38409,14 @@ pub mod builder {
                 encode_path(&subnet_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -38658,11 +38658,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/roles", client.baseurl,);
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -38903,14 +38903,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/groups", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -39051,14 +39051,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/session/me/sshkeys", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -39574,14 +39574,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/certificates", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -39919,14 +39919,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/hardware/disks", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -40067,14 +40067,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/hardware/racks", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -40275,14 +40275,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/hardware/sleds", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -40501,14 +40501,14 @@ pub mod builder {
                 encode_path(&sled_id.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -40649,14 +40649,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/images", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -40988,14 +40988,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -41418,11 +41418,11 @@ pub mod builder {
                 encode_path(&pool_name.to_string()),
             );
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -41745,11 +41745,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/ip-pools-service/ranges", client.baseurl,);
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -42051,18 +42051,18 @@ pub mod builder {
                 encode_path(&metric_name.to_string()),
             );
             let mut query = Vec::with_capacity(5usize);
-            if let Some(v) = &end_time {
-                query.push(("end_time", v.to_string()));
+            if let Some(end_time) = &end_time {
+                query.push(("end_time", end_time.to_string()));
             }
             query.push(("id", id.to_string()));
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &start_time {
-                query.push(("start_time", v.to_string()));
+            if let Some(start_time) = &start_time {
+                query.push(("start_time", start_time.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -42271,14 +42271,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/sagas", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -42479,14 +42479,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/silos", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -42836,14 +42836,14 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -43603,14 +43603,14 @@ pub mod builder {
                 encode_path(&silo_name.to_string()),
             );
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -43830,14 +43830,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/system/user", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -44024,11 +44024,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/timeseries/schema", client.baseurl,);
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -44168,14 +44168,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/users", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -44346,20 +44346,20 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/disks", client.baseurl,);
             let mut query = Vec::with_capacity(5usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -44511,8 +44511,8 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/disks", client.baseurl,);
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
             query.push(("project", project.to_string()));
             #[allow(unused_mut)]
@@ -44611,11 +44611,11 @@ pub mod builder {
                 encode_path(&disk.to_string()),
             );
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -44712,11 +44712,11 @@ pub mod builder {
                 encode_path(&disk.to_string()),
             );
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -44841,20 +44841,20 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/instances", client.baseurl,);
             let mut query = Vec::with_capacity(5usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -45006,8 +45006,8 @@ pub mod builder {
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/instances", client.baseurl,);
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
             query.push(("project", project.to_string()));
             #[allow(unused_mut)]
@@ -45106,11 +45106,11 @@ pub mod builder {
                 encode_path(&instance.to_string()),
             );
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -45207,11 +45207,11 @@ pub mod builder {
                 encode_path(&instance.to_string()),
             );
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -45354,20 +45354,20 @@ pub mod builder {
                 encode_path(&instance.to_string()),
             );
             let mut query = Vec::with_capacity(5usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -45538,11 +45538,11 @@ pub mod builder {
                 encode_path(&instance.to_string()),
             );
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -45666,11 +45666,11 @@ pub mod builder {
                 encode_path(&instance.to_string()),
             );
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -45794,11 +45794,11 @@ pub mod builder {
                 encode_path(&instance.to_string()),
             );
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -45896,11 +45896,11 @@ pub mod builder {
                 encode_path(&instance.to_string()),
             );
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -46044,20 +46044,20 @@ pub mod builder {
                 encode_path(&instance.to_string()),
             );
             let mut query = Vec::with_capacity(5usize);
-            if let Some(v) = &from_start {
-                query.push(("from_start", v.to_string()));
+            if let Some(from_start) = &from_start {
+                query.push(("from_start", from_start.to_string()));
             }
-            if let Some(v) = &max_bytes {
-                query.push(("max_bytes", v.to_string()));
+            if let Some(max_bytes) = &max_bytes {
+                query.push(("max_bytes", max_bytes.to_string()));
             }
-            if let Some(v) = &most_recent {
-                query.push(("most_recent", v.to_string()));
+            if let Some(most_recent) = &most_recent {
+                query.push(("most_recent", most_recent.to_string()));
             }
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -46157,11 +46157,11 @@ pub mod builder {
                 encode_path(&instance.to_string()),
             );
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -46259,11 +46259,11 @@ pub mod builder {
                 encode_path(&instance.to_string()),
             );
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -46360,11 +46360,11 @@ pub mod builder {
                 encode_path(&instance.to_string()),
             );
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &project {
-                query.push(("project", v.to_string()));
+            if let Some(project) = &project {
+                query.push(("project", project.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -46459,14 +46459,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/organizations", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -47072,17 +47072,17 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/projects", client.baseurl,);
             let mut query = Vec::with_capacity(4usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -47300,8 +47300,8 @@ pub mod builder {
                 encode_path(&project.to_string()),
             );
             let mut query = Vec::with_capacity(1usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -47409,8 +47409,8 @@ pub mod builder {
                 encode_path(&project.to_string()),
             );
             let mut query = Vec::with_capacity(1usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -47493,8 +47493,8 @@ pub mod builder {
                 encode_path(&project.to_string()),
             );
             let mut query = Vec::with_capacity(1usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -47578,8 +47578,8 @@ pub mod builder {
                 encode_path(&project.to_string()),
             );
             let mut query = Vec::with_capacity(1usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -47691,8 +47691,8 @@ pub mod builder {
                 encode_path(&project.to_string()),
             );
             let mut query = Vec::with_capacity(1usize);
-            if let Some(v) = &organization {
-                query.push(("organization", v.to_string()));
+            if let Some(organization) = &organization {
+                query.push(("organization", organization.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -47789,14 +47789,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/components", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -47939,14 +47939,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/deployments", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client
@@ -48304,14 +48304,14 @@ pub mod builder {
             let sort_by = sort_by.map_err(Error::InvalidRequest)?;
             let url = format!("{}/v1/system/update/updates", client.baseurl,);
             let mut query = Vec::with_capacity(3usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
-            if let Some(v) = &sort_by {
-                query.push(("sort_by", v.to_string()));
+            if let Some(sort_by) = &sort_by {
+                query.push(("sort_by", sort_by.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client

--- a/progenitor-impl/tests/output/src/nexus_positional.rs
+++ b/progenitor-impl/tests/output/src/nexus_positional.rs
@@ -13911,16 +13911,16 @@ impl Client {
     ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
         let url = format!("{}/groups", self.baseurl,);
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -14162,16 +14162,16 @@ impl Client {
     ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
         let url = format!("{}/organizations", self.baseurl,);
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -14505,16 +14505,16 @@ impl Client {
             encode_path(&organization_name.to_string()),
         );
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -14792,16 +14792,16 @@ impl Client {
             encode_path(&project_name.to_string()),
         );
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -15045,20 +15045,20 @@ impl Client {
             encode_path(&metric_name.to_string()),
         );
         let mut query = Vec::with_capacity(4usize);
-        if let Some(v) = &end_time {
-            query.push(("end_time", v.to_string()));
+        if let Some(end_time) = &end_time {
+            query.push(("end_time", end_time.to_string()));
         }
 
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &start_time {
-            query.push(("start_time", v.to_string()));
+        if let Some(start_time) = &start_time {
+            query.push(("start_time", start_time.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -15184,16 +15184,16 @@ impl Client {
             encode_path(&project_name.to_string()),
         );
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -15435,16 +15435,16 @@ impl Client {
             encode_path(&project_name.to_string()),
         );
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -15686,16 +15686,16 @@ impl Client {
             encode_path(&instance_name.to_string()),
         );
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -15991,16 +15991,16 @@ impl Client {
             encode_path(&instance_name.to_string()),
         );
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -16350,16 +16350,16 @@ impl Client {
             encode_path(&instance_name.to_string()),
         );
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &from_start {
-            query.push(("from_start", v.to_string()));
+        if let Some(from_start) = &from_start {
+            query.push(("from_start", from_start.to_string()));
         }
 
-        if let Some(v) = &max_bytes {
-            query.push(("max_bytes", v.to_string()));
+        if let Some(max_bytes) = &max_bytes {
+            query.push(("max_bytes", max_bytes.to_string()));
         }
 
-        if let Some(v) = &most_recent {
-            query.push(("most_recent", v.to_string()));
+        if let Some(most_recent) = &most_recent {
+            query.push(("most_recent", most_recent.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -16632,16 +16632,16 @@ impl Client {
             encode_path(&project_name.to_string()),
         );
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -16875,16 +16875,16 @@ impl Client {
             encode_path(&project_name.to_string()),
         );
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -17246,16 +17246,16 @@ impl Client {
             encode_path(&vpc_name.to_string()),
         );
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -17553,16 +17553,16 @@ impl Client {
             encode_path(&router_name.to_string()),
         );
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -17870,16 +17870,16 @@ impl Client {
             encode_path(&vpc_name.to_string()),
         );
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -18175,16 +18175,16 @@ impl Client {
             encode_path(&subnet_name.to_string()),
         );
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -18354,12 +18354,12 @@ impl Client {
     ) -> Result<ResponseValue<types::RoleResultsPage>, Error<types::Error>> {
         let url = format!("{}/roles", self.baseurl,);
         let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -18508,16 +18508,16 @@ impl Client {
     ) -> Result<ResponseValue<types::GroupResultsPage>, Error<types::Error>> {
         let url = format!("{}/session/me/groups", self.baseurl,);
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -18602,16 +18602,16 @@ impl Client {
     ) -> Result<ResponseValue<types::SshKeyResultsPage>, Error<types::Error>> {
         let url = format!("{}/session/me/sshkeys", self.baseurl,);
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -18915,16 +18915,16 @@ impl Client {
     ) -> Result<ResponseValue<types::CertificateResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/certificates", self.baseurl,);
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -19121,16 +19121,16 @@ impl Client {
     ) -> Result<ResponseValue<types::PhysicalDiskResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/hardware/disks", self.baseurl,);
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -19214,16 +19214,16 @@ impl Client {
     ) -> Result<ResponseValue<types::RackResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/hardware/racks", self.baseurl,);
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -19344,16 +19344,16 @@ impl Client {
     ) -> Result<ResponseValue<types::SledResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/hardware/sleds", self.baseurl,);
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -19480,16 +19480,16 @@ impl Client {
             encode_path(&sled_id.to_string()),
         );
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -19580,16 +19580,16 @@ impl Client {
     ) -> Result<ResponseValue<types::GlobalImageResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/images", self.baseurl,);
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -19788,16 +19788,16 @@ impl Client {
     ) -> Result<ResponseValue<types::IpPoolResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/ip-pools", self.baseurl,);
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -20025,12 +20025,12 @@ impl Client {
             encode_path(&pool_name.to_string()),
         );
         let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -20220,12 +20220,12 @@ impl Client {
     ) -> Result<ResponseValue<types::IpPoolRangeResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/ip-pools-service/ranges", self.baseurl,);
         let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -20383,21 +20383,21 @@ impl Client {
             encode_path(&metric_name.to_string()),
         );
         let mut query = Vec::with_capacity(5usize);
-        if let Some(v) = &end_time {
-            query.push(("end_time", v.to_string()));
+        if let Some(end_time) = &end_time {
+            query.push(("end_time", end_time.to_string()));
         }
 
         query.push(("id", id.to_string()));
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &start_time {
-            query.push(("start_time", v.to_string()));
+        if let Some(start_time) = &start_time {
+            query.push(("start_time", start_time.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -20503,16 +20503,16 @@ impl Client {
     ) -> Result<ResponseValue<types::SagaResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/sagas", self.baseurl,);
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -20632,16 +20632,16 @@ impl Client {
     ) -> Result<ResponseValue<types::SiloResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/silos", self.baseurl,);
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -20844,16 +20844,16 @@ impl Client {
             encode_path(&silo_name.to_string()),
         );
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -21246,16 +21246,16 @@ impl Client {
             encode_path(&silo_name.to_string()),
         );
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -21381,16 +21381,16 @@ impl Client {
     ) -> Result<ResponseValue<types::UserBuiltinResultsPage>, Error<types::Error>> {
         let url = format!("{}/system/user", self.baseurl,);
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -21510,12 +21510,12 @@ impl Client {
     ) -> Result<ResponseValue<types::TimeseriesSchemaResultsPage>, Error<types::Error>> {
         let url = format!("{}/timeseries/schema", self.baseurl,);
         let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -21597,16 +21597,16 @@ impl Client {
     ) -> Result<ResponseValue<types::UserResultsPage>, Error<types::Error>> {
         let url = format!("{}/users", self.baseurl,);
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -21693,24 +21693,24 @@ impl Client {
     ) -> Result<ResponseValue<types::DiskResultsPage>, Error<types::Error>> {
         let url = format!("{}/v1/disks", self.baseurl,);
         let mut query = Vec::with_capacity(5usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+        if let Some(organization) = &organization {
+            query.push(("organization", organization.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+        if let Some(project) = &project {
+            query.push(("project", project.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -21791,8 +21791,8 @@ impl Client {
     ) -> Result<ResponseValue<types::Disk>, Error<types::Error>> {
         let url = format!("{}/v1/disks", self.baseurl,);
         let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+        if let Some(organization) = &organization {
+            query.push(("organization", organization.to_string()));
         }
 
         query.push(("project", project.to_string()));
@@ -21836,12 +21836,12 @@ impl Client {
             encode_path(&disk.to_string()),
         );
         let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+        if let Some(organization) = &organization {
+            query.push(("organization", organization.to_string()));
         }
 
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+        if let Some(project) = &project {
+            query.push(("project", project.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -21883,12 +21883,12 @@ impl Client {
             encode_path(&disk.to_string()),
         );
         let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+        if let Some(organization) = &organization {
+            query.push(("organization", organization.to_string()));
         }
 
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+        if let Some(project) = &project {
+            query.push(("project", project.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -21936,24 +21936,24 @@ impl Client {
     ) -> Result<ResponseValue<types::InstanceResultsPage>, Error<types::Error>> {
         let url = format!("{}/v1/instances", self.baseurl,);
         let mut query = Vec::with_capacity(5usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+        if let Some(organization) = &organization {
+            query.push(("organization", organization.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+        if let Some(project) = &project {
+            query.push(("project", project.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -22035,8 +22035,8 @@ impl Client {
     ) -> Result<ResponseValue<types::Instance>, Error<types::Error>> {
         let url = format!("{}/v1/instances", self.baseurl,);
         let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+        if let Some(organization) = &organization {
+            query.push(("organization", organization.to_string()));
         }
 
         query.push(("project", project.to_string()));
@@ -22080,12 +22080,12 @@ impl Client {
             encode_path(&instance.to_string()),
         );
         let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+        if let Some(organization) = &organization {
+            query.push(("organization", organization.to_string()));
         }
 
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+        if let Some(project) = &project {
+            query.push(("project", project.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -22127,12 +22127,12 @@ impl Client {
             encode_path(&instance.to_string()),
         );
         let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+        if let Some(organization) = &organization {
+            query.push(("organization", organization.to_string()));
         }
 
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+        if let Some(project) = &project {
+            query.push(("project", project.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -22186,24 +22186,24 @@ impl Client {
             encode_path(&instance.to_string()),
         );
         let mut query = Vec::with_capacity(5usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+        if let Some(organization) = &organization {
+            query.push(("organization", organization.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+        if let Some(project) = &project {
+            query.push(("project", project.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -22298,12 +22298,12 @@ impl Client {
             encode_path(&instance.to_string()),
         );
         let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+        if let Some(organization) = &organization {
+            query.push(("organization", organization.to_string()));
         }
 
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+        if let Some(project) = &project {
+            query.push(("project", project.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -22347,12 +22347,12 @@ impl Client {
             encode_path(&instance.to_string()),
         );
         let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+        if let Some(organization) = &organization {
+            query.push(("organization", organization.to_string()));
         }
 
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+        if let Some(project) = &project {
+            query.push(("project", project.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -22396,12 +22396,12 @@ impl Client {
             encode_path(&instance.to_string()),
         );
         let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+        if let Some(organization) = &organization {
+            query.push(("organization", organization.to_string()));
         }
 
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+        if let Some(project) = &project {
+            query.push(("project", project.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -22444,12 +22444,12 @@ impl Client {
             encode_path(&instance.to_string()),
         );
         let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+        if let Some(organization) = &organization {
+            query.push(("organization", organization.to_string()));
         }
 
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+        if let Some(project) = &project {
+            query.push(("project", project.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -22510,24 +22510,24 @@ impl Client {
             encode_path(&instance.to_string()),
         );
         let mut query = Vec::with_capacity(5usize);
-        if let Some(v) = &from_start {
-            query.push(("from_start", v.to_string()));
+        if let Some(from_start) = &from_start {
+            query.push(("from_start", from_start.to_string()));
         }
 
-        if let Some(v) = &max_bytes {
-            query.push(("max_bytes", v.to_string()));
+        if let Some(max_bytes) = &max_bytes {
+            query.push(("max_bytes", max_bytes.to_string()));
         }
 
-        if let Some(v) = &most_recent {
-            query.push(("most_recent", v.to_string()));
+        if let Some(most_recent) = &most_recent {
+            query.push(("most_recent", most_recent.to_string()));
         }
 
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+        if let Some(organization) = &organization {
+            query.push(("organization", organization.to_string()));
         }
 
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+        if let Some(project) = &project {
+            query.push(("project", project.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -22570,12 +22570,12 @@ impl Client {
             encode_path(&instance.to_string()),
         );
         let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+        if let Some(organization) = &organization {
+            query.push(("organization", organization.to_string()));
         }
 
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+        if let Some(project) = &project {
+            query.push(("project", project.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -22618,12 +22618,12 @@ impl Client {
             encode_path(&instance.to_string()),
         );
         let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+        if let Some(organization) = &organization {
+            query.push(("organization", organization.to_string()));
         }
 
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+        if let Some(project) = &project {
+            query.push(("project", project.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -22665,12 +22665,12 @@ impl Client {
             encode_path(&instance.to_string()),
         );
         let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+        if let Some(organization) = &organization {
+            query.push(("organization", organization.to_string()));
         }
 
-        if let Some(v) = &project {
-            query.push(("project", v.to_string()));
+        if let Some(project) = &project {
+            query.push(("project", project.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -22714,16 +22714,16 @@ impl Client {
     ) -> Result<ResponseValue<types::OrganizationResultsPage>, Error<types::Error>> {
         let url = format!("{}/v1/organizations", self.baseurl,);
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -23020,20 +23020,20 @@ impl Client {
     ) -> Result<ResponseValue<types::ProjectResultsPage>, Error<types::Error>> {
         let url = format!("{}/v1/projects", self.baseurl,);
         let mut query = Vec::with_capacity(4usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+        if let Some(organization) = &organization {
+            query.push(("organization", organization.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -23151,8 +23151,8 @@ impl Client {
             encode_path(&project.to_string()),
         );
         let mut query = Vec::with_capacity(1usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+        if let Some(organization) = &organization {
+            query.push(("organization", organization.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -23194,8 +23194,8 @@ impl Client {
             encode_path(&project.to_string()),
         );
         let mut query = Vec::with_capacity(1usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+        if let Some(organization) = &organization {
+            query.push(("organization", organization.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -23237,8 +23237,8 @@ impl Client {
             encode_path(&project.to_string()),
         );
         let mut query = Vec::with_capacity(1usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+        if let Some(organization) = &organization {
+            query.push(("organization", organization.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -23279,8 +23279,8 @@ impl Client {
             encode_path(&project.to_string()),
         );
         let mut query = Vec::with_capacity(1usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+        if let Some(organization) = &organization {
+            query.push(("organization", organization.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -23322,8 +23322,8 @@ impl Client {
             encode_path(&project.to_string()),
         );
         let mut query = Vec::with_capacity(1usize);
-        if let Some(v) = &organization {
-            query.push(("organization", v.to_string()));
+        if let Some(organization) = &organization {
+            query.push(("organization", organization.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -23368,16 +23368,16 @@ impl Client {
     ) -> Result<ResponseValue<types::UpdateableComponentResultsPage>, Error<types::Error>> {
         let url = format!("{}/v1/system/update/components", self.baseurl,);
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -23461,16 +23461,16 @@ impl Client {
     ) -> Result<ResponseValue<types::UpdateDeploymentResultsPage>, Error<types::Error>> {
         let url = format!("{}/v1/system/update/deployments", self.baseurl,);
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]
@@ -23683,16 +23683,16 @@ impl Client {
     ) -> Result<ResponseValue<types::SystemUpdateResultsPage>, Error<types::Error>> {
         let url = format!("{}/v1/system/update/updates", self.baseurl,);
         let mut query = Vec::with_capacity(3usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
-        if let Some(v) = &sort_by {
-            query.push(("sort_by", v.to_string()));
+        if let Some(sort_by) = &sort_by {
+            query.push(("sort_by", sort_by.to_string()));
         }
 
         #[allow(unused_mut)]

--- a/progenitor-impl/tests/output/src/param_overrides_builder.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder.rs
@@ -185,11 +185,11 @@ pub mod builder {
             let unique_key = unique_key.map_err(Error::InvalidRequest)?;
             let url = format!("{}/key", client.baseurl,);
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &key {
-                query.push(("key", v.to_string()));
+            if let Some(key) = &key {
+                query.push(("key", key.to_string()));
             }
-            if let Some(v) = &unique_key {
-                query.push(("uniqueKey", v.to_string()));
+            if let Some(unique_key) = &unique_key {
+                query.push(("uniqueKey", unique_key.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client.client.get(url).query(&query).build()?;

--- a/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_builder_tagged.rs
@@ -185,11 +185,11 @@ pub mod builder {
             let unique_key = unique_key.map_err(Error::InvalidRequest)?;
             let url = format!("{}/key", client.baseurl,);
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &key {
-                query.push(("key", v.to_string()));
+            if let Some(key) = &key {
+                query.push(("key", key.to_string()));
             }
-            if let Some(v) = &unique_key {
-                query.push(("uniqueKey", v.to_string()));
+            if let Some(unique_key) = &unique_key {
+                query.push(("uniqueKey", unique_key.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client.client.get(url).query(&query).build()?;

--- a/progenitor-impl/tests/output/src/param_overrides_positional.rs
+++ b/progenitor-impl/tests/output/src/param_overrides_positional.rs
@@ -121,12 +121,12 @@ impl Client {
     ) -> Result<ResponseValue<()>, Error<()>> {
         let url = format!("{}/key", self.baseurl,);
         let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &key {
-            query.push(("key", v.to_string()));
+        if let Some(key) = &key {
+            query.push(("key", key.to_string()));
         }
 
-        if let Some(v) = &unique_key {
-            query.push(("uniqueKey", v.to_string()));
+        if let Some(unique_key) = &unique_key {
+            query.push(("uniqueKey", unique_key.to_string()));
         }
 
         #[allow(unused_mut)]

--- a/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_builder.rs
@@ -412,11 +412,11 @@ pub mod builder {
             let page_token = page_token.map_err(Error::InvalidRequest)?;
             let url = format!("{}/", client.baseurl,);
             let mut query = Vec::with_capacity(2usize);
-            if let Some(v) = &limit {
-                query.push(("limit", v.to_string()));
+            if let Some(limit) = &limit {
+                query.push(("limit", limit.to_string()));
             }
-            if let Some(v) = &page_token {
-                query.push(("page_token", v.to_string()));
+            if let Some(page_token) = &page_token {
+                query.push(("page_token", page_token.to_string()));
             }
             #[allow(unused_mut)]
             let mut request = client

--- a/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
+++ b/progenitor-impl/tests/output/src/test_stream_pagination_positional.rs
@@ -204,12 +204,12 @@ impl Client {
     ) -> Result<ResponseValue<types::Uint32ResultsPage>, Error<types::Error>> {
         let url = format!("{}/", self.baseurl,);
         let mut query = Vec::with_capacity(2usize);
-        if let Some(v) = &limit {
-            query.push(("limit", v.to_string()));
+        if let Some(limit) = &limit {
+            query.push(("limit", limit.to_string()));
         }
 
-        if let Some(v) = &page_token {
-            query.push(("page_token", v.to_string()));
+        if let Some(page_token) = &page_token {
+            query.push(("page_token", page_token.to_string()));
         }
 
         #[allow(unused_mut)]


### PR DESCRIPTION
Includes a small refactor which changes generated variable names in the output.

This currently assumes explode=true, and therefore only partially resolves #692. I'm looking for some guidance on how to best improve this. The openapiv3 crate exposes `explode` in its ParameterData so the necessary configuration is available, but it's unclear to me if this value is best passed separately as part of the current `OperationParameter`, or within `OperationParameterKind::Query`.

While I have manually tested this with an endpoint another issue is the lack of a test. The `oxidecomputer/dropshot` server used in  tests doesn't yet support non-scalar query parameters. Another option is to include an openapi document and verify its output, but that feels rather heavy.
