### PR TITLE
Re-disable the default features for reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ quote = "1.0.36"
 rand = "0.8.5"
 regex = "1.10.5"
 regress = "0.10.0"
-reqwest = { version = "0.11.27", features = ["json", "stream"] }
+reqwest = { version = "0.11.27", default-features = false, features = ["json", "stream"] }
 rustfmt-wrapper = "0.2.1"
 schemars = { version = "0.8.21", features = ["chrono", "uuid1"] }
 serde = { version = "1.0.204", features = ["derive"] }


### PR DESCRIPTION
After the refactor from separate `Cargo.toml` files to a workspace `Cargo.toml`, the `default-features = false` option for the `reqwest` dependency was removed. This PR re-introduces it.