### PR TITLE
implement std::fmt::Debug for ByteStream

### DIFF
--- a/progenitor-client/src/progenitor_client.rs
+++ b/progenitor-client/src/progenitor_client.rs
@@ -50,6 +50,14 @@ impl DerefMut for ByteStream {
     }
 }
 
+impl std::fmt::Debug for ByteStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ByteStream")
+            .field("inner", &"<Stream>")
+            .finish()
+    }
+}
+
 /// Typed value returned by generated client methods.
 ///
 /// This is used for successful responses and may appear in error responses
@@ -363,16 +371,6 @@ where
             f,
             "status: {}; headers: {:?}; value: {:?}",
             self.status, self.headers, self.inner,
-        )
-    }
-}
-
-impl ErrorFormat for ResponseValue<ByteStream> {
-    fn fmt_info(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "status: {}; headers: {:?}; value: <stream>",
-            self.status, self.headers,
         )
     }
 }


### PR DESCRIPTION
cargo-progenitor doesn't compile because of some conflict between ByteStream and ResponseValue<ByteStream> implementations

If we implement Debug for ByteStream then we don't need the special ErrorFormat for ResponseValue<ByteStream> 