### PR TITLE
fix(progenitor-macro): if 'client.inner' is not set by user do not provide it to user-specified functions.

### DIFF
--- a/example-macro/src/main.rs
+++ b/example-macro/src/main.rs
@@ -4,8 +4,7 @@ use progenitor::generate_api;
 
 generate_api!(
     spec = "../sample_openapi/keeper.json",
-    inner_type = (),
-    pre_hook = (|_, request| {
+    pre_hook = (|request| {
         println!("doing this {:?}", request);
     }),
     pre_hook_async = crate::add_auth_headers,
@@ -14,7 +13,6 @@ generate_api!(
 );
 
 async fn add_auth_headers(
-    _: &(),
     req: &mut reqwest::Request,
 ) -> Result<(), reqwest::header::InvalidHeaderValue> {
     // You can perform asynchronous, fallible work in a request hook, then
@@ -29,7 +27,7 @@ async fn add_auth_headers(
     Ok(())
 }
 
-fn all_done(_: &(), _result: &reqwest::Result<reqwest::Response>) {}
+fn all_done(_result: &reqwest::Result<reqwest::Response>) {}
 
 mod buildomat {
     use progenitor::generate_api;

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -337,22 +337,30 @@ impl Generator {
             &self.settings.interface,
             &self.settings.tag,
         ) {
-            (InterfaceStyle::Positional, TagStyle::Merged) => {
-                self.generate_tokens_positional_merged(&raw_methods, self.settings.inner_type.is_some())
-            }
+            (InterfaceStyle::Positional, TagStyle::Merged) => self
+                .generate_tokens_positional_merged(
+                    &raw_methods,
+                    self.settings.inner_type.is_some(),
+                ),
             (InterfaceStyle::Positional, TagStyle::Separate) => {
                 unimplemented!("positional arguments with separate tags are currently unsupported")
             }
-            (InterfaceStyle::Builder, TagStyle::Merged) => {
-                self.generate_tokens_builder_merged(&raw_methods, self.settings.inner_type.is_some())
-            }
+            (InterfaceStyle::Builder, TagStyle::Merged) => self
+                .generate_tokens_builder_merged(
+                    &raw_methods,
+                    self.settings.inner_type.is_some(),
+                ),
             (InterfaceStyle::Builder, TagStyle::Separate) => {
                 let tag_info = spec
                     .tags
                     .iter()
                     .map(|tag| (&tag.name, tag))
                     .collect::<BTreeMap<_, _>>();
-                self.generate_tokens_builder_separate(&raw_methods, tag_info, self.settings.inner_type.is_some())
+                self.generate_tokens_builder_separate(
+                    &raw_methods,
+                    tag_info,
+                    self.settings.inner_type.is_some(),
+                )
             }
         }?;
 
@@ -535,7 +543,9 @@ impl Generator {
     ) -> Result<TokenStream> {
         let builder_struct = input_methods
             .iter()
-            .map(|method| self.builder_struct(method, TagStyle::Merged, has_inner))
+            .map(|method| {
+                self.builder_struct(method, TagStyle::Merged, has_inner)
+            })
             .collect::<Result<Vec<_>>>()?;
 
         let builder_methods = input_methods
@@ -583,7 +593,9 @@ impl Generator {
     ) -> Result<TokenStream> {
         let builder_struct = input_methods
             .iter()
-            .map(|method| self.builder_struct(method, TagStyle::Separate, has_inner))
+            .map(|method| {
+                self.builder_struct(method, TagStyle::Separate, has_inner)
+            })
             .collect::<Result<Vec<_>>>()?;
 
         let (traits_and_impls, trait_preludes) =

--- a/progenitor-impl/src/lib.rs
+++ b/progenitor-impl/src/lib.rs
@@ -338,13 +338,13 @@ impl Generator {
             &self.settings.tag,
         ) {
             (InterfaceStyle::Positional, TagStyle::Merged) => {
-                self.generate_tokens_positional_merged(&raw_methods)
+                self.generate_tokens_positional_merged(&raw_methods, self.settings.inner_type.is_some())
             }
             (InterfaceStyle::Positional, TagStyle::Separate) => {
                 unimplemented!("positional arguments with separate tags are currently unsupported")
             }
             (InterfaceStyle::Builder, TagStyle::Merged) => {
-                self.generate_tokens_builder_merged(&raw_methods)
+                self.generate_tokens_builder_merged(&raw_methods, self.settings.inner_type.is_some())
             }
             (InterfaceStyle::Builder, TagStyle::Separate) => {
                 let tag_info = spec
@@ -352,7 +352,7 @@ impl Generator {
                     .iter()
                     .map(|tag| (&tag.name, tag))
                     .collect::<BTreeMap<_, _>>();
-                self.generate_tokens_builder_separate(&raw_methods, tag_info)
+                self.generate_tokens_builder_separate(&raw_methods, tag_info, self.settings.inner_type.is_some())
             }
         }?;
 
@@ -503,10 +503,11 @@ impl Generator {
     fn generate_tokens_positional_merged(
         &mut self,
         input_methods: &[method::OperationMethod],
+        has_inner: bool,
     ) -> Result<TokenStream> {
         let methods = input_methods
             .iter()
-            .map(|method| self.positional_method(method))
+            .map(|method| self.positional_method(method, has_inner))
             .collect::<Result<Vec<_>>>()?;
 
         // The allow(unused_imports) on the `pub use` is necessary with Rust 1.76+, in case the
@@ -530,10 +531,11 @@ impl Generator {
     fn generate_tokens_builder_merged(
         &mut self,
         input_methods: &[method::OperationMethod],
+        has_inner: bool,
     ) -> Result<TokenStream> {
         let builder_struct = input_methods
             .iter()
-            .map(|method| self.builder_struct(method, TagStyle::Merged))
+            .map(|method| self.builder_struct(method, TagStyle::Merged, has_inner))
             .collect::<Result<Vec<_>>>()?;
 
         let builder_methods = input_methods
@@ -577,10 +579,11 @@ impl Generator {
         &mut self,
         input_methods: &[method::OperationMethod],
         tag_info: BTreeMap<&String, &openapiv3::Tag>,
+        has_inner: bool,
     ) -> Result<TokenStream> {
         let builder_struct = input_methods
             .iter()
-            .map(|method| self.builder_struct(method, TagStyle::Separate))
+            .map(|method| self.builder_struct(method, TagStyle::Separate, has_inner))
             .collect::<Result<Vec<_>>>()?;
 
         let (traits_and_impls, trait_preludes) =

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -1133,7 +1133,7 @@ impl Generator {
 
         let inner = match has_inner {
             true => quote! { &#client.inner, },
-            false => quote! { },
+            false => quote! {},
         };
         let pre_hook = self.settings.pre_hook.as_ref().map(|hook| {
             quote! {
@@ -1480,7 +1480,7 @@ impl Generator {
         &mut self,
         method: &OperationMethod,
         tag_style: TagStyle,
-        has_inner: bool
+        has_inner: bool,
     ) -> Result<TokenStream> {
         let struct_name = sanitize(&method.operation_id, Case::Pascal);
         let struct_ident = format_ident!("{}", struct_name);
@@ -1725,7 +1725,8 @@ impl Generator {
             success,
             error,
             body,
-        } = self.method_sig_body(method, quote! { #client_ident }, has_inner)?;
+        } =
+            self.method_sig_body(method, quote! { #client_ident }, has_inner)?;
 
         let send_doc = format!(
             "Sends a `{}` request to `{}`",

--- a/progenitor-impl/src/method.rs
+++ b/progenitor-impl/src/method.rs
@@ -592,6 +592,7 @@ impl Generator {
     pub(crate) fn positional_method(
         &mut self,
         method: &OperationMethod,
+        has_inner: bool,
     ) -> Result<TokenStream> {
         let operation_id = format_ident!("{}", method.operation_id);
 
@@ -658,7 +659,7 @@ impl Generator {
             success: success_type,
             error: error_type,
             body,
-        } = self.method_sig_body(method, quote! { self })?;
+        } = self.method_sig_body(method, quote! { self }, has_inner)?;
 
         let method_impl = quote! {
             #[doc = #doc_comment]
@@ -814,6 +815,7 @@ impl Generator {
         &self,
         method: &OperationMethod,
         client: TokenStream,
+        has_inner: bool,
     ) -> Result<MethodSigBody> {
         let param_names = method
             .params
@@ -1129,14 +1131,18 @@ impl Generator {
             }
         };
 
+        let inner = match has_inner {
+            true => quote! { &#client.inner, },
+            false => quote! { },
+        };
         let pre_hook = self.settings.pre_hook.as_ref().map(|hook| {
             quote! {
-                (#hook)(&#client.inner, &#request_ident);
+                (#hook)(#inner &#request_ident);
             }
         });
         let pre_hook_async = self.settings.pre_hook_async.as_ref().map(|hook| {
             quote! {
-                match (#hook)(&#client.inner, &mut #request_ident).await {
+                match (#hook)(#inner &mut #request_ident).await {
                     Ok(_) => (),
                     Err(e) => return Err(Error::PreHookError(e.to_string())),
                 }
@@ -1144,7 +1150,7 @@ impl Generator {
         });
         let post_hook = self.settings.post_hook.as_ref().map(|hook| {
             quote! {
-                (#hook)(&#client.inner, &#result_ident);
+                (#hook)(#inner &#result_ident);
             }
         });
 
@@ -1474,6 +1480,7 @@ impl Generator {
         &mut self,
         method: &OperationMethod,
         tag_style: TagStyle,
+        has_inner: bool
     ) -> Result<TokenStream> {
         let struct_name = sanitize(&method.operation_id, Case::Pascal);
         let struct_ident = format_ident!("{}", struct_name);
@@ -1718,7 +1725,7 @@ impl Generator {
             success,
             error,
             body,
-        } = self.method_sig_body(method, quote! { #client_ident })?;
+        } = self.method_sig_body(method, quote! { #client_ident }, has_inner)?;
 
         let send_doc = format!(
             "Sends a `{}` request to `{}`",


### PR DESCRIPTION
## Description

When adding any hooks (`pre_async`, `post`, `pre`) you were implicitly required to add an empty type just to fill in `client.inner` property - even if you weren't actually using the client for anything. This mean that if you set an async hook without setting an inner client progenitor would create invalid code.

We have changed that behaviour to only generate the `inner` parameter if it's actually set by the end user.

## Previous Code

```rust 
// an inner type MUST be set to use with_pre_hook_async?!
// if we exclude this the generator succeeds but the generated code doesn't compile!
.with_inner_type(quote! { () })

// The actual hook...
.with_pre_hook_async(quote! {
    // We aren't even using the client.inner property!
    |_, request: &mut reqwest::Request| {
        Box::pin(async { Ok::<_, Box<dyn std::error::Error>>(()) })
    }
})
```

## After Change

```rust
.with_pre_hook_async(quote! {
    |request: &mut reqwest::Request| {
        Box::pin(async { Ok::<_, Box<dyn std::error::Error>>(()) })
    }
})
```            

## Future Work

Given we have a token stream of the hook body, we could try to identify the parameters required and be a little smarter... but this is already a big improvement.